### PR TITLE
Select from available type serializers in the order they were added

### DIFF
--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializerCollection.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializerCollection.java
@@ -21,6 +21,8 @@ import com.google.common.reflect.TypeToken;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 /**
@@ -28,8 +30,8 @@ import java.util.function.Predicate;
  */
 public class TypeSerializerCollection {
     private final TypeSerializerCollection parent;
+    private final SerializerList serializers = new SerializerList();
     private final Map<TypeToken<?>, TypeSerializer<?>> typeMatches = new ConcurrentHashMap<>();
-    private final Map<Predicate<TypeToken<?>>, TypeSerializer<?>> functionMatches = new ConcurrentHashMap<>();
 
     TypeSerializerCollection(TypeSerializerCollection parent) {
         this.parent = parent;
@@ -39,27 +41,8 @@ public class TypeSerializerCollection {
     public <T> TypeSerializer<T> get(TypeToken<T> type) {
         Preconditions.checkNotNull(type, "type");
         type = type.wrap();
-        TypeSerializer<?> serial = typeMatches.get(type);
-        if (serial == null) {
-            for (Map.Entry<TypeToken<?>, TypeSerializer<?>> ent : typeMatches.entrySet()) {
-                if (ent.getKey().isSupertypeOf(type)) {
-                    serial = ent.getValue();
-                    typeMatches.put(type, serial);
-                    break;
-                }
-            }
-        }
 
-        if (serial == null) {
-            for (Map.Entry<Predicate<TypeToken<?>>, TypeSerializer<?>> ent : functionMatches.entrySet()) {
-                if (ent.getKey().test(type)) {
-                    serial = ent.getValue();
-                    typeMatches.put(type, serial);
-                    break;
-                }
-            }
-        }
-
+        TypeSerializer<?> serial = typeMatches.computeIfAbsent(type, serializers);
         if (serial == null && parent != null) {
             serial = parent.get(type);
         }
@@ -79,29 +62,57 @@ public class TypeSerializerCollection {
     public <T> TypeSerializerCollection registerType(TypeToken<T> type, TypeSerializer<? super T> serializer) {
         Preconditions.checkNotNull(type, "type");
         Preconditions.checkNotNull(serializer, "serializer");
-        typeMatches.put(type, serializer);
+        serializers.add(new RegisteredSerializer(type, serializer));
         return this;
     }
 
     /**
      * Register a type serializer matching against a given predicate.
      *
-     * @param type The predicate to match types against
+     * @param test The predicate to match types against
      * @param serializer The serializer to serialize matching types with
      * @param <T> The type parameter
      * @return this
      */
     @SuppressWarnings("unchecked")
-    public <T> TypeSerializerCollection registerPredicate(Predicate<TypeToken<T>> type, TypeSerializer<? super T>
+    public <T> TypeSerializerCollection registerPredicate(Predicate<TypeToken<T>> test, TypeSerializer<? super T>
             serializer) {
-        Preconditions.checkNotNull(type, "type");
+        Preconditions.checkNotNull(test, "test");
         Preconditions.checkNotNull(serializer, "serializer");
-        functionMatches.put((Predicate) type, serializer);
+        serializers.add(new RegisteredSerializer((Predicate) test, serializer));
         return this;
     }
 
     public TypeSerializerCollection newChild() {
         return new TypeSerializerCollection(this);
+    }
+
+    private static final class RegisteredSerializer {
+        private final Predicate<TypeToken<?>> predicate;
+        private final TypeSerializer<?> serializer;
+
+        private RegisteredSerializer(Predicate<TypeToken<?>> predicate, TypeSerializer<?> serializer) {
+            this.predicate = predicate;
+            this.serializer = serializer;
+        }
+
+        private RegisteredSerializer(TypeToken<?> type, TypeSerializer<?> serializer) {
+            this(type::isSupertypeOf, serializer);
+        }
+    }
+
+    private final class SerializerList extends CopyOnWriteArrayList<RegisteredSerializer>
+            implements Function<TypeToken<?>, TypeSerializer<?>> {
+
+        @Override
+        public TypeSerializer<?> apply(TypeToken<?> type) {
+            for (RegisteredSerializer ent : this) {
+                if (ent.predicate.test(type)) {
+                    return ent.serializer;
+                }
+            }
+            return null;
+        }
     }
 
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializers.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializers.java
@@ -51,6 +51,10 @@ public class TypeSerializers {
         return DEFAULT_SERIALIZERS;
     }
 
+    public static TypeSerializerCollection newCollection() {
+        return DEFAULT_SERIALIZERS.newChild();
+    }
+
     static {
         DEFAULT_SERIALIZERS.registerType(TypeToken.of(URI.class), new URISerializer());
         DEFAULT_SERIALIZERS.registerType(TypeToken.of(URL.class), new URLSerializer());


### PR DESCRIPTION
Closes #75 (maybe?!)

Involves a refactor of the way `TypeSerializer`s are selected from a `TypeSerializerCollection`. Predicate and supertype matchers are added to the same collection, and tested in the order they were added.