### PR TITLE
Fix object mapping interface/abstract field types

### DIFF
--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializers.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializers.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
+
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.SimpleConfigurationNode;
 import ninja.leaping.configurate.Types;
@@ -34,7 +35,12 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 


### PR DESCRIPTION
For interface/abstract classes, the TypeSerializer currently adds a `__class__` node whose value is the canonical name of the interface/abstract class. This isn't very useful when it comes to deserialization since we want to know the concrete type in order to instantiate and populate.

This PR changes the behaviour so that, during serialization, it's the instance's class that is used in the `__class__` node instead (which I believe was the original intention).