### PR TITLE
Improve JavaDocs

### DIFF
--- a/configurate-core/pom.xml
+++ b/configurate-core/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Configurate
@@ -17,20 +18,16 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-      <groupId>ninja.leaping.configurate</groupId>
-      <artifactId>configurate-parent</artifactId>
-      <version>3.4-SNAPSHOT</version>
-  </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ninja.leaping.configurate</groupId>
+        <artifactId>configurate-parent</artifactId>
+        <version>3.4-SNAPSHOT</version>
+    </parent>
 
-  <artifactId>configurate-core</artifactId>
-  <packaging>jar</packaging>
-  <name>Configurate Core</name>
-
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
+    <artifactId>configurate-core</artifactId>
+    <name>Configurate Core</name>
+    <packaging>jar</packaging>
 
     <dependencies>
         <dependency>
@@ -45,4 +42,5 @@
             <optional>true</optional>
         </dependency>
     </dependencies>
+
 </project>

--- a/configurate-core/src/main/java/ninja/leaping/configurate/ConfigValue.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/ConfigValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/ConfigValue.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/ConfigValue.java
@@ -16,44 +16,87 @@
  */
 package ninja.leaping.configurate;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import java.util.Iterator;
 
+/**
+ * The value in a {@link ConfigurationNode}.
+ */
 abstract class ConfigValue {
+
+    /**
+     * The node this value "belongs" to.
+     */
+    @NonNull
     protected final SimpleConfigurationNode holder;
 
-    protected ConfigValue(SimpleConfigurationNode holder) {
+    protected ConfigValue(@NonNull SimpleConfigurationNode holder) {
         this.holder = holder;
     }
 
+    /**
+     * Gets the value encapsulated by this instance
+     *
+     * @return The value
+     */
+    @Nullable
     abstract Object getValue();
-    abstract void setValue(Object value);
 
     /**
-     * put a child, or null to remove value at key
+     * Sets the value encapsulated by this instance
      *
-     * @param key the key
-     * @param value the node to put at key
-     * @return existing node at key, if present
+     * @param value The value
      */
-    abstract SimpleConfigurationNode putChild(Object key, SimpleConfigurationNode value);
-    abstract SimpleConfigurationNode putChildIfAbsent(Object key, SimpleConfigurationNode value);
+    abstract void setValue(@Nullable Object value);
 
     /**
-     * gets the currently present child.
-     * returns null if no child is present
+     * Put a child value, or null to remove value at that key
      *
-     * @param key the key to get child at
-     * @return the child if any
+     * @param key The key
+     * @param value The node to put at key
+     * @return Existing node at key, if present
      */
-    abstract SimpleConfigurationNode getChild(Object key);
+    @Nullable
+    abstract SimpleConfigurationNode putChild(@NonNull Object key, @Nullable SimpleConfigurationNode value);
+
+    /**
+     * Put a child value, if one isn't already present at that key
+     *
+     * @param key The key
+     * @param value The node to put at key
+     * @return Existing node at key, if present
+     */
+    @Nullable
+    abstract SimpleConfigurationNode putChildIfAbsent(@NonNull Object key, @Nullable SimpleConfigurationNode value);
+
+    /**
+     * Gets the currently present child for the given key. Returns null if no child is present
+     *
+     * @param key The key to get child at
+     * @return The child if any
+     */
+    @Nullable
+    abstract SimpleConfigurationNode getChild(@Nullable Object key);
+
+    /**
+     * Returns an iterable over all child nodes
+     *
+     * @return An iterator
+     */
+    @NonNull
     abstract Iterable<SimpleConfigurationNode> iterateChildren();
 
+    /**
+     * Clears the set value (or any attached child values) from this value
+     */
     void clear() {
         for (Iterator<SimpleConfigurationNode> it = iterateChildren().iterator(); it.hasNext();) {
             SimpleConfigurationNode node = it.next();
             node.attached = false;
             it.remove();
-            if (node.getParentAttached().equals(holder)) {
+            if (node.getParentEnsureAttached().equals(holder)) {
                 node.clear();
             }
         }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/ConfigurationNode.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/ConfigurationNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/ConfigurationNode.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/ConfigurationNode.java
@@ -18,132 +18,254 @@ package ninja.leaping.configurate;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.TypeToken;
+import ninja.leaping.configurate.loader.ConfigurationLoader;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
- * A node in the configuration tree. This is more or less the main class of configurate, providing the methods to
- * navigate through the configuration tree and get values
+ * A node in the configuration tree.
+ *
+ * <p>All aspects of a configurations structure are represented using instances of
+ * {@link ConfigurationNode}, and the links between them.</p>
+ *
+ * <p>{@link ConfigurationNode}s can:</p>
+ * <p>
+ * <ul>
+ *     <li>Hold a single "scalar" value</li>
+ *     <li>Represent a "list" of child {@link ConfigurationNode}s - see {@link #hasListChildren()}</li>
+ *     <li>Represent a "map" of child {@link ConfigurationNode}s - see {@link #hasMapChildren()}</li>
+ *     <li>Hold no value at all</li>
+ * </ul>
+ *
+ * <p>The overall configuration stems from a single "root" node, which is provided by the
+ * {@link ConfigurationLoader}, or by other means programmatically.</p>
+ *
+ * <p>This is effectively the main class of configurate.</p>
  */
 public interface ConfigurationNode {
     int NUMBER_DEF = 0;
+
     /**
-     * The key for this node.
-     * If this node is currently virtual, this method's result may be inaccurate.
+     * Gets the "key" of this node.
      *
-     * @return The key for this node
+     * <p>The key determines this {@link ConfigurationNode}s position within the overall
+     * configuration structure.</p>
+     *
+     * <p>If this node is currently {@link #isVirtual() virtual}, this method's result may be
+     * inaccurate.</p>
+     *
+     * <p>Note that this method only returns the nearest "link" in the hierarchy, and does not
+     * return a representation of the full path. See {@link #getPath()} for that.</p>
+     *
+     * <p>The {@link ConfigurationNode}s returned as values from {@link #getChildrenMap()} will
+     * have keys derived from their pairing in the map node.</p>
+     *
+     * <p>The {@link ConfigurationNode}s returned from {@link #getChildrenList()} will have keys
+     * derived from their position (index) in the list node.</p>
+     *
+     * @return The key of this node
      */
+    @Nullable
     Object getKey();
 
     /**
-     * The full path from the root to this node.
+     * Gets the full path of {@link #getKey() keys} from the root node to this node.
      *
-     * Node implementations may keep a full path for each node, so this method may involve some object churn.
+     * <p>Node implementations may not keep a full path for each node, so this method may be
+     * somewhat complex to calculate.</p>
      *
      * @return An array compiled from the keys for each node up the hierarchy
      */
+    @NonNull
     Object[] getPath();
 
     /**
-     * Returns the current parent for this node.
-     * If this node is currently virtual, this method's result may be inaccurate.
-     * @return The appropriate parent
+     * Gets the parent of this node.
+     *
+     * <p>If this node is currently {@link #isVirtual() virtual}, this method's result may be
+     * inaccurate.</p>
+     *
+     * @return The nodes parent
      */
+    @Nullable
     ConfigurationNode getParent();
 
     /**
-     * Return the options that currently apply to this node
+     * Gets the node at the given (relative) path, possibly traversing multiple levels of nodes.
+     *
+     * <p>This is the main method used to navigate through the configuration.</p>
+     *
+     * <p>The path parameter effectively consumes an array of keys, which locate the unique position
+     * of a given node within the structure.</p>
+     *
+     * <p>A node is <b>always</b> returned by this method. If the given node does not exist in the
+     * structure, a {@link #isVirtual() virtual} node will be returned which represents the
+     * position.</p>
+     *
+     * @param path The path to fetch the node at
+     * @return The node at the given path, possibly virtual
+     */
+    @NonNull
+    ConfigurationNode getNode(@NonNull Object... path);
+
+    /**
+     * Gets if this node is virtual.
+     *
+     * <p>Virtual nodes are nodes which are not attached to a wider configuration structure.</p>
+     *
+     * <p>A node is primarily "virtual" when it has no set value.</p>
+     *
+     * @return true if this node is virtual
+     */
+    boolean isVirtual();
+
+    /**
+     * Gets the options that currently apply to this node
      *
      * @return The ConfigurationOptions instance that governs the functionality of this node
      */
+    @NonNull
     ConfigurationOptions getOptions();
 
     /**
+     * Gets if this node has "list children".
+     *
+     * @return if this node has children in the form of a list
+     */
+    boolean hasListChildren();
+
+    /**
+     * Gets if this node has "map children".
+     *
+     * @return if this node has children in the form of a map
+     */
+    boolean hasMapChildren();
+
+    /**
+     * Gets the "list children" attached to this node, if it has any.
+     *
+     * <p>If this node does not {@link #hasListChildren() have list children}, an empty list is
+     * returned.</p>
+     *
+     * @return The list children currently attached to this node
+     */
+    @NonNull
+    List<? extends ConfigurationNode> getChildrenList();
+
+    /**
+     * Gets the "map children" attached to this node, if it has any.
+     *
+     * <p>If this node does not {@link #hasMapChildren() have map children}, an empty map
+     * returned.</p>
+     *
+     * @return The map children currently attached to this node
+     */
+    @NonNull
+    Map<Object, ? extends ConfigurationNode> getChildrenMap();
+
+    /**
      * Get the current value associated with this node.
-     * If this node has children, this method will recursively unwrap them to construct a List or a Map
+     *
+     * <p>If this node has children, this method will recursively unwrap them to construct a List
+     * or a Map.</p>
      *
      * @see #getValue(Object)
      * @return This configuration's current value, or null if there is none
      */
+    @Nullable
     default Object getValue() {
         return getValue((Object) null);
     }
 
     /**
      * Get the current value associated with this node.
-     * If this node has children, this method will recursively unwrap them to construct a List or a Map
+     *
+     * <p>If this node has children, this method will recursively unwrap them to construct a List
+     * or a Map.</p>
      *
      * @param def The default value to return if this node has no set value
      * @return This configuration's current value, or {@code def} if there is none
      */
-    Object getValue(Object def);
+    Object getValue(@Nullable Object def);
 
     /**
      * Get the current value associated with this node.
-     * If this node has children, this method will recursively unwrap them to construct a List or a Map
      *
-     * @param defSupplier The function that will be called to calculate a default value only if there is no existing
-     *                    value
+     * <p>If this node has children, this method will recursively unwrap them to construct a List
+     * or a Map.</p>
+     *
+     * @param defSupplier The function that will be called to calculate a default value only if
+     *                    there is no existing value
      * @return This configuration's current value, or {@code def} if there is none
      */
-
-    Object getValue(Supplier<Object> defSupplier);
+    Object getValue(@NonNull Supplier<Object> defSupplier);
 
     /**
-     * Gets the appropriately transformed typed version of this node's value from the provided transformation function
+     * Gets the appropriately transformed typed version of this node's value from the provided
+     * transformation function.
      *
      * @param transformer The transformation function
      * @param <T> The expected type
-     * @return A transformed value of the correct type, or null either if no value is present or the value could not
-     * be converted
+     * @return A transformed value of the correct type, or null either if no value is present or the
+     * value could not be converted
      */
-    default <T> T getValue(Function<Object, T> transformer) {
+    @Nullable
+    default <T> T getValue(@NonNull Function<Object, T> transformer) {
         return getValue(transformer, (T) null);
     }
 
     /**
-     * Gets the appropriately transformed typed version of this node's value from the provided transformation function
+     * Gets the appropriately transformed typed version of this node's value from the provided
+     * transformation function.
      *
      * @param transformer The transformation function
-     * @param def The default value to return if this node has no set value or is not of a convertable type
+     * @param def The default value to return if this node has no set value or is not of a
+     *            convertible type
      * @param <T> The expected type
-     * @return A transformed value of the correct type, or {@code def} either if no value is present or the value
-     * could not be converted
+     * @return A transformed value of the correct type, or {@code def} either if no value is present
+     * or the value could not be converted
      */
-    <T> T getValue(Function<Object, T> transformer, T def);
+    <T> T getValue(@NonNull Function<Object, T> transformer, @Nullable T def);
 
     /**
-     * Gets the appropriately transformed typed version of this node's value from the provided transformation function
+     * Gets the appropriately transformed typed version of this node's value from the provided
+     * transformation function.
      *
      * @param transformer The transformation function
-     * @param defSupplier The function that will be called to calculate a default value only if there is no existing
-     *                    value of the correct type
+     * @param defSupplier The function that will be called to calculate a default value only if
+     *                    there is no existing value of the correct type
      * @param <T> The expected type
-     * @return A transformed value of the correct type, or {@code def} either if no value is present or the value
-     * could not be converted
+     * @return A transformed value of the correct type, or {@code def} either if no value is present
+     * or the value could not be converted
      */
-    <T> T getValue(Function<Object, T> transformer, Supplier<T> defSupplier);
+    <T> T getValue(@NonNull Function<Object, T> transformer, @NonNull Supplier<T> defSupplier);
 
     /**
-     * If this node has list values, this function unwraps them and converts them to an appropriate type based on the
-     * provided function.
-     * If this node has a scalar value, this function treats it as a list with one value
+     * If this node has list values, this function unwraps them and converts them to an appropriate
+     * type based on the provided function.
+     *
+     * <p>If this node has a scalar value, this function treats it as a list with one value</p>
      *
      * @param transformer The transformation function
      * @param <T> The expected type
      * @return An immutable copy of the values contained
      */
-    <T> List<T> getList(Function<Object, T> transformer);
+    @NonNull
+    <T> List<T> getList(@NonNull Function<Object, T> transformer);
 
     /**
-     * If this node has list values, this function unwraps them and converts them to an appropriate type based on the
-     * provided function.
-     * If this node has a scalar value, this function treats it as a list with one value
+     * If this node has list values, this function unwraps them and converts them to an appropriate
+     * type based on the provided function.
+     *
+     * <p>If this node has a scalar value, this function treats it as a list with one value.</p>
      *
      * @param transformer The transformation function
      * @param def The default value if no appropriate value is set
@@ -151,12 +273,13 @@ public interface ConfigurationNode {
      * @return An immutable copy of the values contained that could be successfully converted, or {@code def} if no
      * values could be converted
      */
-    <T> List<T> getList(Function<Object, T> transformer, List<T> def);
+    <T> List<T> getList(@NonNull Function<Object, T> transformer, @Nullable List<T> def);
 
     /**
-     * If this node has list values, this function unwraps them and converts them to an appropriate type based on the
-     * provided function.
-     * If this node has a scalar value, this function treats it as a list with one value
+     * If this node has list values, this function unwraps them and converts them to an appropriate
+     * type based on the provided function.
+     *
+     * <p>If this node has a scalar value, this function treats it as a list with one value.</p>
      *
      * @param transformer The transformation function
      * @param defSupplier The function that will be called to calculate a default value only if there is no existing
@@ -165,25 +288,28 @@ public interface ConfigurationNode {
      * @return An immutable copy of the values contained that could be successfully converted, or {@code def} if no
      * values could be converted
      */
-    <T> List<T> getList(Function<Object, T> transformer, Supplier<List<T>> defSupplier);
+    <T> List<T> getList(@NonNull Function<Object, T> transformer, @NonNull Supplier<List<T>> defSupplier);
 
     /**
-     * If this node has list values, this function unwraps them and converts them to an appropriate type based on the
-     * provided type.
-     * If this node has a scalar value, this function treats it as a list with one value
+     * If this node has list values, this function unwraps them and converts them to an appropriate
+     * type based on the provided function.
+     *
+     * <p>If this node has a scalar value, this function treats it as a list with one value.</p>
      *
      * @param type The expected type
      * @param <T> The expected type
      * @return An immutable copy of the values contained
      */
-    default <T> List<T> getList(TypeToken<T> type) throws ObjectMappingException {
+    @NonNull
+    default <T> List<T> getList(@NonNull TypeToken<T> type) throws ObjectMappingException {
         return getList(type, ImmutableList.of());
     }
 
     /**
-     * If this node has list values, this function unwraps them and converts them to an appropriate type based on the
-     * provided type.
-     * If this node has a scalar value, this function treats it as a list with one value
+     * If this node has list values, this function unwraps them and converts them to an appropriate
+     * type based on the provided function.
+     *
+     * <p>If this node has a scalar value, this function treats it as a list with one value.</p>
      *
      * @param type The expected type
      * @param def The default value if no appropriate value is set
@@ -191,12 +317,13 @@ public interface ConfigurationNode {
      * @return An immutable copy of the values contained that could be successfully converted, or {@code def} if no
      * values could be converted
      */
-    <T> List<T> getList(TypeToken<T> type, List<T> def) throws ObjectMappingException;
+    <T> List<T> getList(@NonNull TypeToken<T> type, @Nullable List<T> def) throws ObjectMappingException;
 
     /**
-     * If this node has list values, this function unwraps them and converts them to an appropriate type based on the
-     * provided type.
-     * If this node has a scalar value, this function treats it as a list with one value
+     * If this node has list values, this function unwraps them and converts them to an appropriate
+     * type based on the provided function.
+     *
+     * <p>If this node has a scalar value, this function treats it as a list with one value.</p>
      *
      * @param type The expected type
      * @param defSupplier The function that will be called to calculate a default value only if there is no existing
@@ -205,7 +332,7 @@ public interface ConfigurationNode {
      * @return An immutable copy of the values contained that could be successfully converted, or {@code def} if no
      * values could be converted
      */
-    <T> List<T> getList(TypeToken<T> type, Supplier<List<T>> defSupplier) throws ObjectMappingException;
+    <T> List<T> getList(@NonNull TypeToken<T> type, @NonNull Supplier<List<T>> defSupplier) throws ObjectMappingException;
 
     /**
      * Gets the value typed using the appropriate type conversion from {@link Types}
@@ -213,6 +340,7 @@ public interface ConfigurationNode {
      * @see #getValue()
      * @return The appropriate type conversion, null if no appropriate value is available
      */
+    @Nullable
     default String getString() {
         return getString(null);
     }
@@ -224,7 +352,7 @@ public interface ConfigurationNode {
      * @see #getValue()
      * @return The appropriate type conversion, {@code def} if no appropriate value is available
      */
-    default String getString(String def) {
+    default String getString(@Nullable String def) {
         return getValue(Types::asString, def);
     }
 
@@ -334,44 +462,47 @@ public interface ConfigurationNode {
     }
 
     /**
-     * Set this node's value to the given value.
-     * If the provided value is a {@link java.util.Collection} or a {@link java.util.Map}, it will be unwrapped into
-     * the appropriate configuration node structure
-     *
-     * @param value The value to set
-     * @return this
-     */
-    ConfigurationNode setValue(Object value);
-
-    /**
      * Get the current value associated with this node.
-     * If this node has children, this method will recursively unwrap them to construct a List or a Map.
-     * This method will also perform deserialization using the appropriate TypeSerializer for the given type, or casting if no type serializer is found.
+     *
+     * <p>If this node has children, this method will recursively unwrap them to construct a
+     * List or a Map.</p>
+     *
+     * <p>This method will also perform deserialization using the appropriate TypeSerializer for
+     * the given type, or casting if no type serializer is found.</p>
      *
      * @param type The type to deserialize to
      * @param <T> the type to get
      * @return the value if present and of the proper type, else null
      */
-    default <T> T getValue(TypeToken<T> type) throws ObjectMappingException {
+    @Nullable
+    default <T> T getValue(@NonNull TypeToken<T> type) throws ObjectMappingException {
         return getValue(type, (T) null);
     }
 
     /**
      * Get the current value associated with this node.
-     * If this node has children, this method will recursively unwrap them to construct a List or a Map.
-     * This method will also perform deserialization using the appropriate TypeSerializer for the given type, or casting if no type serializer is found.
+     *
+     * <p>If this node has children, this method will recursively unwrap them to construct a
+     * List or a Map.</p>
+     *
+     * <p>This method will also perform deserialization using the appropriate TypeSerializer for
+     * the given type, or casting if no type serializer is found.</p>
      *
      * @param type The type to deserialize to
      * @param def The value to return if no value or value is not of appropriate type
      * @param <T> the type to get
      * @return the value if of the proper type, else {@code def}
      */
-    <T> T getValue(TypeToken<T> type, T def) throws ObjectMappingException;
+    <T> T getValue(@NonNull TypeToken<T> type, T def) throws ObjectMappingException;
 
     /**
      * Get the current value associated with this node.
-     * If this node has children, this method will recursively unwrap them to construct a List or a Map.
-     * This method will also perform deserialization using the appropriate TypeSerializer for the given type, or casting if no type serializer is found.
+     *
+     * <p>If this node has children, this method will recursively unwrap them to construct a
+     * List or a Map.</p>
+     *
+     * <p>This method will also perform deserialization using the appropriate TypeSerializer for
+     * the given type, or casting if no type serializer is found.</p>
      *
      * @param type The type to deserialize to
      * @param defSupplier The function that will be called to calculate a default value only if there is no existing
@@ -379,25 +510,42 @@ public interface ConfigurationNode {
      * @param <T> the type to get
      * @return the value if of the proper type, else {@code def}
      */
-    <T> T getValue(TypeToken<T> type, Supplier<T> defSupplier) throws ObjectMappingException;
+    <T> T getValue(@NonNull TypeToken<T> type, @NonNull Supplier<T> defSupplier) throws ObjectMappingException;
 
     /**
      * Set this node's value to the given value.
-     * If the provided value is a {@link java.util.Collection} or a {@link java.util.Map}, it will be unwrapped into
-     * the appropriate configuration node structure.
-     * This method will also perform serialization using the appropriate TypeSerializer for the given type, or casting if no type serializer is found.
+     *
+     * <p>If the provided value is a {@link Collection} or a {@link Map}, it will be unwrapped into
+     * the appropriate configuration node structure.</p>
+     *
+     * @param value The value to set
+     * @return this
+     */
+    @NonNull
+    ConfigurationNode setValue(@Nullable Object value);
+
+    /**
+     * Set this node's value to the given value.
+     *
+     * <p>If the provided value is a {@link Collection} or a {@link Map}, it will be unwrapped into
+     * the appropriate configuration node structure.</p>
+     *
+     * <p>This method will also perform serialization using the appropriate TypeSerializer for the
+     * given type, or casting if no type serializer is found.</p>
      *
      * @param type The type to use for serialization type information
      * @param value The value to set
      * @param <T> The type to serialize to
      * @return this
      */
-    default <T> ConfigurationNode setValue(TypeToken<T> type, T value) throws ObjectMappingException {
+    @NonNull
+    default <T> ConfigurationNode setValue(@NonNull TypeToken<T> type, @Nullable T value) throws ObjectMappingException {
         if (value == null) {
             setValue(null);
             return this;
         }
-        TypeSerializer serial = getOptions().getSerializers().get(type);
+
+        TypeSerializer<T> serial = getOptions().getSerializers().get(type);
         if (serial != null) {
             serial.serialize(type, value, this);
         } else if (getOptions().acceptsType(value.getClass())) {
@@ -412,36 +560,13 @@ public interface ConfigurationNode {
      * Set all the values from the given node that are not present in this node
      * to their values in the provided node.
      *
-     * Map keys will be merged. Lists and scalar values will be replaced.
+     * <p>Map keys will be merged. Lists and scalar values will be replaced.</p>
      *
      * @param other The node to merge values from
      * @return this
      */
-    ConfigurationNode mergeValuesFrom(ConfigurationNode other);
-
-    /**
-     * @return if this node has children in the form of a list
-     */
-    boolean hasListChildren();
-
-    /**
-     * @return if this node has children in the form of a map
-     */
-    boolean hasMapChildren();
-
-    /**
-     * Return an immutable copy of the list of children this node is aware of
-     *
-     * @return The children currently attached to this node
-     */
-    List<? extends ConfigurationNode> getChildrenList();
-
-    /**
-     * Return an immutable copy of the mapping from key to node of every child this node is aware of
-     *
-     * @return Child nodes currently attached
-     */
-    Map<Object, ? extends ConfigurationNode> getChildrenMap();
+    @NonNull
+    ConfigurationNode mergeValuesFrom(@NonNull ConfigurationNode other);
 
     /**
      * Removes a direct child of this node
@@ -449,26 +574,14 @@ public interface ConfigurationNode {
      * @param key The key of the node to remove
      * @return if an actual node was removed
      */
-    boolean removeChild(Object key);
+    boolean removeChild(@NonNull Object key);
 
     /**
+     * Gets a new child node created as the next entry in the list.
+     *
      * @return a new child created as the next entry in the list when it is attached
      */
+    @NonNull
     ConfigurationNode getAppendedNode();
 
-
-    /**
-     * Gets the node at the given (relative) path, possibly traversing multiple levels of nodes
-     *
-     * @param path The path to fetch the node at
-     * @return The node at the given path, possibly virtual
-     */
-    ConfigurationNode getNode(Object... path);
-
-    /**
-     * Whether this node does not currently exist in the configuration structure.
-     *
-     * @return true if this node is not attached (this occurs primarily when the node has no set value)
-     */
-    boolean isVirtual();
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/ConfigurationOptions.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/ConfigurationOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/ConfigurationOptions.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/ConfigurationOptions.java
@@ -26,24 +26,30 @@ import ninja.leaping.configurate.objectmapping.serialize.TypeSerializerCollectio
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializers;
 import ninja.leaping.configurate.util.MapFactories;
 import ninja.leaping.configurate.util.MapFactory;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Set;
 
 /**
- * This object is a holder for general configuration options. This is meant to hold options
- * that are used in configuring how the configuration data structures are handled, rather than the serialization configuration that is located in {@link ConfigurationLoader}s
+ * This object is a holder for general configuration options.
+ *
+ * <p>This is meant to hold options that are used in configuring how the configuration data
+ * structures are handled, rather than the serialization configuration that is located in
+ * {@link ConfigurationLoader}s.</p>
+ *
+ * <p>This class is immutable.</p>
  */
 public class ConfigurationOptions {
-    private final MapFactory mapSupplier;
-    private final String header;
-    private final TypeSerializerCollection serializers;
-    private final ImmutableSet<Class<?>> acceptedTypes;
-    private final ObjectMapperFactory objectMapperFactory;
+    @NonNull private final MapFactory mapFactory;
+    @Nullable private final String header;
+    @NonNull private final TypeSerializerCollection serializers;
+    @Nullable private final ImmutableSet<Class<?>> acceptedTypes;
+    @NonNull private final ObjectMapperFactory objectMapperFactory;
     private final boolean shouldCopyDefaults;
 
-    private ConfigurationOptions(MapFactory mapSupplier, String header,
-                                 TypeSerializerCollection serializers, Set<Class<?>> acceptedTypes, ObjectMapperFactory objectMapperFactory, boolean shouldCopyDefaults) {
-        this.mapSupplier = mapSupplier;
+    private ConfigurationOptions(@NonNull MapFactory mapFactory, @Nullable String header, @NonNull TypeSerializerCollection serializers, @Nullable Set<Class<?>> acceptedTypes, @NonNull ObjectMapperFactory objectMapperFactory, boolean shouldCopyDefaults) {
+        this.mapFactory = mapFactory;
         this.header = header;
         this.serializers = serializers;
         this.acceptedTypes = acceptedTypes == null ? null : ImmutableSet.copyOf(acceptedTypes);
@@ -56,90 +62,125 @@ public class ConfigurationOptions {
      *
      * @return A new default options object
      */
+    @NonNull
     public static ConfigurationOptions defaults() {
-        return new ConfigurationOptions(MapFactories.<SimpleConfigurationNode>insertionOrdered(), null, TypeSerializers
-                .getDefaultSerializers(), null, DefaultObjectMapperFactory.getInstance(), false);
+        return new ConfigurationOptions(MapFactories.<SimpleConfigurationNode>insertionOrdered(), null,
+                TypeSerializers.getDefaultSerializers(), null, DefaultObjectMapperFactory.getInstance(), false);
     }
 
     /**
-     * Get the key comparator currently being used for this configuration
+     * Gets the {@link MapFactory} specified in these options.
      *
-     * @return The active key comparator
+     * @return The map factory
      */
+    @NonNull
     public MapFactory getMapFactory() {
-        return mapSupplier;
+        return mapFactory;
     }
 
     /**
-     * Return a new options object with the provided option set.
+     * Creates a new {@link ConfigurationOptions} instance, with the specified {@link MapFactory}
+     * set, and all other settings copied from this instance.
      *
-     * @param factory The new factory to use to create a map
+     * @param mapFactory The new factory to use to create a map
      * @return The new options object
      */
-    public ConfigurationOptions setMapFactory(MapFactory factory) {
-        Preconditions.checkNotNull(factory, "factory");
-        return new ConfigurationOptions(factory, header, serializers, acceptedTypes, objectMapperFactory, shouldCopyDefaults);
+    @NonNull
+    public ConfigurationOptions setMapFactory(@NonNull MapFactory mapFactory) {
+        Preconditions.checkNotNull(mapFactory, "mapFactory");
+        if (this.mapFactory == mapFactory) {
+            return this;
+        }
+        return new ConfigurationOptions(mapFactory, header, serializers, acceptedTypes, objectMapperFactory, shouldCopyDefaults);
     }
 
     /**
-     * Get the header used for this configuration
+     * Gets the header specified in these options.
      *
      * @return The current header. Lines are split by \n,
      */
+    @Nullable
     public String getHeader() {
         return this.header;
     }
 
     /**
-     * Set the header that will be written to a file if
-     * @param header The new header to use for the configuration
-     * @return The map's header
+     * Creates a new {@link ConfigurationOptions} instance, with the specified header
+     * set, and all other settings copied from this instance.
+     *
+     * @param header The new header to use
+     * @return The new options object
      */
-    public ConfigurationOptions setHeader(String header) {
-        return new ConfigurationOptions(mapSupplier, header, serializers, acceptedTypes, objectMapperFactory, shouldCopyDefaults);
+    @NonNull
+    public ConfigurationOptions setHeader(@Nullable String header) {
+        if (Objects.equal(this.header, header)) {
+            return this;
+        }
+        return new ConfigurationOptions(mapFactory, header, serializers, acceptedTypes, objectMapperFactory, shouldCopyDefaults);
     }
 
+    /**
+     * Gets the {@link TypeSerializerCollection} specified in these options.
+     *
+     * @return The type serializers
+     */
+    @NonNull
     public TypeSerializerCollection getSerializers() {
         return this.serializers;
     }
 
     /**
-     * Set the collection of TypeSerializers to be used for lookups
+     * Creates a new {@link ConfigurationOptions} instance, with the specified {@link TypeSerializerCollection}
+     * set, and all other settings copied from this instance.
      *
      * @param serializers The serializers to use
-     * @return updated options object
+     * @return The new options object
      */
-    public ConfigurationOptions setSerializers(TypeSerializerCollection serializers) {
-        return new ConfigurationOptions(mapSupplier, header, serializers, acceptedTypes, objectMapperFactory, shouldCopyDefaults);
+    @NonNull
+    public ConfigurationOptions setSerializers(@NonNull TypeSerializerCollection serializers) {
+        Preconditions.checkNotNull(serializers, "serializers");
+        if (this.serializers == serializers) {
+            return this;
+        }
+        return new ConfigurationOptions(mapFactory, header, serializers, acceptedTypes, objectMapperFactory, shouldCopyDefaults);
     }
 
     /**
-     * Get the current object mapper factory that is most appropriate to this configuration.
+     * Gets the {@link ObjectMapperFactory} specified in these options.
      *
      * @return The factory used to construct ObjectMapper instances
      */
+    @NonNull
     public ObjectMapperFactory getObjectMapperFactory() {
         return this.objectMapperFactory;
     }
 
     /**
-     * Set the factory to use to produce object mapper instances for this configuration
+     * Creates a new {@link ConfigurationOptions} instance, with the specified {@link ObjectMapperFactory}
+     * set, and all other settings copied from this instance.
      *
-     * @param factory The factory to use to produce object mapper instances. Must not be null
+     * @param objectMapperFactory The factory to use to produce object mapper instances. Must not be null
      * @return updated options object
      */
-    public ConfigurationOptions setObjectMapperFactory(ObjectMapperFactory factory) {
-        Preconditions.checkNotNull(factory, "factory");
-        return new ConfigurationOptions(mapSupplier, header, serializers, acceptedTypes, factory, shouldCopyDefaults);
+    @NonNull
+    public ConfigurationOptions setObjectMapperFactory(@NonNull ObjectMapperFactory objectMapperFactory) {
+        Preconditions.checkNotNull(objectMapperFactory, "factory");
+        if (this.objectMapperFactory == objectMapperFactory) {
+            return this;
+        }
+        return new ConfigurationOptions(mapFactory, header, serializers, acceptedTypes, objectMapperFactory, shouldCopyDefaults);
     }
 
     /**
-     * Return whether objects of the provided type are accepted as values for nodes with this as their options object.
+     * Gets whether objects of the provided type are accepted as values for nodes with this as
+     * their options object.
      *
      * @param type The type to check
      * @return Whether the type is accepted
      */
-    public boolean acceptsType(Class<?> type) {
+    public boolean acceptsType(@NonNull Class<?> type) {
+        Preconditions.checkNotNull(type, "type");
+
         if (this.acceptedTypes == null) {
             return true;
         }
@@ -157,16 +198,27 @@ public class ConfigurationOptions {
     }
 
     /**
-     * Set types that will be accepted as native values for this configuration
+     * Creates a new {@link ConfigurationOptions} instance, with the specified accepted types
+     * set, and all other settings copied from this instance.
+     *
+     * <p>'Accepted types' are types which are accepted as native values for the configuration.</p>
+     *
+     * <p>Null indicates that all types are accepted.</p>
+     *
      * @param acceptedTypes The types that will be accepted to a call to {@link ConfigurationNode#setValue(Object)}
      * @return updated options object
      */
-    public ConfigurationOptions setAcceptedTypes(Set<Class<?>> acceptedTypes) {
-        return new ConfigurationOptions(mapSupplier, header, serializers, acceptedTypes, objectMapperFactory, shouldCopyDefaults);
+    @NonNull
+    public ConfigurationOptions setAcceptedTypes(@Nullable Set<Class<?>> acceptedTypes) {
+        if (Objects.equal(this.acceptedTypes, acceptedTypes)) {
+            return this;
+        }
+        return new ConfigurationOptions(mapFactory, header, serializers, acceptedTypes, objectMapperFactory, shouldCopyDefaults);
     }
 
     /**
-     * Return whether or not default parameters provided to {@link ConfigurationNode} getter methods should be set to the node when used.
+     * Gets whether or not default parameters provided to {@link ConfigurationNode} getter methods
+     * should be set to the node when used.
      *
      * @return Whether defaults should be copied into value
      */
@@ -175,14 +227,19 @@ public class ConfigurationOptions {
     }
 
     /**
-     * Set whether defaults should be set when used.
+     * Creates a new {@link ConfigurationOptions} instance, with the specified 'copy defaults' setting
+     * set, and all other settings copied from this instance.
      *
      * @see #shouldCopyDefaults() for information on what this method does
      * @param shouldCopyDefaults whether to copy defaults
      * @return updated options object
      */
+    @NonNull
     public ConfigurationOptions setShouldCopyDefaults(boolean shouldCopyDefaults) {
-        return new ConfigurationOptions(mapSupplier, header, serializers, acceptedTypes, objectMapperFactory, shouldCopyDefaults);
+        if (this.shouldCopyDefaults == shouldCopyDefaults) {
+            return this;
+        }
+        return new ConfigurationOptions(mapFactory, header, serializers, acceptedTypes, objectMapperFactory, shouldCopyDefaults);
     }
 
     @Override
@@ -191,7 +248,7 @@ public class ConfigurationOptions {
         if (!(o instanceof ConfigurationOptions)) return false;
         ConfigurationOptions that = (ConfigurationOptions) o;
         return Objects.equal(shouldCopyDefaults, that.shouldCopyDefaults) &&
-                Objects.equal(mapSupplier, that.mapSupplier) &&
+                Objects.equal(mapFactory, that.mapFactory) &&
                 Objects.equal(header, that.header) &&
                 Objects.equal(serializers, that.serializers) &&
                 Objects.equal(acceptedTypes, that.acceptedTypes) &&
@@ -200,6 +257,6 @@ public class ConfigurationOptions {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(mapSupplier, header, serializers, acceptedTypes, objectMapperFactory, shouldCopyDefaults);
+        return Objects.hashCode(mapFactory, header, serializers, acceptedTypes, objectMapperFactory, shouldCopyDefaults);
     }
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/ListConfigValue.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/ListConfigValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/MapConfigValue.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/MapConfigValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/MapConfigValue.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/MapConfigValue.java
@@ -17,11 +17,16 @@
 package ninja.leaping.configurate;
 
 import com.google.common.base.Objects;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 
+/**
+ * A {@link ConfigValue} which holds a map of values.
+ */
 class MapConfigValue extends ConfigValue {
     volatile ConcurrentMap<Object, SimpleConfigurationNode> values;
 
@@ -30,17 +35,22 @@ class MapConfigValue extends ConfigValue {
         values = newMap();
     }
 
+    private ConcurrentMap<Object, SimpleConfigurationNode> newMap() {
+        return holder.getOptions().getMapFactory().create();
+    }
+
+    @Nullable
     @Override
     public Object getValue() {
         Map<Object, Object> value = new LinkedHashMap<>();
         for (Map.Entry<Object, ? extends SimpleConfigurationNode> ent : values.entrySet()) {
-            value.put(ent.getKey(), ent.getValue().getValue());
+            value.put(ent.getKey(), ent.getValue().getValue()); // unwrap key from the backing node
         }
         return value;
     }
 
     @Override
-    public void setValue(Object value) {
+    public void setValue(@Nullable Object value) {
         if (value instanceof Map) {
             final ConcurrentMap<Object, SimpleConfigurationNode> newValue = newMap();
             for (Map.Entry<?, ?> ent : ((Map<?, ?>) value).entrySet()) {
@@ -60,11 +70,11 @@ class MapConfigValue extends ConfigValue {
         } else {
             throw new IllegalArgumentException("Map configuration values can only be set to values of type Map");
         }
-
     }
 
+    @Nullable
     @Override
-    SimpleConfigurationNode putChild(Object key, SimpleConfigurationNode value) {
+    SimpleConfigurationNode putChild(@NonNull Object key, @Nullable SimpleConfigurationNode value) {
         if (value == null) {
             return values.remove(key);
         } else {
@@ -72,8 +82,9 @@ class MapConfigValue extends ConfigValue {
         }
     }
 
+    @Nullable
     @Override
-    SimpleConfigurationNode putChildIfAbsent(Object key, SimpleConfigurationNode value) {
+    SimpleConfigurationNode putChildIfAbsent(@NonNull Object key, @Nullable SimpleConfigurationNode value) {
         if (value == null) {
             return values.remove(key);
         } else {
@@ -81,17 +92,19 @@ class MapConfigValue extends ConfigValue {
         }
     }
 
+    @Nullable
     @Override
-    public SimpleConfigurationNode getChild(Object key) {
+    public SimpleConfigurationNode getChild(@Nullable Object key) {
         return values.get(key);
     }
 
+    @NonNull
     @Override
     public Iterable<SimpleConfigurationNode> iterateChildren() {
         return values.values();
     }
 
-    private void detachChildren(Map<Object, SimpleConfigurationNode> map) {
+    private static void detachChildren(Map<Object, SimpleConfigurationNode> map) {
         for (SimpleConfigurationNode value : map.values()) {
             value.attached = false;
             value.clear();
@@ -105,11 +118,6 @@ class MapConfigValue extends ConfigValue {
             this.values = newMap();
             detachChildren(oldMap);
         }
-    }
-
-    @SuppressWarnings("unchecked")
-    private ConcurrentMap<Object, SimpleConfigurationNode> newMap() {
-        return holder.getOptions().getMapFactory().create();
     }
 
     @Override

--- a/configurate-core/src/main/java/ninja/leaping/configurate/NullConfigValue.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/NullConfigValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/NullConfigValue.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/NullConfigValue.java
@@ -16,37 +16,48 @@
  */
 package ninja.leaping.configurate;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Collections;
 
+/**
+ * A {@link ConfigValue} which holds no value.
+ */
 class NullConfigValue extends ConfigValue {
     NullConfigValue(SimpleConfigurationNode holder) {
         super(holder);
     }
+
+    @Nullable
     @Override
     public Object getValue() {
         return null;
     }
 
     @Override
-    public void setValue(Object value) {
+    public void setValue(@Nullable Object value) {
     }
 
+    @Nullable
     @Override
-    SimpleConfigurationNode putChild(Object key, SimpleConfigurationNode value) {
+    SimpleConfigurationNode putChild(@NonNull Object key, @Nullable SimpleConfigurationNode value) {
         return null;
     }
 
+    @Nullable
     @Override
-    SimpleConfigurationNode putChildIfAbsent(Object key, SimpleConfigurationNode value) {
+    SimpleConfigurationNode putChildIfAbsent(@NonNull Object key, @Nullable SimpleConfigurationNode value) {
         return null;
     }
 
+    @Nullable
     @Override
-    public SimpleConfigurationNode getChild(Object key) {
+    public SimpleConfigurationNode getChild(@Nullable Object key) {
         return null;
     }
 
+    @NonNull
     @Override
     public Iterable<SimpleConfigurationNode> iterateChildren() {
         return Collections.emptySet();

--- a/configurate-core/src/main/java/ninja/leaping/configurate/ScalarConfigValue.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/ScalarConfigValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/ScalarConfigValue.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/ScalarConfigValue.java
@@ -18,9 +18,14 @@ package ninja.leaping.configurate;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Collections;
 
+/**
+ * A {@link ConfigValue} which holds a single ("scalar") value.
+ */
 class ScalarConfigValue extends ConfigValue {
     private volatile Object value;
 
@@ -28,38 +33,40 @@ class ScalarConfigValue extends ConfigValue {
         super(holder);
     }
 
+    @Nullable
     @Override
     public Object getValue() {
         return value;
     }
 
     @Override
-    public void setValue(Object value) {
+    public void setValue(@Nullable Object value) {
         Preconditions.checkNotNull(value);
-
         if (!holder.getOptions().acceptsType(value.getClass())) {
-            throw new IllegalArgumentException("Configuration does not accept objects of type " + value
-                    .getClass());
+            throw new IllegalArgumentException("Configuration does not accept objects of type " + value.getClass());
         }
-
         this.value = value;
     }
 
+    @Nullable
     @Override
-    SimpleConfigurationNode putChild(Object key, SimpleConfigurationNode value) {
+    SimpleConfigurationNode putChild(@NonNull Object key, @Nullable SimpleConfigurationNode value) {
         return null;
     }
 
+    @Nullable
     @Override
-    SimpleConfigurationNode putChildIfAbsent(Object key, SimpleConfigurationNode value) {
+    SimpleConfigurationNode putChildIfAbsent(@NonNull Object key, @Nullable SimpleConfigurationNode value) {
         return null;
     }
 
+    @Nullable
     @Override
-    public SimpleConfigurationNode getChild(Object key) {
+    public SimpleConfigurationNode getChild(@Nullable Object key) {
         return null;
     }
 
+    @NonNull
     @Override
     public Iterable<SimpleConfigurationNode> iterateChildren() {
         return Collections.emptySet();

--- a/configurate-core/src/main/java/ninja/leaping/configurate/SimpleConfigurationNode.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/SimpleConfigurationNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/Types.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/Types.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/Types.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/Types.java
@@ -16,27 +16,60 @@
  */
 package ninja.leaping.configurate;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 /**
  * Contains functions useful for performing configuration type conversions.
- * The naming scheme is as follows:
- * as* functions attempt to convert the data passed to the appropriate type
- * strictAs* functions will only return values if the input value is already of an appropriate type
+ *
+ * <p>The naming scheme is as follows:</p>
+ * <p>
+ * <ul>
+ *     <li><code>as</code> methods attempt to convert the data passed to the appropriate type</li>
+ *     <li><code>strictAs</code> methods will only return values if the input value is already of an appropriate type</li>
+ * </ul>
  */
-public class Types {
-    private Types() {
-        // Always nope
-    }
+public final class Types {
+    private Types() {}
 
-    public static String asString(Object value) {
+    /**
+     * Attempts to convert <code>value</code> to a {@link String}.
+     *
+     * <p>Returns null if <code>value</code> is null, and the {@link Object#toString()}
+     * representation of <code>value</code> otherwise.</p>
+     *
+     * @param value The value
+     * @return <code>value</code> as a {@link String}, or null
+     * @see Object#toString()
+     */
+    @Nullable
+    public static String asString(@Nullable Object value) {
         return value == null ? null : value.toString();
     }
 
-    public static String strictAsString(Object value) {
+    /**
+     * Returns <code>value</code> if it is a {@link String}.
+     *
+     * @param value The value
+     * @return <code>value</code> as a {@link String}, or null
+     */
+    @Nullable
+    public static String strictAsString(@Nullable Object value) {
         return value instanceof String ? (String) value : null;
-
     }
 
-    public static Float asFloat(Object value) {
+    /**
+     * Attempts to convert <code>value</code> to a {@link Float}.
+     *
+     * <p>Returns null if <code>value</code> is null.</p>
+     *
+     * <p>This method will attempt to cast <code>value</code> to {@link Float}, or
+     * {@link Float#parseFloat(String) parse} the <code>value</code> if it is a {@link String}.</p>
+     *
+     * @param value The value
+     * @return <code>value</code> as a {@link Float}, or null
+     */
+    @Nullable
+    public static Float asFloat(@Nullable Object value) {
         if (value == null) {
             return null;
         }
@@ -54,7 +87,14 @@ public class Types {
         }
     }
 
-    public static Float strictAsFloat(Object value) {
+    /**
+     * Returns <code>value</code> if it is a {@link Float}.
+     *
+     * @param value The value
+     * @return <code>value</code> as a {@link Float}, or null
+     */
+    @Nullable
+    public static Float strictAsFloat(@Nullable Object value) {
         if (value == null) {
             return null;
         }
@@ -63,10 +103,23 @@ public class Types {
                 || value instanceof Integer) {
             return ((Number) value).floatValue();
         }
+
         return null;
     }
 
-    public static Double asDouble(Object value) {
+    /**
+     * Attempts to convert <code>value</code> to a {@link Double}.
+     *
+     * <p>Returns null if <code>value</code> is null.</p>
+     *
+     * <p>This method will attempt to cast <code>value</code> to {@link Double}, or
+     * {@link Double#parseDouble(String) parse} the <code>value</code> if it is a {@link String}.</p>
+     *
+     * @param value The value
+     * @return <code>value</code> as a {@link Float}, or null
+     */
+    @Nullable
+    public static Double asDouble(@Nullable Object value) {
         if (value == null) {
             return null;
         }
@@ -86,7 +139,14 @@ public class Types {
         }
     }
 
-    public static Double strictAsDouble(Object value) {
+    /**
+     * Returns <code>value</code> if it is a {@link Double}.
+     *
+     * @param value The value
+     * @return <code>value</code> as a {@link Double}, or null
+     */
+    @Nullable
+    public static Double strictAsDouble(@Nullable Object value) {
         if (value == null) {
             return null;
         }
@@ -97,11 +157,23 @@ public class Types {
                 || value instanceof Long) {
             return ((Number) value).doubleValue();
         }
-        return null;
 
+        return null;
     }
 
-    public static Integer asInt(Object value) {
+    /**
+     * Attempts to convert <code>value</code> to a {@link Integer}.
+     *
+     * <p>Returns null if <code>value</code> is null.</p>
+     *
+     * <p>This method will attempt to cast <code>value</code> to {@link Integer}, or
+     * {@link Integer#parseInt(String) parse} the <code>value</code> if it is a {@link String}.</p>
+     *
+     * @param value The value
+     * @return <code>value</code> as a {@link Float}, or null
+     */
+    @Nullable
+    public static Integer asInt(@Nullable Object value) {
         if (value == null) {
             return null;
         }
@@ -109,6 +181,7 @@ public class Types {
         if (value instanceof Integer) {
             return (Integer) value;
         }
+
         if (value instanceof Float
             || value instanceof Double) {
             double val = ((Number) value).doubleValue();
@@ -122,10 +195,16 @@ public class Types {
         } catch (IllegalArgumentException ex) {
             return null;
         }
-
     }
 
-    public static Integer strictAsInt(Object value) {
+    /**
+     * Returns <code>value</code> if it is a {@link Integer}.
+     *
+     * @param value The value
+     * @return <code>value</code> as a {@link Integer}, or null
+     */
+    @Nullable
+    public static Integer strictAsInt(@Nullable Object value) {
         if (value == null) {
             return null;
         }
@@ -133,7 +212,19 @@ public class Types {
         return value instanceof Integer ? (Integer) value : null;
     }
 
-    public static Long asLong(Object value) {
+    /**
+     * Attempts to convert <code>value</code> to a {@link Long}.
+     *
+     * <p>Returns null if <code>value</code> is null.</p>
+     *
+     * <p>This method will attempt to cast <code>value</code> to {@link Long}, or
+     * {@link Long#parseLong(String) parse} the <code>value</code> if it is a {@link String}.</p>
+     *
+     * @param value The value
+     * @return <code>value</code> as a {@link Float}, or null
+     */
+    @Nullable
+    public static Long asLong(@Nullable Object value) {
         if (value == null) {
             return null;
         }
@@ -157,10 +248,16 @@ public class Types {
         } catch (IllegalArgumentException ex) {
             return null;
         }
-
     }
 
-    public static Long strictAsLong(Object value) {
+    /**
+     * Returns <code>value</code> if it is a {@link Long}.
+     *
+     * @param value The value
+     * @return <code>value</code> as a {@link Long}, or null
+     */
+    @Nullable
+    public static Long strictAsLong(@Nullable Object value) {
         if (value == null) {
             return null;
         }
@@ -170,22 +267,27 @@ public class Types {
         } else if (value instanceof Integer) {
             return ((Number) value).longValue();
         }
+
         return null;
     }
 
     /**
-     * Tries to convert a value to a boolean.
+     * Attempts to convert <code>value</code> to a {@link Boolean}.
      *
-     * If value is a boolean, casts and returns
-     * If value is a Number, returns true if value is not 0
-     * If value.toString() returns true, t, yes, y, or 1, returns true
-     * If value.toString() returns false, f, no, n, or 0, returns false
-     * Otherwise returns null
+     * <p>
+     * <ul>
+     *     <li>If <code>value</code> is a {@link Boolean}, casts and returns</li>
+     *     <li>If <code>value</code> is a {@link Number}, returns true if value is not 0</li>
+     *     <li>If <code>value.toString()</code> returns true, t, yes, y, or 1, returns true</li>
+     *     <li>If <code>value.toString()</code> returns false, f, no, n, or 0, returns false</li>
+     *     <li>Otherwise returns null</li>
+     * </ul>
      *
-     * @param value The value to convert
-     * @return Value converted following rules specified above:w
+     * @param value The value
+     * @return <code>value</code> as a {@link Boolean}, or null
      */
-    public static Boolean asBoolean(Object value) {
+    @Nullable
+    public static Boolean asBoolean(@Nullable Object value) {
         if (value == null) {
             return null;
         }
@@ -193,9 +295,11 @@ public class Types {
         if (value instanceof Boolean) {
             return (Boolean) value;
         }
+
         if (value instanceof Number) {
             return !value.equals(0);
         }
+
         final String potential = value.toString();
         if (potential.equals("true")
                 || potential.equals("t")
@@ -210,10 +314,18 @@ public class Types {
                 || potential.equals("0")) {
             return false;
         }
+
         return null;
     }
 
-    public static Boolean strictAsBoolean(Object value) {
+    /**
+     * Returns <code>value</code> if it is a {@link Boolean}.
+     *
+     * @param value The value
+     * @return <code>value</code> as a {@link Boolean}, or null
+     */
+    @Nullable
+    public static Boolean strictAsBoolean(@Nullable Object value) {
         if (value == null) {
             return null;
         }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/commented/CommentedConfigurationNode.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/commented/CommentedConfigurationNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/commented/CommentedConfigurationNode.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/commented/CommentedConfigurationNode.java
@@ -16,43 +16,44 @@
  */
 package ninja.leaping.configurate.commented;
 
-import java.util.Optional;
 import ninja.leaping.configurate.ConfigurationNode;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
- * A configuration node that is capable of having an attached comment
+ * A configuration node that can have a comment attached to it.
  */
 public interface CommentedConfigurationNode extends ConfigurationNode {
+
     /**
-     * Gets the current value for the comment. If the comment contains multiple lines, the lines will be split by \n
+     * Gets the current value for the comment.
      *
-     * @return the configuration's current comment
+     * <p>If the comment contains multiple lines, the lines will be split by \n</p>
+     *
+     * @return The configuration's current comment
      */
+    @NonNull
     Optional<String> getComment();
 
     /**
-     * Sets the comment for this configuration.
+     * Sets the comment for this configuration node.
+     *
      * @param comment The comment to set. Line breaks should be represented as LFs (\n)
      * @return this
      */
-    CommentedConfigurationNode setComment(String comment);
+    @NonNull
+    CommentedConfigurationNode setComment(@Nullable String comment);
 
     // Methods from superclass overridden to have correct return types
-
-    CommentedConfigurationNode getParent();
-    @Override
-    List<? extends CommentedConfigurationNode> getChildrenList();
-    @Override
-    Map<Object, ? extends CommentedConfigurationNode> getChildrenMap();
-    @Override
-    CommentedConfigurationNode setValue(Object value);
-    @Override
-    CommentedConfigurationNode mergeValuesFrom(ConfigurationNode other);
-    @Override
-    CommentedConfigurationNode getAppendedNode();
-    @Override
-    CommentedConfigurationNode getNode(Object... path);
+    @Nullable @Override CommentedConfigurationNode getParent();
+    @NonNull @Override List<? extends CommentedConfigurationNode> getChildrenList();
+    @NonNull @Override Map<Object, ? extends CommentedConfigurationNode> getChildrenMap();
+    @NonNull @Override CommentedConfigurationNode setValue(@Nullable Object value);
+    @NonNull @Override CommentedConfigurationNode mergeValuesFrom(@NonNull ConfigurationNode other);
+    @NonNull @Override CommentedConfigurationNode getAppendedNode();
+    @NonNull @Override CommentedConfigurationNode getNode(@NonNull Object... path);
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/commented/SimpleCommentedConfigurationNode.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/commented/SimpleCommentedConfigurationNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/commented/SimpleCommentedConfigurationNode.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/commented/SimpleCommentedConfigurationNode.java
@@ -16,46 +16,54 @@
  */
 package ninja.leaping.configurate.commented;
 
-import java.util.Optional;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.ConfigurationOptions;
 import ninja.leaping.configurate.SimpleConfigurationNode;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
-
 /**
- * Represents a configuration node containing comments
+ * Basic implementation of {@link CommentedConfigurationNode}.
  */
 public class SimpleCommentedConfigurationNode extends SimpleConfigurationNode implements CommentedConfigurationNode {
     private final AtomicReference<String> comment = new AtomicReference<>();
 
+    @NonNull
     public static SimpleCommentedConfigurationNode root() {
         return root(ConfigurationOptions.defaults());
     }
 
-    public static SimpleCommentedConfigurationNode root(ConfigurationOptions options) {
+    @NonNull
+    public static SimpleCommentedConfigurationNode root(@NonNull ConfigurationOptions options) {
         return new SimpleCommentedConfigurationNode(null, null, options);
     }
 
-    protected SimpleCommentedConfigurationNode(Object path, SimpleConfigurationNode parent, ConfigurationOptions options) {
+    protected SimpleCommentedConfigurationNode(@Nullable Object path, @Nullable SimpleConfigurationNode parent, @NonNull ConfigurationOptions options) {
         super(path, parent, options);
     }
 
+    @NonNull
     @Override
     public Optional<String> getComment() {
         return Optional.ofNullable(comment.get());
     }
 
+    @NonNull
     @Override
-    public SimpleCommentedConfigurationNode setComment(String comment) {
+    public SimpleCommentedConfigurationNode setComment(@Nullable String comment) {
         attachIfNecessary();
         this.comment.set(comment);
         return this;
     }
 
+    // Methods from superclass overridden to have correct return types
+
+    @Nullable
     @Override
     public SimpleCommentedConfigurationNode getParent() {
         return (SimpleCommentedConfigurationNode) super.getParent();
@@ -66,16 +74,18 @@ public class SimpleCommentedConfigurationNode extends SimpleConfigurationNode im
         return new SimpleCommentedConfigurationNode(path, this, getOptions());
     }
 
+    @NonNull
     @Override
-    public SimpleCommentedConfigurationNode setValue(Object value) {
+    public SimpleCommentedConfigurationNode setValue(@Nullable Object value) {
         if (value instanceof CommentedConfigurationNode && ((CommentedConfigurationNode) value).getComment().isPresent()) {
             setComment(((CommentedConfigurationNode) value).getComment().get());
         }
-        return (SimpleCommentedConfigurationNode)super.setValue(value);
+        return (SimpleCommentedConfigurationNode) super.setValue(value);
     }
 
+    @NonNull
     @Override
-    public SimpleCommentedConfigurationNode mergeValuesFrom(ConfigurationNode other) {
+    public SimpleCommentedConfigurationNode mergeValuesFrom(@NonNull ConfigurationNode other) {
         if (other instanceof CommentedConfigurationNode) {
             Optional<String> otherComment = ((CommentedConfigurationNode) other).getComment();
             if (otherComment.isPresent()) {
@@ -85,23 +95,27 @@ public class SimpleCommentedConfigurationNode extends SimpleConfigurationNode im
         return (SimpleCommentedConfigurationNode) super.mergeValuesFrom(other);
     }
 
+    @NonNull
     @Override
-    public SimpleCommentedConfigurationNode getNode(Object... path) {
-        return (SimpleCommentedConfigurationNode)super.getNode(path);
+    public SimpleCommentedConfigurationNode getNode(@NonNull Object... path) {
+        return (SimpleCommentedConfigurationNode) super.getNode(path);
     }
 
+    @NonNull
     @Override
     @SuppressWarnings("unchecked")
     public List<? extends SimpleCommentedConfigurationNode> getChildrenList() {
         return (List<SimpleCommentedConfigurationNode>) super.getChildrenList();
     }
 
+    @NonNull
     @Override
     @SuppressWarnings("unchecked")
     public Map<Object, ? extends SimpleCommentedConfigurationNode> getChildrenMap() {
         return (Map<Object, SimpleCommentedConfigurationNode>) super.getChildrenMap();
     }
 
+    @NonNull
     @Override
     public SimpleCommentedConfigurationNode getAppendedNode() {
         return (SimpleCommentedConfigurationNode) super.getAppendedNode();
@@ -114,9 +128,7 @@ public class SimpleCommentedConfigurationNode extends SimpleConfigurationNode im
         if (!super.equals(o)) return false;
 
         SimpleCommentedConfigurationNode that = (SimpleCommentedConfigurationNode) o;
-
         if (!comment.equals(that.comment)) return false;
-
         return true;
     }
 
@@ -131,7 +143,7 @@ public class SimpleCommentedConfigurationNode extends SimpleConfigurationNode im
     public String toString() {
         return "SimpleCommentedConfigurationNode{" +
                 "super=" + super.toString() +
-                "comment=" + comment +
+                ", comment=" + comment +
                 '}';
     }
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/loader/AbstractConfigurationLoader.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/loader/AbstractConfigurationLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/loader/AbstractConfigurationLoader.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/loader/AbstractConfigurationLoader.java
@@ -20,6 +20,8 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.ConfigurationOptions;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -43,127 +45,99 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  *
  * Either the source or sink may be null. If this is true, this loader may not support either loading or saving. In
  * this case, implementing classes are expected to throw an IOException.
+ *
+ * @param <NodeType> The {@link ConfigurationNode} type produced by the loader
  */
 public abstract class AbstractConfigurationLoader<NodeType extends ConfigurationNode> implements ConfigurationLoader<NodeType> {
+
+    /**
+     * The escape sequence used by Configurate to separate comment lines
+     */
     public static final String CONFIGURATE_LINE_SEPARATOR = "\n";
+
+    /**
+     * A {@link Splitter} for splitting comment lines
+     */
     protected static final Splitter LINE_SPLITTER = Splitter.on(CONFIGURATE_LINE_SEPARATOR);
+
+    /**
+     * The line separator used by the system
+     * @see System#lineSeparator
+     */
     protected static final String SYSTEM_LINE_SEPARATOR = System.lineSeparator();
+
+
+    /**
+     * The reader source for this loader.
+     *
+     * <p>Can be null (for loaders which don't support loading!)</p>
+     */
+    @Nullable
     protected final Callable<BufferedReader> source;
-    private final Callable<BufferedWriter> sink;
+
+    /**
+     * The writer sink for this loader.
+     *
+     * <p>Can be null (for loaders which don't support saving!)</p>
+     */
+    @Nullable
+    protected final Callable<BufferedWriter> sink;
+
+    /**
+     * The comment handlers defined for this loader
+     */
+    @NonNull
     private final CommentHandler[] commentHandlers;
+
+    /**
+     * The mode used to read/write configuration headers
+     */
+    @NonNull
     private final HeaderMode headerMode;
+
+    /**
+     * The default {@link ConfigurationOptions} used by this loader.
+     */
+    @NonNull
     private final ConfigurationOptions defaultOptions;
 
-    protected static abstract class Builder<T extends Builder> {
-        protected HeaderMode headerMode = HeaderMode.PRESERVE;
-        protected Callable<BufferedReader> source;
-        protected Callable<BufferedWriter> sink;
-        protected ConfigurationOptions defaultOptions = ConfigurationOptions.defaults();
-
-        protected Builder() {}
-
-        @SuppressWarnings("unchecked")
-        private T self() {
-            return (T) this;
-        }
-
-        public T setFile(File file) {
-            return setPath(file.toPath());
-        }
-
-        public T setPath(Path path) {
-            Path absPath = Objects.requireNonNull(path, "path").toAbsolutePath();
-            this.source = () -> Files.newBufferedReader(absPath, UTF_8);
-            this.sink = AtomicFiles.createAtomicWriterFactory(absPath, UTF_8);
-            return self();
-        }
-
-        public T setURL(URL url) {
-            this.source = () -> new BufferedReader(new InputStreamReader(url.openConnection().getInputStream(), UTF_8));
-            return self();
-        }
-
-        public T setSource(Callable<BufferedReader> source) {
-            this.source = source;
-            return self();
-        }
-
-        public T setSink(Callable<BufferedWriter> sink) {
-            this.sink = sink;
-            return self();
-        }
-
-        public Callable<BufferedReader> getSource() {
-            return this.source;
-        }
-
-        public Callable<BufferedWriter> getSink() {
-            return this.sink;
-        }
-
-        @Deprecated
-        public T setPreservesHeader(boolean preservesHeader) {
-            this.headerMode = preservesHeader ? HeaderMode.PRESERVE : HeaderMode.PRESET;
-            return self();
-        }
-
-        @Deprecated
-        public boolean preservesHeader() {
-            return this.headerMode == HeaderMode.PRESERVE;
-        }
-
-        public T setHeaderMode(HeaderMode mode) {
-            this.headerMode = mode;
-            return self();
-        }
-
-        public HeaderMode getHeaderMode() {
-            return this.headerMode;
-        }
-
-        public T setDefaultOptions(ConfigurationOptions defaultOptions) {
-            this.defaultOptions = Objects.requireNonNull(defaultOptions, "defaultOptions");
-            return self();
-        }
-
-        public ConfigurationOptions getDefaultOptions() {
-            return this.defaultOptions;
-        }
-
-        public abstract AbstractConfigurationLoader build();
-
-    }
-
-    protected AbstractConfigurationLoader(Builder<?> builder, CommentHandler[] commentHandlers) {
+    protected AbstractConfigurationLoader(@NonNull Builder<?> builder, @NonNull CommentHandler[] commentHandlers) {
         this.source = builder.getSource();
         this.sink = builder.getSink();
         this.headerMode = builder.getHeaderMode();
-        this.defaultOptions = builder.getDefaultOptions();
         this.commentHandlers = commentHandlers;
+        this.defaultOptions = builder.getDefaultOptions();
     }
 
+    /**
+     * Gets the primary {@link CommentHandler} used by this loader.
+     *
+     * @return The default comment handler
+     */
+    @NonNull
     public CommentHandler getDefaultCommentHandler() {
         return this.commentHandlers[0];
     }
 
+    @NonNull
     @Override
-    public NodeType load(ConfigurationOptions options) throws IOException {
-        if (!canLoad()) {
+    public NodeType load(@NonNull ConfigurationOptions options) throws IOException {
+        if (source == null) {
             throw new IOException("No source present to read from!");
         }
         try (BufferedReader reader = source.call()) {
-            NodeType node;
             if (headerMode == HeaderMode.PRESERVE || headerMode == HeaderMode.NONE) {
                 String comment = CommentHandlers.extractComment(reader, commentHandlers);
                 if (comment != null && comment.length() > 0) {
                     options = options.setHeader(comment);
                 }
             }
-            node = createEmptyNode(options);
+            NodeType node = createEmptyNode(options);
             loadInternal(node, reader);
             return node;
         } catch (FileNotFoundException | NoSuchFileException e) {
             // Squash -- there's nothing to read
+            return createEmptyNode(options);
         } catch (Exception e) {
             if (e instanceof IOException) {
                 throw (IOException) e;
@@ -171,14 +145,13 @@ public abstract class AbstractConfigurationLoader<NodeType extends Configuration
                 throw new IOException(e);
             }
         }
-        return createEmptyNode(options);
     }
 
     protected abstract void loadInternal(NodeType node, BufferedReader reader) throws IOException;
 
     @Override
-    public void save(ConfigurationNode node) throws IOException {
-        if (!canSave()) {
+    public void save(@NonNull ConfigurationNode node) throws IOException {
+        if (sink == null) {
             throw new IOException("No sink present to write to!");
         }
         try (Writer writer = sink.call()) {
@@ -204,22 +177,218 @@ public abstract class AbstractConfigurationLoader<NodeType extends Configuration
 
     protected abstract void saveInternal(ConfigurationNode node, Writer writer) throws IOException;
 
-    /**
-     * Get the default options that any new nodes will be created with if no options object is passed.
-     *
-     * @return The default options
-     */
+    @NonNull
     @Override
     public ConfigurationOptions getDefaultOptions() {
         return this.defaultOptions;
     }
 
-    public boolean canLoad() {
+    @Override
+    public final boolean canLoad() {
         return this.source != null;
     }
 
-    public boolean canSave() {
+    @Override
+    public final boolean canSave() {
         return this.sink != null;
+    }
+
+    /**
+     * An abstract builder implementation for {@link AbstractConfigurationLoader}s.
+     *
+     * @param <T> The builders own type (for chaining using generic types)
+     */
+    protected static abstract class Builder<T extends Builder> {
+        @NonNull protected HeaderMode headerMode = HeaderMode.PRESERVE;
+        @Nullable protected Callable<BufferedReader> source;
+        @Nullable protected Callable<BufferedWriter> sink;
+        @NonNull protected ConfigurationOptions defaultOptions = ConfigurationOptions.defaults();
+
+        protected Builder() {}
+
+        @SuppressWarnings("unchecked")
+        @NonNull
+        private T self() {
+            return (T) this;
+        }
+
+        /**
+         * Sets the sink and source of the resultant loader to the given file.
+         *
+         * <p>The {@link #getSource() source} is defined using
+         * {@link Files#newBufferedReader(Path)} with UTF-8 encoding.</p>
+         *
+         * <p>The {@link #getSink() sink} is defined using {@link AtomicFiles} with UTF-8
+         * encoding.</p>
+         *
+         * @param file The configuration file
+         * @return This builder (for chaining)
+         */
+        @NonNull
+        public T setFile(@NonNull File file) {
+            return setPath(Objects.requireNonNull(file, "file").toPath());
+        }
+
+        /**
+         * Sets the sink and source of the resultant loader to the given path.
+         *
+         * <p>The {@link #getSource() source} is defined using
+         * {@link Files#newBufferedReader(Path)} with UTF-8 encoding.</p>
+         *
+         * <p>The {@link #getSink() sink} is defined using {@link AtomicFiles} with UTF-8
+         * encoding.</p>
+         *
+         * @param path The path of the configuration file
+         * @return This builder (for chaining)
+         */
+        @NonNull
+        public T setPath(@NonNull Path path) {
+            Path absPath = Objects.requireNonNull(path, "path").toAbsolutePath();
+            this.source = () -> Files.newBufferedReader(absPath, UTF_8);
+            this.sink = AtomicFiles.createAtomicWriterFactory(absPath, UTF_8);
+            return self();
+        }
+
+        /**
+         * Sets the source of the resultant loader to the given URL.
+         *
+         * @param url The URL of the source
+         * @return This builder (for chaining)
+         */
+        @NonNull
+        public T setURL(@NonNull URL url) {
+            Objects.requireNonNull(url, "url");
+            this.source = () -> new BufferedReader(new InputStreamReader(url.openConnection().getInputStream(), UTF_8));
+            return self();
+        }
+
+        /**
+         * Sets the source of the resultant loader.
+         *
+         * <p>The "source" is used by the loader to load the configuration.</p>
+         *
+         * @param source The source
+         * @return This builder (for chaining)
+         */
+        @NonNull
+        public T setSource(@Nullable Callable<BufferedReader> source) {
+            this.source = source;
+            return self();
+        }
+
+        /**
+         * Sets the sink of the resultant loader.
+         *
+         * <p>The "sink" is used by the loader to save the configuration.</p>
+         *
+         * @param sink The sink
+         * @return This builder (for chaining)
+         */
+        @NonNull
+        public T setSink(@Nullable Callable<BufferedWriter> sink) {
+            this.sink = sink;
+            return self();
+        }
+
+        /**
+         * Gets the source to be used by the resultant loader.
+         *
+         * @return The source
+         */
+        @Nullable
+        public Callable<BufferedReader> getSource() {
+            return this.source;
+        }
+
+        /**
+         * Gets the sink to be used by the resultant loader.
+         *
+         * @return The sink
+         */
+        @Nullable
+        public Callable<BufferedWriter> getSink() {
+            return this.sink;
+        }
+
+        /**
+         * Sets the header mode of the resultant loader.
+         *
+         * @param mode The header mode
+         * @return This builder (for chaining)
+         */
+        @NonNull
+        public T setHeaderMode(@NonNull HeaderMode mode) {
+            this.headerMode = Objects.requireNonNull(mode, "mode");
+            return self();
+        }
+
+        /**
+         * Gets the header mode to be used by the resultant loader.
+         *
+         * @return The header mode
+         */
+        @NonNull
+        public HeaderMode getHeaderMode() {
+            return this.headerMode;
+        }
+
+        /**
+         * Sets if the header of the configuration should be preserved.
+         *
+         * <p>See {@link HeaderMode#PRESERVE} and {@link HeaderMode#PRESET}.</p>
+         *
+         * @param preservesHeader If the header should be preserved
+         * @return this builder (for chaining)
+         * @deprecated In favour of {@link #setHeaderMode(HeaderMode)}
+         */
+        @NonNull
+        @Deprecated
+        public T setPreservesHeader(boolean preservesHeader) {
+            this.headerMode = preservesHeader ? HeaderMode.PRESERVE : HeaderMode.PRESET;
+            return self();
+        }
+
+        /**
+         * Gets if the header of the configuration should be preserved.
+         *
+         * @return If the header should be preserved
+         * @deprecated In favour of {@link #getHeaderMode()}
+         */
+        @Deprecated
+        public boolean preservesHeader() {
+            return this.headerMode == HeaderMode.PRESERVE;
+        }
+
+        /**
+         * Sets the default configuration options to be used by the resultant loader.
+         *
+         * @param defaultOptions The options
+         * @return This builder (for chaining)
+         */
+        @NonNull
+        public T setDefaultOptions(@NonNull ConfigurationOptions defaultOptions) {
+            this.defaultOptions = Objects.requireNonNull(defaultOptions, "defaultOptions");
+            return self();
+        }
+
+        /**
+         * Gets the default configuration options to be used by the resultant loader.
+         *
+         * @return The options
+         */
+        @NonNull
+        public ConfigurationOptions getDefaultOptions() {
+            return this.defaultOptions;
+        }
+
+        /**
+         * Builds the loader.
+         *
+         * @return The loader
+         */
+        @NonNull
+        public abstract AbstractConfigurationLoader build();
+
     }
 
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/loader/AtomicFiles.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/loader/AtomicFiles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/loader/AtomicFiles.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/loader/AtomicFiles.java
@@ -17,6 +17,7 @@
 package ninja.leaping.configurate.loader;
 
 import com.google.common.base.Preconditions;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.io.BufferedWriter;
 import java.io.FilterWriter;
@@ -26,25 +27,40 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.attribute.FileAttribute;
 import java.util.concurrent.Callable;
 
-public class AtomicFiles {
-    private static final FileAttribute<?>[] EMPTY_ATTRIBUTE_ARR = new FileAttribute[0];
+/**
+ * A utility for creating "atomic" file writers.
+ *
+ * <p>An atomic writer copies any existing file at the given path to a temporary location, then
+ * writes to the same temporary location, before moving the file back to the desired output path
+ * once the write is fully complete.</p>
+ */
+public final class AtomicFiles {
     private AtomicFiles() {}
 
-    public static Callable<BufferedWriter> createAtomicWriterFactory(Path path, Charset charset) {
+    /**
+     * Creates and returns an "atomic" writer factory for the given path.
+     *
+     * @param path The path
+     * @param charset The charset to be used by the writer
+     * @return The writer factory
+     */
+    @NonNull
+    public static Callable<BufferedWriter> createAtomicWriterFactory(@NonNull Path path, @NonNull Charset charset) {
         Preconditions.checkNotNull(path, "path");
         return () -> createAtomicBufferedWriter(path, charset);
     }
 
-    private static Path getTemporaryPath(Path parent, String key) {
-        String fileName = System.nanoTime() + Preconditions.checkNotNull(key, "key").replaceAll("\\\\|/|:",
-                "-") + ".tmp";
-        return parent.resolve(fileName);
-    }
-
-    public static BufferedWriter createAtomicBufferedWriter(Path path, Charset charset) throws IOException {
+    /**
+     * Creates and returns an "atomic" writer for the given path.
+     *
+     * @param path The path
+     * @param charset The charset to be used by the writer
+     * @return The writer factory
+     */
+    @NonNull
+    public static BufferedWriter createAtomicBufferedWriter(@NonNull Path path, @NonNull Charset charset) throws IOException {
         path = path.toAbsolutePath();
 
         Path writePath = getTemporaryPath(path.getParent(), path.getFileName().toString());
@@ -56,10 +72,17 @@ public class AtomicFiles {
         return new BufferedWriter(new AtomicFileWriter(writePath, path, output));
     }
 
+    @NonNull
+    private static Path getTemporaryPath(@NonNull Path parent, @NonNull String key) {
+        String fileName = System.nanoTime() + Preconditions.checkNotNull(key, "key").replaceAll("\\\\|/|:",
+                "-") + ".tmp";
+        return parent.resolve(fileName);
+    }
+
     private static class AtomicFileWriter extends FilterWriter {
         private final Path targetPath, writePath;
 
-        protected AtomicFileWriter(Path writePath, Path targetPath, Writer wrapping) throws IOException {
+        protected AtomicFileWriter(Path writePath, Path targetPath, Writer wrapping) {
             super(wrapping);
             this.writePath = writePath;
             this.targetPath = targetPath;

--- a/configurate-core/src/main/java/ninja/leaping/configurate/loader/CommentHandler.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/loader/CommentHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/loader/CommentHandler.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/loader/CommentHandler.java
@@ -16,21 +16,35 @@
  */
 package ninja.leaping.configurate.loader;
 
-import java.util.Optional;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * Interface specifying methods for handling abstract comments
  */
 public interface CommentHandler {
-    Optional<String> extractHeader(BufferedReader reader) throws IOException;
+
     /**
-     * Convert the given lines into a comment
+     * Defines the handlers behaviour for reading comments.
+     *
+     * @param reader The reader
+     * @return The comment
+     * @throws IOException If any IO error occurs in the process
+     */
+    @NonNull
+    Optional<String> extractHeader(@NonNull BufferedReader reader) throws IOException;
+
+    /**
+     * Converts the given lines into a comment
+     *
      * @param lines The lines to make a comment
      * @return The transformed lines
      */
-    Collection<String> toComment(Collection<String> lines);
+    @NonNull
+    Collection<String> toComment(@NonNull Collection<String> lines);
+
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/loader/CommentHandlers.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/loader/CommentHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/loader/CommentHandlers.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/loader/CommentHandlers.java
@@ -16,27 +16,39 @@
  */
 package ninja.leaping.configurate.loader;
 
-import java.util.Optional;
 import com.google.common.collect.Collections2;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
- * Handlers for various comment formats
+ * Defines a number of default {@link CommentHandler}s.
  */
 public enum CommentHandlers implements CommentHandler {
-    HASH("#"),
-    DOUBLE_SLASH("//"),
+
     /**
-     * Block comments delineated by
+     * {@link CommentHandler} for comments prefixed by the <code>#</code> character.
+     */
+    HASH("#"),
+
+    /**
+     * {@link CommentHandler} for comments prefixed by a <code>//</code> escape.
+     */
+    DOUBLE_SLASH("//"),
+
+    /**
+     * {@link CommentHandler} for comments delineated using <code>/* *\/</code>.
      */
     SLASH_BLOCK() {
+        @NonNull
         @Override
-        public Optional<String> extractHeader(BufferedReader reader) throws IOException {
+        public Optional<String> extractHeader(@NonNull BufferedReader reader) throws IOException {
             final StringBuilder build = new StringBuilder();
             String line = reader.readLine();
             if (line == null) {
@@ -93,8 +105,9 @@ public enum CommentHandlers implements CommentHandler {
             return moreLines;
         }
 
+        @NonNull
         @Override
-        public Collection<String> toComment(Collection<String> lines) {
+        public Collection<String> toComment(@NonNull Collection<String> lines) {
             if (lines.size() == 1) {
                 return lines.stream().map(i -> "/* " + i + " */").collect(Collectors.toList());
             } else {
@@ -105,22 +118,27 @@ public enum CommentHandlers implements CommentHandler {
                 return ret;
             }
         }
-    }
-    ;
+    };
 
+    /**
+     * Limit on the number of characters that may be read by a comment handler while still
+     * preserving the mark.
+     */
     private static final int READAHEAD_LEN = 4096;
 
     private final String commentPrefix;
 
-    private CommentHandlers() {
-        this.commentPrefix = null;
-    }
-
-    private CommentHandlers(String commentPrefix) {
+    CommentHandlers(String commentPrefix) {
         this.commentPrefix = commentPrefix;
     }
 
-    public Optional<String> extractHeader(BufferedReader reader) throws IOException {
+    CommentHandlers() {
+        this(null);
+    }
+
+    @NonNull
+    @Override
+    public Optional<String> extractHeader(@NonNull BufferedReader reader) throws IOException {
         StringBuilder build = new StringBuilder();
         for (String line = reader.readLine(); line != null; line = reader.readLine()) {
             if (line.trim().startsWith(commentPrefix)) {
@@ -141,11 +159,12 @@ public enum CommentHandlers implements CommentHandler {
             }
         }
         // We've reached the end of the document?
-        return build.length() > 0 ? Optional.ofNullable(build.toString()) : Optional.<String>empty();
+        return build.length() > 0 ? Optional.of(build.toString()) : Optional.empty();
     }
 
+    @NonNull
     @Override
-    public Collection<String> toComment(Collection<String> lines) {
+    public Collection<String> toComment(@NonNull Collection<String> lines) {
         return Collections2.transform(lines, s -> {
             if (s.startsWith(" ")) {
                 return commentPrefix + s;
@@ -155,7 +174,16 @@ public enum CommentHandlers implements CommentHandler {
         });
     }
 
-    public static String extractComment(BufferedReader reader, CommentHandler... allowedHeaderTypes) throws IOException {
+    /**
+     * Uses provided comment handlers to extract a comment from the reader.
+     *
+     * @param reader The reader
+     * @param allowedHeaderTypes The handlers to try
+     * @return The extracted comment, or null if a comment could not be extracted
+     * @throws IOException If an IO error occurs
+     */
+    @Nullable
+    public static String extractComment(@NonNull BufferedReader reader, @NonNull CommentHandler... allowedHeaderTypes) throws IOException {
         reader.mark(READAHEAD_LEN);
         for (CommentHandler handler : allowedHeaderTypes) {
             Optional<String> comment = handler.extractHeader(reader);

--- a/configurate-core/src/main/java/ninja/leaping/configurate/loader/ConfigurationLoader.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/loader/ConfigurationLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/loader/ConfigurationLoader.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/loader/ConfigurationLoader.java
@@ -18,52 +18,71 @@ package ninja.leaping.configurate.loader;
 
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.ConfigurationOptions;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.io.IOException;
 
 /**
- * Loader for a specific configuration format
+ * Represents an object which can load and save {@link ConfigurationNode} objects in a specific
+ * configuration format.
+ *
+ * <p>An abstract implementation is provided by {@link AbstractConfigurationLoader}.</p>
+ *
+ * @param <NodeType> The {@link ConfigurationNode} type produced by the loader
  */
 public interface ConfigurationLoader<NodeType extends ConfigurationNode> {
+
     /**
-     * Get the default options that any new nodes will be created with if no options object is passed.
+     * Gets the default {@link ConfigurationOptions} used by the loader.
+     *
+     * <p>New nodes will be created using the default options if a specific set is not defined.</p>
      *
      * @return The default options
      */
+    @NonNull
     ConfigurationOptions getDefaultOptions();
 
     /**
-     * Create a new configuration node populated with the appropriate data.
+     * Attempts to load a {@link ConfigurationNode} using this loader, from the defined source.
+     *
+     * <p>The resultant node represents the root of the configuration being loaded.</p>
+     *
+     * <p>The {@link #getDefaultOptions() default options} will be used to construct the resultant
+     * configuration nodes.</p>
      *
      * @return The newly constructed node
-     * @throws java.io.IOException if any sort of error occurs with reading or parsing the configuration
+     * @throws IOException if any sort of error occurs with reading or parsing the configuration
      */
+    @NonNull
     default NodeType load() throws IOException {
         return load(getDefaultOptions());
     }
 
     /**
-     * Create a new configuration node populated with the appropriate data, structured with the provided options.
+     * Attempts to load a {@link ConfigurationNode} using this loader, from the defined source.
+     *
+     * <p>The resultant node represents the root of the configuration being loaded.</p>
      *
      * @param options The options to load with
      * @return The newly constructed node
-     * @throws java.io.IOException if any sort of error occurs with reading or parsing the configuration
+     * @throws IOException if any sort of error occurs with reading or parsing the configuration
      */
-    NodeType load(ConfigurationOptions options) throws IOException;
+    @NonNull
+    NodeType load(@NonNull ConfigurationOptions options) throws IOException;
 
     /**
-     * Save the contents of the given node tree to this loader.
+     * Attempts to save a {@link ConfigurationNode} using this loader, to the defined sink.
      *
-     * @param node The node a save is being requested for
-     * @throws java.io.IOException if any sort of error occurs with writing or generating the configuration
+     * @throws IOException if any sort of error occurs with writing or generating the configuration
      */
-    void save(ConfigurationNode node) throws IOException;
+    void save(@NonNull ConfigurationNode node) throws IOException;
 
     /**
      * Return an empty node of the most appropriate type for this loader, using the default options.
      *
      * @return The appropriate node type
      */
+    @NonNull
     default NodeType createEmptyNode() {
         return createEmptyNode(getDefaultOptions());
     }
@@ -71,8 +90,27 @@ public interface ConfigurationLoader<NodeType extends ConfigurationNode> {
     /**
      * Return an empty node of the most appropriate type for this loader
      *
-     * @param options The options to use with this node. Must not be null (take a look at {@link ConfigurationOptions#defaults()})
+     * @param options The options to use with this node. Must not be null (see {@link ConfigurationOptions#defaults()})
      * @return The appropriate node type
      */
-    NodeType createEmptyNode(ConfigurationOptions options);
+    @NonNull
+    NodeType createEmptyNode(@NonNull ConfigurationOptions options);
+
+    /**
+     * Gets if this loader is capable of loading configurations.
+     *
+     * @return If this loader can load
+     */
+    default boolean canLoad() {
+        return true;
+    }
+
+    /**
+     * Gets if this loader is capable of saving configurations.
+     *
+     * @return If this loader can save
+     */
+    default boolean canSave() {
+        return true;
+    }
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/loader/HeaderMode.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/loader/HeaderMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/loader/HeaderMode.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/loader/HeaderMode.java
@@ -17,17 +17,20 @@
 package ninja.leaping.configurate.loader;
 
 /**
- * Options for header handling
+ * Modes which {@link ConfigurationLoader}s can use to manipulate headers when loading/saving.
  */
 public enum HeaderMode {
+
     /**
      * Use the header loaded from an existing file, replacing any header set in the options
      */
     PRESERVE,
+
     /**
-     * ignore any header present in input, and output a header if one has been set in options
+     * Ignore any header present in input, and output a header if one has been set in options
      */
     PRESET,
+
     /**
      * Ignore any header present in input, and do not output any header
      */

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/DefaultObjectMapperFactory.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/DefaultObjectMapperFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/DefaultObjectMapperFactory.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/DefaultObjectMapperFactory.java
@@ -20,25 +20,35 @@ import com.google.common.base.Preconditions;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.concurrent.ExecutionException;
 
 /**
- * Factory for a basic {@link ObjectMapper}
+ * Factory for a basic {@link ObjectMapper}.
  */
 public class DefaultObjectMapperFactory implements ObjectMapperFactory {
     private static final ObjectMapperFactory INSTANCE = new DefaultObjectMapperFactory();
-    private final LoadingCache<Class<?>, ObjectMapper<?>> mapperCache = CacheBuilder.newBuilder().weakKeys()
-            .maximumSize(500).build(new CacheLoader<Class<?>, ObjectMapper<?>>() {
+
+    @NonNull
+    public static ObjectMapperFactory getInstance() {
+        return INSTANCE;
+    }
+
+    private final LoadingCache<Class<?>, ObjectMapper<?>> mapperCache = CacheBuilder.newBuilder()
+            .weakKeys()
+            .maximumSize(500)
+            .build(new CacheLoader<Class<?>, ObjectMapper<?>>() {
                 @Override
                 public ObjectMapper<?> load(Class<?> key) throws Exception {
                     return new ObjectMapper<>(key);
                 }
             });
 
+    @NonNull
     @Override
     @SuppressWarnings("unchecked")
-    public <T> ObjectMapper<T> getMapper(Class<T> type) throws ObjectMappingException {
+    public <T> ObjectMapper<T> getMapper(@NonNull Class<T> type) throws ObjectMappingException {
         Preconditions.checkNotNull(type, "type");
         try {
             return (ObjectMapper<T>) mapperCache.get(type);
@@ -49,9 +59,5 @@ public class DefaultObjectMapperFactory implements ObjectMapperFactory {
                 throw new ObjectMappingException(e);
             }
         }
-    }
-
-    public static ObjectMapperFactory getInstance() {
-        return INSTANCE;
     }
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/GuiceObjectMapper.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/GuiceObjectMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/GuiceObjectMapper.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/GuiceObjectMapper.java
@@ -19,21 +19,26 @@ package ninja.leaping.configurate.objectmapping;
 import com.google.inject.ConfigurationException;
 import com.google.inject.Injector;
 import com.google.inject.Key;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
- * This subclass creates new object instances using a provided Injector to allow configuration objects to take
- * additional arguments with Guice. Instances of this object should be reached using a {@link GuiceObjectMapperFactory}.
+ * This subclass creates new object instances using a provided {@link Injector}.
+ *
+ * <p>This allows configuration objects to take additional arguments with Guice.</p>
+ *
+ * <p>Instances of this object should be reached using a {@link GuiceObjectMapperFactory}.</p>
  */
 class GuiceObjectMapper<T> extends ObjectMapper<T> {
     private final Injector injector;
     private final Key<T> typeKey;
+
     /**
      * Create a new object mapper of a given type
      *
      * @param clazz The type this object mapper will work with
      * @throws ObjectMappingException if the provided class is in someway invalid
      */
-    protected GuiceObjectMapper(Injector injector, Class<T> clazz) throws ObjectMappingException {
+    protected GuiceObjectMapper(@NonNull Injector injector, @NonNull Class<T> clazz) throws ObjectMappingException {
         super(clazz);
         this.injector = injector;
         this.typeKey = Key.get(clazz);

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/GuiceObjectMapperFactory.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/GuiceObjectMapperFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/GuiceObjectMapperFactory.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/GuiceObjectMapperFactory.java
@@ -21,33 +21,39 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.inject.Injector;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.concurrent.ExecutionException;
 
 /**
- * A factory for {@link ObjectMapper}s that will inherit the injector from wherever it is provided. This class is
- * intended to be constructed through Guice dependency injection.
+ * A factory for {@link ObjectMapper}s that will inherit the injector from wherever it is provided.
+ *
+ * <p>This class is intended to be constructed through Guice dependency injection.</p>
  */
 @Singleton
 public final class GuiceObjectMapperFactory implements ObjectMapperFactory {
-    private final LoadingCache<Class<?>, ObjectMapper<?>> cache = CacheBuilder.newBuilder().weakKeys().maximumSize
-            (512).build(new CacheLoader<Class<?>, ObjectMapper<?>>() {
-        @Override
-        public ObjectMapper<?> load(Class<?> key) throws Exception {
-            return new GuiceObjectMapper<>(injector, key);
-        }
-    });
+    private final LoadingCache<Class<?>, ObjectMapper<?>> cache = CacheBuilder.newBuilder()
+            .weakKeys().maximumSize(512)
+            .build(new CacheLoader<Class<?>, ObjectMapper<?>>() {
+                @Override
+                public ObjectMapper<?> load(Class<?> key) throws Exception {
+                    return new GuiceObjectMapper<>(injector, key);
+                }
+            });
+
     private final Injector injector;
+
     @Inject
     protected GuiceObjectMapperFactory(Injector baseInjector) {
         this.injector = baseInjector;
     }
 
+    @NonNull
     @Override
     @SuppressWarnings("unchecked")
-    public <T> ObjectMapper<T> getMapper(Class<T> type) throws ObjectMappingException {
+    public <T> ObjectMapper<T> getMapper(@NonNull Class<T> type) throws ObjectMappingException {
         Preconditions.checkNotNull(type, "type");
         try {
             return (ObjectMapper<T>) cache.get(type);

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/InvalidTypeException.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/InvalidTypeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/InvalidTypeException.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/InvalidTypeException.java
@@ -18,8 +18,14 @@ package ninja.leaping.configurate.objectmapping;
 
 import com.google.common.reflect.TypeToken;
 
+/**
+ * Extension of {@link ObjectMappingException} for instances where the present {@link TypeToken type}
+ * is invalid.
+ */
 public class InvalidTypeException extends ObjectMappingException {
+
     public InvalidTypeException(TypeToken<?> received) {
         super("Invalid type presented to serializer: " + received);
     }
+
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/ObjectMapper.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/ObjectMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/ObjectMapper.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/ObjectMapper.java
@@ -21,6 +21,7 @@ import com.google.common.reflect.TypeToken;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -43,7 +44,8 @@ public class ObjectMapper<T> {
 
 
     /**
-     * Create a new object mapper that can work with objects of the given class
+     * Create a new object mapper that can work with objects of the given class using the
+     * {@link DefaultObjectMapperFactory}.
      *
      * @param clazz The type of object
      * @param <T> The type
@@ -51,12 +53,20 @@ public class ObjectMapper<T> {
      * @throws ObjectMappingException If invalid annotated fields are presented
      */
     @SuppressWarnings("unchecked")
-    public static <T> ObjectMapper<T> forClass(Class<T> clazz) throws ObjectMappingException {
+    public static <T> ObjectMapper<T> forClass(@NonNull Class<T> clazz) throws ObjectMappingException {
         return DefaultObjectMapperFactory.getInstance().getMapper(clazz);
     }
 
+    /**
+     * Creates a new object mapper bound to the given object.
+     *
+     * @param obj The object
+     * @param <T> The object type
+     * @return An appropriate object mapper instance.
+     * @throws ObjectMappingException
+     */
     @SuppressWarnings("unchecked")
-    public static <T> ObjectMapper<T>.BoundInstance forObject(T obj) throws ObjectMappingException {
+    public static <T> ObjectMapper<T>.BoundInstance forObject(@NonNull T obj) throws ObjectMappingException {
         Preconditions.checkNotNull(obj);
         return forClass((Class<T>) obj.getClass()).bind(obj);
     }
@@ -69,8 +79,7 @@ public class ObjectMapper<T> {
         private final TypeToken<?> fieldType;
         private final String comment;
 
-        public FieldData(Field field, String comment) throws
-                ObjectMappingException {
+        public FieldData(Field field, String comment) throws ObjectMappingException {
             this.field = field;
             this.comment = comment;
             this.fieldType = TypeToken.of(field.getGenericType());
@@ -95,7 +104,6 @@ public class ObjectMapper<T> {
             } catch (IllegalAccessException e) {
                 throw new ObjectMappingException("Unable to deserialize field " + field.getName(), e);
             }
-
         }
 
         @SuppressWarnings("rawtypes")
@@ -107,8 +115,7 @@ public class ObjectMapper<T> {
                 } else {
                     TypeSerializer serial = node.getOptions().getSerializers().get(this.fieldType);
                     if (serial == null) {
-                        throw new ObjectMappingException("No TypeSerializer found for field " + field.getName() + " of type "
-                                + this.fieldType);
+                        throw new ObjectMappingException("No TypeSerializer found for field " + field.getName() + " of type " + this.fieldType);
                     }
                     serial.serialize(this.fieldType, fieldVal, node);
                 }
@@ -122,7 +129,6 @@ public class ObjectMapper<T> {
             } catch (IllegalAccessException e) {
                 throw new ObjectMappingException("Unable to serialize field " + field.getName(), e);
             }
-
         }
     }
 
@@ -138,6 +144,7 @@ public class ObjectMapper<T> {
 
         /**
          * Populate the annotated fields in a pre-created object
+         *
          * @param source The source to get data from
          * @return The object provided, for easier chaining
          * @throws ObjectMappingException If an error occurs while populating data
@@ -225,11 +232,7 @@ public class ObjectMapper<T> {
         }
         try {
             return constructor.newInstance();
-        } catch (InstantiationException e) { // JDK6 compat
-            throw new ObjectMappingException("Unable to create instance of target class " + clazz, e);
-        } catch (IllegalAccessException e) {
-            throw new ObjectMappingException("Unable to create instance of target class " + clazz, e);
-        } catch (InvocationTargetException e) {
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
             throw new ObjectMappingException("Unable to create instance of target class " + clazz, e);
         }
     }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/ObjectMapperFactory.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/ObjectMapperFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/ObjectMapperFactory.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/ObjectMapperFactory.java
@@ -16,9 +16,22 @@
  */
 package ninja.leaping.configurate.objectmapping;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+
 /**
  * A factory to produce {@link ObjectMapper} instances
  */
 public interface ObjectMapperFactory {
-    <T> ObjectMapper<T> getMapper(Class<T> type) throws ObjectMappingException;
+
+    /**
+     * Creates an {@link ObjectMapper} for the given type.
+     *
+     * @param type The type
+     * @param <T> The type
+     * @return An object mapper
+     * @throws ObjectMappingException If an exception occured whilst mapping
+     */
+    @NonNull
+    <T> ObjectMapper<T> getMapper(@NonNull Class<T> type) throws ObjectMappingException;
+
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/ObjectMappingException.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/ObjectMappingException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/Setting.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/Setting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/Setting.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/Setting.java
@@ -23,18 +23,19 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Fields with this annotation are
+ * Marks a field to be mapped by an {@link ObjectMapper}.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 @Documented
 public @interface Setting {
+
     /**
      * The path this setting is located at
      *
      * @return The path
      */
-    public String value() default "";
+    String value() default "";
 
     /**
      * The default comment associated with this configuration node
@@ -42,5 +43,6 @@ public @interface Setting {
      *
      * @return The comment
      */
-    public String comment() default "";
+    String comment() default "";
+
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/ConfigSerializable.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/ConfigSerializable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/ConfigSerializable.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/ConfigSerializable.java
@@ -23,10 +23,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation is used to indicate that the given type is capable of being serialized and deserialized by the configuration object mapper.
+ * This annotation is used to indicate that the given type is capable of being serialized and
+ * deserialized by the configuration object mapper.
  *
- * Types with this annotation must have a zero-argument constructor to be instantiated by the object mapper
- * (though already instantiated objects can be passed to the object mapper to be populated with settings)
+ * <p>Types with this annotation must have a zero-argument constructor to be instantiated by the
+ * object mapper (though already instantiated objects can be passed to the object mapper to be
+ * populated with settings)</p>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializer.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializer.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializer.java
@@ -19,16 +19,35 @@ package ninja.leaping.configurate.objectmapping.serialize;
 import com.google.common.reflect.TypeToken;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
+/**
+ * Represents an object which can serialize and deserialize objects of a given type.
+ *
+ * @param <T> The type
+ */
 public interface TypeSerializer<T> {
+
     /**
-     * Deserialize an object required to be of a given type from the given configuration node
+     * Deserialize an object (of the correct type) from the given configuration node.
+     *
      * @param type The type of return value required
      * @param value The node containing serialized data
      * @return An object
-     * @throws ObjectMappingException If the presented data is somehow invalid
+     * @throws ObjectMappingException If the presented data is invalid
      */
-    T deserialize(TypeToken<?> type, ConfigurationNode value) throws ObjectMappingException;
+    @Nullable
+    T deserialize(@NonNull TypeToken<?> type, @NonNull ConfigurationNode value) throws ObjectMappingException;
 
-    void serialize(TypeToken<?> type, T obj, ConfigurationNode value) throws ObjectMappingException;
+    /**
+     * Serialize an object to the given configuration node.
+     *
+     * @param type The type of the input object
+     * @param obj The object to be serialized
+     * @param value The node to write to
+     * @throws ObjectMappingException If the object cannot be serialized
+     */
+    void serialize(@NonNull TypeToken<?> type, @Nullable T obj, @NonNull ConfigurationNode value) throws ObjectMappingException;
+
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializerCollection.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializerCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializers.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/transformation/ChainedConfigurationTransformation.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/transformation/ChainedConfigurationTransformation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/transformation/ConfigurationTransformation.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/transformation/ConfigurationTransformation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/transformation/ConfigurationTransformation.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/transformation/ConfigurationTransformation.java
@@ -16,69 +16,64 @@
  */
 package ninja.leaping.configurate.transformation;
 
-import com.google.common.collect.Iterators;
 import ninja.leaping.configurate.ConfigurationNode;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+/**
+ * Represents a set of transformations on a configuration.
+ */
 public abstract class ConfigurationTransformation {
+
     /**
      * A special object that represents a wildcard in a path provided to a configuration transformer
      */
     public static final Object WILDCARD_OBJECT = new Object();
 
     /**
+     * Create a new builder to create a basic configuration transformation.
+     *
+     * @return a new transformation builder.
+     */
+    @NonNull
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * This creates a builder for versioned transformations.
+     *
+     * @return A new builder for versioned transformations
+     */
+    @NonNull
+    public static VersionedBuilder versionedBuilder() {
+        return new VersionedBuilder();
+    }
+
+    /**
+     * Creates a chain of {@link ConfigurationTransformation}s.
+     *
+     * @param transformations The transformations
+     * @return The resultant transformation chain
+     */
+    @NonNull
+    public static ConfigurationTransformation chain(ConfigurationTransformation... transformations) {
+        return new ChainedConfigurationTransformation(transformations);
+    }
+
+    /**
      * Apply this transformation to a given node
      *
      * @param node The target node
      */
-    public abstract void apply(ConfigurationNode node);
+    public abstract void apply(@NonNull ConfigurationNode node);
 
     /**
-     * Wrapper around path Object[]s to prevent transformers modifying what is supposed to be a immutable path.
-     * There is one node path per thread -- data within this object is only guaranteed to be the same during a run of
-     * a transform function
+     * Builds a basic {@link ConfigurationTransformation}.
      */
-    public static class NodePath implements Iterable<Object> {
-        Object[] arr;
-        NodePath() {
-        }
-
-        /**
-         * Gets a specific element from the path array
-         * @param i the index to get
-         * @return object at index
-         */
-        public Object get(int i) {
-            return arr[i];
-        }
-
-        /**
-         *
-         * @return Length of the path array
-         */
-        public int size() {
-            return arr.length;
-        }
-
-        /**
-         * Returns a copy of the original path array
-         *
-         * @return the copied array
-         */
-        public Object[] getArray() {
-            return Arrays.copyOf(arr, arr.length);
-        }
-
-        @Override
-        public Iterator<Object> iterator() {
-            return Iterators.forArray(arr);
-        }
-    }
-
     public static final class Builder {
         private MoveStrategy strategy = MoveStrategy.OVERWRITE;
         private final SortedMap<Object[], TransformAction> actions;
@@ -87,65 +82,94 @@ public abstract class ConfigurationTransformation {
             this.actions = new TreeMap<>(new NodePathComparator());
         }
 
+        /**
+         * Adds an action to the transformation.
+         *
+         * @param path The path to apply the action at
+         * @param action The action
+         * @return This builder (for chaining)
+         */
+        @NonNull
         public Builder addAction(Object[] path, TransformAction action) {
             actions.put(path, action);
             return this;
         }
 
+        /**
+         * Gets the move strategy to be used by the resultant transformation.
+         *
+         * @return The move strategy
+         */
+        @NonNull
         public MoveStrategy getMoveStrategy() {
             return strategy;
         }
 
-        public Builder setMoveStrategy(MoveStrategy strategy) {
+        /**
+         * Sets the mode strategy to be used by the resultant transformation.
+         *
+         * @param strategy The strategy
+         * @return This builder (for chaining)
+         */
+        @NonNull
+        public Builder setMoveStrategy(@NonNull MoveStrategy strategy) {
             this.strategy = strategy;
             return this;
         }
 
+        /**
+         * Builds the transformation.
+         *
+         * @return The transformation
+         */
+        @NonNull
         public ConfigurationTransformation build() {
             return new SingleConfigurationTransformation(actions, strategy);
         }
     }
 
     /**
-     * Create a new builder to create a basic configuration transformation.
-     *
-     * @return a new transformation builder.
+     * Builds a versioned {@link ConfigurationTransformation}.
      */
-    public static Builder builder() {
-        return new Builder();
-    }
-
     public static final class VersionedBuilder {
         private Object[] versionKey = new Object[] {"version"};
         private final SortedMap<Integer, ConfigurationTransformation> versions = new TreeMap<>();
 
         protected VersionedBuilder() {}
 
-        public VersionedBuilder setVersionKey(Object... versionKey) {
+        /**
+         * Sets the path of the version key within the configuration.
+         *
+         * @param versionKey The path to the version key
+         * @return This builder (for chaining)
+         */
+        @NonNull
+        public VersionedBuilder setVersionKey(@NonNull Object... versionKey) {
             this.versionKey = Arrays.copyOf(versionKey, versionKey.length, Object[].class);
             return this;
         }
 
-        public VersionedBuilder addVersion(int version, ConfigurationTransformation transformation) {
+        /**
+         * Adds a transformation to this builder for the given version.
+         *
+         * @param version The version
+         * @param transformation The transformation
+         * @return This builder (for chaining)
+         */
+        @NonNull
+        public VersionedBuilder addVersion(int version, @NonNull ConfigurationTransformation transformation) {
             versions.put(version, transformation);
             return this;
         }
 
+        /**
+         * Builds the transformation.
+         *
+         * @return The transformation
+         */
+        @NonNull
         public ConfigurationTransformation build() {
             return new VersionedTransformation(versionKey, versions);
         }
-    }
-
-    /**
-     * This creates a builder for versioned transformations -- transformations that contain
-     *
-     * @return A new builder for versioned transformations
-     */
-    public static VersionedBuilder versionedBuilder() {
-        return new VersionedBuilder();
-    }
-
-    public static ConfigurationTransformation chain(ConfigurationTransformation... transformations) {
-        return new ChainedConfigurationTransformation(transformations);
     }
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/transformation/MoveStrategy.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/transformation/MoveStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/transformation/MoveStrategy.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/transformation/MoveStrategy.java
@@ -22,12 +22,20 @@ import ninja.leaping.configurate.ConfigurationNode;
  * Strategy to use when moving a node from one path to another
  */
 public enum MoveStrategy {
+
+    /**
+     * Moves nodes using {@link ConfigurationNode#mergeValuesFrom(ConfigurationNode)}.
+     */
     MERGE {
         @Override
         public void move(ConfigurationNode source, ConfigurationNode target) {
             target.mergeValuesFrom(source);
         }
     },
+
+    /**
+     * Moves nodes using {@link ConfigurationNode#setValue(Object)}.
+     */
     OVERWRITE {
         @Override
         public void move(ConfigurationNode source, ConfigurationNode target) {
@@ -35,5 +43,11 @@ public enum MoveStrategy {
         }
     };
 
+    /**
+     * Moves <code>source</code> to <code>target</code>.
+     *
+     * @param source The source node
+     * @param target The target node
+     */
     public abstract void move(ConfigurationNode source, ConfigurationNode target);
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/transformation/NodePath.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/transformation/NodePath.java
@@ -16,25 +16,43 @@
  */
 package ninja.leaping.configurate.transformation;
 
-import ninja.leaping.configurate.ConfigurationNode;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-import java.util.Arrays;
+import java.util.Iterator;
 
 /**
- * Implements a chain of {@link ConfigurationTransformation}s.
+ * Represents the path to a given node.
  */
-class ChainedConfigurationTransformation extends ConfigurationTransformation {
-    private final ConfigurationTransformation[] transformations;
+public interface NodePath extends Iterable<Object> {
 
-    ChainedConfigurationTransformation(ConfigurationTransformation[] transformations) {
-        this.transformations = Arrays.copyOf(transformations, transformations.length);
-    }
+    /**
+     * Gets a specific element from the path array
+     *
+     * @param i The index to get
+     * @return Object at the index
+     */
+    Object get(int i);
 
+    /**
+     * Gets the length of the path
+     *
+     * @return Length of the path array
+     */
+    int size();
+
+    /**
+     * Returns a copy of the original path array
+     *
+     * @return the copied array
+     */
+    Object[] getArray();
+
+    /**
+     * Returns an iterator over the path.
+     *
+     * @return An iterator of the path
+     */
+    @NonNull
     @Override
-    public void apply(@NonNull ConfigurationNode node) {
-        for (ConfigurationTransformation transformation : transformations) {
-            transformation.apply(node);
-        }
-    }
+    Iterator<Object> iterator();
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/transformation/NodePathComparator.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/transformation/NodePathComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/transformation/NodePathComparator.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/transformation/NodePathComparator.java
@@ -21,6 +21,7 @@ import java.util.Comparator;
 import static ninja.leaping.configurate.transformation.ConfigurationTransformation.WILDCARD_OBJECT;
 
 class NodePathComparator implements Comparator<Object[]> {
+
     @Override
     public int compare(Object[] a, Object[] b) {
         for (int i = 0; i < Math.min(a.length, b.length); ++i) {
@@ -39,16 +40,10 @@ class NodePathComparator implements Comparator<Object[]> {
                         return comp;
                 }
             } else {
-                return a[i].equals(b[i]) ? 0 : Integer.valueOf(a[i].hashCode()).compareTo(b[i].hashCode());
+                return a[i].equals(b[i]) ? 0 : Integer.compare(a[i].hashCode(), b[i].hashCode());
             }
         }
-        if (a.length > b.length) {
-            return -1;
-        } else if (b.length > a.length) {
-            return 1;
-        } else {
-            return 0;
-        }
 
+        return Integer.compare(b.length, a.length);
     }
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/transformation/SingleConfigurationTransformation.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/transformation/SingleConfigurationTransformation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/transformation/SingleConfigurationTransformation.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/transformation/SingleConfigurationTransformation.java
@@ -16,51 +16,53 @@
  */
 package ninja.leaping.configurate.transformation;
 
+import com.google.common.collect.Iterators;
 import ninja.leaping.configurate.ConfigurationNode;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
 /**
- * Utility to perform bulk transformations of configuration data
- * Transformations are executed from deepest in the configuration hierarchy outwards
+ * Base implementation of {@link ConfigurationTransformation}.
+ *
+ * <p>Transformations are executed from deepest in the configuration hierarchy outwards.</p>
  */
 class SingleConfigurationTransformation extends ConfigurationTransformation {
     private final MoveStrategy strategy;
     private final Map<Object[], TransformAction> actions;
-    private final ThreadLocal<NodePath> sharedPath = new ThreadLocal<NodePath>() {
-        @Override
-        protected NodePath initialValue() {
-            return new NodePath();
-        }
-    };
 
-    protected SingleConfigurationTransformation(Map<Object[], TransformAction> actions, MoveStrategy strategy) {
+    /**
+     * Thread local {@link NodePath} instance - used so we don't have to create lots of NodePath
+     * instances.
+     *
+     * As such, data within paths is only guaranteed to be the same during a run of
+     * a transform function.
+     */
+    private final ThreadLocal<NodePathImpl> sharedPath = ThreadLocal.withInitial(NodePathImpl::new);
+
+    SingleConfigurationTransformation(Map<Object[], TransformAction> actions, MoveStrategy strategy) {
         this.actions = actions;
         this.strategy = strategy;
     }
 
-    public static Builder builder() {
-        return new Builder();
-    }
-
     @Override
-    public void apply(ConfigurationNode node) {
+    public void apply(@NonNull ConfigurationNode node) {
         for (Map.Entry<Object[], TransformAction> ent : actions.entrySet()) {
             applySingleAction(node, ent.getKey(), 0, node, ent.getValue());
         }
     }
 
-    protected void applySingleAction(ConfigurationNode start, Object[] path, int startIdx, ConfigurationNode node,
-                                     TransformAction action) {
+    private void applySingleAction(ConfigurationNode start, Object[] path, int startIdx, ConfigurationNode node, TransformAction action) {
         for (int i = startIdx; i < path.length; ++i) {
             if (path[i] == WILDCARD_OBJECT) {
                 if (node.hasListChildren()) {
                     List<? extends ConfigurationNode> children = node.getChildrenList();
-                    for (int cI = 0; cI < children.size(); ++cI) {
-                        path[i] = cI;
-                        applySingleAction(start, path, i + 1, children.get(cI), action);
+                    for (int di = 0; di < children.size(); ++di) {
+                        path[i] = di;
+                        applySingleAction(start, path, i + 1, children.get(di), action);
                     }
                     path[i] = WILDCARD_OBJECT;
                 } else if (node.hasMapChildren()) {
@@ -81,12 +83,46 @@ class SingleConfigurationTransformation extends ConfigurationTransformation {
                 }
             }
         }
-        NodePath immutablePath = sharedPath.get();
-        immutablePath.arr = path;
-        Object[] transformedPath = action.visitPath(immutablePath, node);
+
+        // apply action
+        NodePathImpl nodePath = sharedPath.get();
+        nodePath.arr = path;
+
+        Object[] transformedPath = action.visitPath(nodePath, node);
         if (transformedPath != null && !Arrays.equals(path, transformedPath)) {
             this.strategy.move(node, start.getNode(transformedPath));
             node.setValue(null);
+        }
+    }
+
+    /**
+     * Implementation of {@link NodePath} used by this class.
+     */
+    static class NodePathImpl implements NodePath {
+        Object[] arr;
+
+        NodePathImpl() {
+        }
+
+        @Override
+        public Object get(int i) {
+            return arr[i];
+        }
+
+        @Override
+        public int size() {
+            return arr.length;
+        }
+
+        @Override
+        public Object[] getArray() {
+            return Arrays.copyOf(arr, arr.length);
+        }
+
+        @NonNull
+        @Override
+        public Iterator<Object> iterator() {
+            return Iterators.forArray(arr);
         }
     }
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/transformation/TransformAction.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/transformation/TransformAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/transformation/TransformAction.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/transformation/TransformAction.java
@@ -17,17 +17,26 @@
 package ninja.leaping.configurate.transformation;
 
 import ninja.leaping.configurate.ConfigurationNode;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Represents an action to be performed that transforms a node in the configuration tree
  */
 @FunctionalInterface
 public interface TransformAction {
+
     /**
-     * Called at a certain path, with the node at that path
+     * Called at a certain path, with the node at that path.
+     *
+     * <p>The state of the <code>inputPath</code> is only guaranteed to be accurate during a run of
+     * the transform function. Use {@link NodePath#getArray()} if it's state needs to be stored.</p>
+     *
      * @param inputPath The path of the given node
      * @param valueAtPath The node at the input path. May be modified
      * @return A modified path, or null if the path is to stay the same
      */
-    Object[] visitPath(SingleConfigurationTransformation.NodePath inputPath, ConfigurationNode valueAtPath);
+    @Nullable
+    Object[] visitPath(@NonNull NodePath inputPath, @NonNull ConfigurationNode valueAtPath);
+
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/transformation/VersionedTransformation.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/transformation/VersionedTransformation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/transformation/VersionedTransformation.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/transformation/VersionedTransformation.java
@@ -17,9 +17,14 @@
 package ninja.leaping.configurate.transformation;
 
 import ninja.leaping.configurate.ConfigurationNode;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.SortedMap;
 
+/**
+ * Implements a number of child {@link ConfigurationTransformation}s which are only applied if required,
+ * according to the configurations current version.
+ */
 class VersionedTransformation extends ConfigurationTransformation {
     private final Object[] versionPath;
     private final SortedMap<Integer, ConfigurationTransformation> versionTransformations;
@@ -30,7 +35,7 @@ class VersionedTransformation extends ConfigurationTransformation {
     }
 
     @Override
-    public void apply(ConfigurationNode node) {
+    public void apply(@NonNull ConfigurationNode node) {
         ConfigurationNode versionNode = node.getNode(versionPath);
         int currentVersion = versionNode.getInt(-1);
         for (SortedMap.Entry<Integer, ConfigurationTransformation> entry : versionTransformations.entrySet()) {

--- a/configurate-core/src/main/java/ninja/leaping/configurate/util/EnumLookup.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/util/EnumLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/util/EnumLookup.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/util/EnumLookup.java
@@ -20,6 +20,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -29,25 +30,30 @@ import java.util.concurrent.ExecutionException;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * Utility class to cache more flexible enum lookup. While normally case and punctuation have to match exactly, this
- * method performs lookup that:
- *<ul>
+ * Utility class to cache more flexible enum lookup.
+ *
+ * <p>While normally case and punctuation have to match exactly, this method performs lookup that:</p>
+ * <p>
+ * <ul>
  *     <li>is case-insensitive</li>
  *     <li>ignores underscores</li>
- *     <li>Caches mappings</li>
- *</ul>
+ *     <li>caches mappings</li>
+ * </ul>
  *
- * If the enum has two fields that are equal except for case and underscores, an exact match will return the
- * appropriate value, and any fuzzy matches will map to the first value in the enum that is applicable.
+ * <p>If the enum has two fields that are equal except for case and underscores, an exact match
+ * will return the appropriate value, and any fuzzy matches will map to the first value in the enum
+ * that is applicable.</p>
  */
-public class EnumLookup {
-    private static final LoadingCache<Class<? extends Enum<?>>, Map<String, Enum<?>>> enumFieldCache = CacheBuilder
+public final class EnumLookup {
+    private EnumLookup() {}
+
+    private static final LoadingCache<Class<? extends Enum<?>>, Map<String, Enum<?>>> ENUM_FIELD_CACHE = CacheBuilder
             .newBuilder()
             .weakKeys()
             .maximumSize(512)
             .build(new CacheLoader<Class<? extends Enum<?>>, Map<String, Enum<?>>>() {
                 @Override
-                public Map<String, Enum<?>> load(Class<? extends Enum<?>> key) throws Exception {
+                public Map<String, Enum<?>> load(Class<? extends Enum<?>> key) {
                     Map<String, Enum<?>> ret = new HashMap<>();
                     for (Enum<?> field : key.getEnumConstants()) {
                         ret.put(field.name(), field);
@@ -57,21 +63,19 @@ public class EnumLookup {
                 }
             });
 
-    private EnumLookup() {
-        // wheeeeeeee
-    }
-
-    private static String processKey(String key) {
-        checkNotNull(key, "key");
-        return "🌸" + key.toLowerCase().replace("_", ""); // stick a flower at the front so processed keys are
-        // different from literal keys
+    @NonNull
+    private static String processKey(@NonNull String key) {
+        // stick a flower at the front so processed keys are different from literal keys
+        return "🌸" + key.toLowerCase().replace("_", "");
     }
 
     @SuppressWarnings("unchecked")
-    public static <T extends Enum<T>> Optional<T> lookupEnum(Class<T> clazz, String key) {
+    @NonNull
+    public static <T extends Enum<T>> Optional<T> lookupEnum(@NonNull Class<T> clazz, @NonNull String key) {
         checkNotNull(clazz, "clazz");
+        checkNotNull(key, "key");
         try {
-            Map<String, Enum<?>> vals = enumFieldCache.get(clazz);
+            Map<String, Enum<?>> vals = ENUM_FIELD_CACHE.get(clazz);
             Enum<?> possibleRet = vals.get(key);
             if (possibleRet != null) {
                 return Optional.of((T) possibleRet);
@@ -80,6 +84,5 @@ public class EnumLookup {
         } catch (ExecutionException e) {
             return Optional.empty();
         }
-
     }
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/util/MapFactories.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/util/MapFactories.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/util/MapFactories.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/util/MapFactories.java
@@ -17,7 +17,9 @@
 package ninja.leaping.configurate.util;
 
 import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.Collection;
 import java.util.Comparator;
@@ -29,11 +31,96 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 
 /**
- * Factories to create map implementations commonly used for maps
+ * Default implementations of {@link MapFactory}.
  */
-public class MapFactories {
-    private MapFactories() {
-        // Nope
+public final class MapFactories {
+    private MapFactories() {}
+
+    /**
+     * Returns a {@link MapFactory} which creates maps without an order.
+     *
+     * @return A map factory which produces unordered maps
+     */
+    public static MapFactory unordered() {
+        return DefaultFactory.UNORDERED;
+    }
+
+    /**
+     * Returns a {@link MapFactory} which creates maps which are sorted using the given comparator.
+     *
+     * @param comparator The comparator used to sort the map keys
+     * @return A map factory which produces sorted maps
+     */
+    public static MapFactory sorted(Comparator<Object> comparator) {
+        Preconditions.checkNotNull(comparator, "comparator");
+        return new SortedMapFactory(comparator);
+    }
+
+    /**
+     * Returns a {@link MapFactory} which creates maps which are naturally sorted.
+     *
+     * @return A map factory which produces naturally sorted maps
+     * @see Comparator#naturalOrder()
+     */
+    public static MapFactory sortedNatural() {
+        return DefaultFactory.SORTED_NATURAL;
+    }
+
+    /**
+     * Returns a {@link MapFactory} which creates maps which are sorted by insertion order.
+     *
+     * @return A map factory which produces maps sorted by insertion order
+     */
+    public static MapFactory insertionOrdered() {
+        return DefaultFactory.INSERTION_ORDERED;
+    }
+
+    private enum DefaultFactory implements MapFactory {
+        UNORDERED {
+            @NonNull
+            @Override
+            public <K, V> ConcurrentMap<K, V> create() {
+                return new ConcurrentHashMap<>();
+            }
+        },
+        SORTED_NATURAL {
+            @NonNull
+            @Override
+            public <K, V> ConcurrentMap<K, V> create() {
+                return new ConcurrentSkipListMap<>();
+            }
+        },
+        INSERTION_ORDERED {
+            @NonNull
+            @Override
+            public <K, V> ConcurrentMap<K, V> create() {
+                return new SynchronizedWrapper<>(new LinkedHashMap<>());
+            }
+        }
+    }
+
+    private static final class SortedMapFactory implements MapFactory {
+        private final Comparator<Object> comparator;
+
+        private SortedMapFactory(Comparator<Object> comparator) {
+            this.comparator = comparator;
+        }
+
+        @NonNull
+        @Override
+        public <K, V> ConcurrentMap<K, V> create() {
+            return new ConcurrentSkipListMap<>(comparator);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof SortedMapFactory && comparator.equals(((SortedMapFactory) obj).comparator);
+        }
+
+        @Override
+        public int hashCode() {
+            return comparator.hashCode();
+        }
     }
 
     private static class SynchronizedWrapper<K, V> implements ConcurrentMap<K, V> {
@@ -170,49 +257,5 @@ public class MapFactories {
             }
         }
     }
-
-    public static MapFactory  unordered() {
-        return new EqualsSupplier() {
-            @Override
-            public <K, V> ConcurrentMap<K, V> create() {
-                return new ConcurrentHashMap<>();
-            }
-        };
-    }
-
-    public static MapFactory sorted(final Comparator<Object> comparator) {
-        return new EqualsSupplier() {
-            @Override
-            public <K, V> ConcurrentMap<K, V> create() {
-                return new ConcurrentSkipListMap<>(comparator);
-            }
-        };
-    }
-
-    public static MapFactory sortedNatural() {
-        return new EqualsSupplier() {
-            @Override
-            public <K, V> ConcurrentMap<K, V> create() {
-                return new ConcurrentSkipListMap<>();
-            }
-        };
-    }
-
-    public static MapFactory insertionOrdered() {
-        return new EqualsSupplier() {
-            @Override
-            public <K, V> ConcurrentMap<K, V> create() {
-                return new SynchronizedWrapper<>(new LinkedHashMap<>());
-            }
-        };
-    }
-
-    private static abstract class EqualsSupplier implements MapFactory {
-        @Override
-        public boolean equals(Object o) {
-            return o.getClass().equals(getClass());
-        }
-    }
-
 
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/util/MapFactory.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/util/MapFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/util/MapFactory.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/util/MapFactory.java
@@ -16,10 +16,16 @@
  */
 package ninja.leaping.configurate.util;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+
 import java.util.concurrent.ConcurrentMap;
 
+/**
+ * A factory which creates {@link ConcurrentMap} instances.
+ */
 @FunctionalInterface
 public interface MapFactory {
+
     /**
      * Create a new map instance for the given types
      *
@@ -27,5 +33,7 @@ public interface MapFactory {
      * @param <V> The value
      * @return A new map instance
      */
+    @NonNull
     <K, V> ConcurrentMap<K, V> create();
+
 }

--- a/configurate-core/src/test/java/ninja/leaping/configurate/SimpleConfigurationNodeTest.java
+++ b/configurate-core/src/test/java/ninja/leaping/configurate/SimpleConfigurationNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/test/java/ninja/leaping/configurate/SimpleConfigurationNodeTest.java
+++ b/configurate-core/src/test/java/ninja/leaping/configurate/SimpleConfigurationNodeTest.java
@@ -70,8 +70,8 @@ public class SimpleConfigurationNodeTest {
         nodeOne.setValue("one");
         nodeTwo.setValue("lilac");
         ConfigurationNode attachedParent = config.getNode("uncreated", "step");
-        assertEquals(attachedParent, nodeOne.getParentAttached());
-        assertEquals(attachedParent, nodeTwo.getParentAttached());
+        assertEquals(attachedParent, nodeOne.getParentEnsureAttached());
+        assertEquals(attachedParent, nodeTwo.getParentEnsureAttached());
     }
 
     @Test

--- a/configurate-core/src/test/java/ninja/leaping/configurate/TypesTest.java
+++ b/configurate-core/src/test/java/ninja/leaping/configurate/TypesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/test/java/ninja/leaping/configurate/commented/SimpleCommentedConfigurationNodeTest.java
+++ b/configurate-core/src/test/java/ninja/leaping/configurate/commented/SimpleCommentedConfigurationNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/test/java/ninja/leaping/configurate/loader/AbstractConfigurationLoaderTest.java
+++ b/configurate-core/src/test/java/ninja/leaping/configurate/loader/AbstractConfigurationLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/test/java/ninja/leaping/configurate/loader/CommentHandlersTest.java
+++ b/configurate-core/src/test/java/ninja/leaping/configurate/loader/CommentHandlersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/test/java/ninja/leaping/configurate/loader/CommentHandlersTest.java
+++ b/configurate-core/src/test/java/ninja/leaping/configurate/loader/CommentHandlersTest.java
@@ -17,12 +17,12 @@
 package ninja.leaping.configurate.loader;
 
 import com.google.common.base.Joiner;
-import java.util.Optional;
 import org.junit.Test;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.Optional;
 
 import static org.junit.Assert.*;
 

--- a/configurate-core/src/test/java/ninja/leaping/configurate/loader/TestConfigurationLoader.java
+++ b/configurate-core/src/test/java/ninja/leaping/configurate/loader/TestConfigurationLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/test/java/ninja/leaping/configurate/loader/TestConfigurationLoader.java
+++ b/configurate-core/src/test/java/ninja/leaping/configurate/loader/TestConfigurationLoader.java
@@ -19,6 +19,7 @@ package ninja.leaping.configurate.loader;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.ConfigurationOptions;
 import ninja.leaping.configurate.SimpleConfigurationNode;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -31,6 +32,7 @@ public class TestConfigurationLoader extends AbstractConfigurationLoader<Configu
     private ConfigurationNode result;
     public static final class Builder extends AbstractConfigurationLoader.Builder<Builder> {
 
+        @NonNull
         @Override
         public TestConfigurationLoader build() {
             return new TestConfigurationLoader(this);
@@ -69,8 +71,9 @@ public class TestConfigurationLoader extends AbstractConfigurationLoader<Configu
      * @param options The options to use with this node. Must not be null (take a look at {@link ConfigurationOptions#defaults()})
      * @return The appropriate node type
      */
+    @NonNull
     @Override
-    public ConfigurationNode createEmptyNode(ConfigurationOptions options) {
+    public ConfigurationNode createEmptyNode(@NonNull ConfigurationOptions options) {
         return SimpleConfigurationNode.root(options);
     }
 }

--- a/configurate-core/src/test/java/ninja/leaping/configurate/objectmapping/GuiceObjectMapperTest.java
+++ b/configurate-core/src/test/java/ninja/leaping/configurate/objectmapping/GuiceObjectMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/test/java/ninja/leaping/configurate/objectmapping/ObjectMapperTest.java
+++ b/configurate-core/src/test/java/ninja/leaping/configurate/objectmapping/ObjectMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/test/java/ninja/leaping/configurate/objectmapping/TypeSerializersTest.java
+++ b/configurate-core/src/test/java/ninja/leaping/configurate/objectmapping/TypeSerializersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/test/java/ninja/leaping/configurate/objectmapping/TypeSerializersTest.java
+++ b/configurate-core/src/test/java/ninja/leaping/configurate/objectmapping/TypeSerializersTest.java
@@ -19,16 +19,12 @@ package ninja.leaping.configurate.objectmapping;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.reflect.TypeToken;
-
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.SimpleConfigurationNode;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializerCollection;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializers;
-
-import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -42,9 +38,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class TypeSerializersTest {
     private static final TypeSerializerCollection SERIALIZERS = TypeSerializers.getDefaultSerializers();

--- a/configurate-core/src/test/java/ninja/leaping/configurate/transformation/ConfigurationTransformationTest.java
+++ b/configurate-core/src/test/java/ninja/leaping/configurate/transformation/ConfigurationTransformationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-core/src/test/java/ninja/leaping/configurate/transformation/ConfigurationTransformationTest.java
+++ b/configurate-core/src/test/java/ninja/leaping/configurate/transformation/ConfigurationTransformationTest.java
@@ -19,6 +19,8 @@ package ninja.leaping.configurate.transformation;
 import com.google.common.collect.ImmutableList;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.SimpleConfigurationNode;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -54,8 +56,9 @@ public class ConfigurationTransformationTest {
         );
 
         final TransformAction action = new TransformAction() {
+            @Nullable
             @Override
-            public Object[] visitPath(SingleConfigurationTransformation.NodePath inputPath, ConfigurationNode valueAtPath) {
+            public Object[] visitPath(@NonNull NodePath inputPath, @NonNull ConfigurationNode valueAtPath) {
                 autoSortedKeys.add(inputPath.getArray());
                 return null;
             }
@@ -105,8 +108,9 @@ public class ConfigurationTransformationTest {
         );
 
         final TransformAction action = new TransformAction() {
+            @Nullable
             @Override
-            public Object[] visitPath(SingleConfigurationTransformation.NodePath path, ConfigurationNode valueAtPath) {
+            public Object[] visitPath(@NonNull NodePath path, @NonNull ConfigurationNode valueAtPath) {
                 populatedResults.add(path.getArray());
                 return null;
             }
@@ -128,8 +132,9 @@ public class ConfigurationTransformationTest {
     public void testMoveNode() {
         final ConfigurationTransformation transform = ConfigurationTransformation.builder()
                 .addAction(p("old", "path"), new TransformAction() {
+                    @Nullable
                     @Override
-                    public Object[] visitPath(SingleConfigurationTransformation.NodePath inputPath, ConfigurationNode valueAtPath) {
+                    public Object[] visitPath(@NonNull NodePath inputPath, @NonNull ConfigurationNode valueAtPath) {
                         return p("new", "path");
                     }
                 }).build();
@@ -148,14 +153,16 @@ public class ConfigurationTransformationTest {
         node.getNode("a").setValue("something?");
         final List<String> actualOutput = new ArrayList<>(), expectedOutput = ImmutableList.of("one", "two");
         ConfigurationTransformation.chain(ConfigurationTransformation.builder().addAction(p("a"), new TransformAction() {
+            @Nullable
             @Override
-            public Object[] visitPath(SingleConfigurationTransformation.NodePath inputPath, ConfigurationNode valueAtPath) {
+            public Object[] visitPath(@NonNull NodePath inputPath, @NonNull ConfigurationNode valueAtPath) {
                 actualOutput.add("one");
                 return null;
             }
         }).build(), ConfigurationTransformation.builder().addAction(p("a"), new TransformAction() {
+            @Nullable
             @Override
-            public Object[] visitPath(SingleConfigurationTransformation.NodePath inputPath, ConfigurationNode valueAtPath) {
+            public Object[] visitPath(@NonNull NodePath inputPath, @NonNull ConfigurationNode valueAtPath) {
                 actualOutput.add("two");
                 return null;
             }
@@ -167,8 +174,9 @@ public class ConfigurationTransformationTest {
     public void testMoveToBase() {
         final ConfigurationTransformation transform = ConfigurationTransformation.builder()
                 .addAction(p("sub"), new TransformAction() {
+                    @Nullable
                     @Override
-                    public Object[] visitPath(SingleConfigurationTransformation.NodePath inputPath, ConfigurationNode valueAtPath) {
+                    public Object[] visitPath(@NonNull NodePath inputPath, @NonNull ConfigurationNode valueAtPath) {
                         return new Object[0];
                     }
                 }).build();
@@ -185,8 +193,9 @@ public class ConfigurationTransformationTest {
     public void testMoveStrategy() {
         final ConfigurationTransformation.Builder build = ConfigurationTransformation.builder()
                 .addAction(p("one"), new TransformAction() {
+                    @Nullable
                     @Override
-                    public Object[] visitPath(SingleConfigurationTransformation.NodePath inputPath, ConfigurationNode valueAtPath) {
+                    public Object[] visitPath(@NonNull NodePath inputPath, @NonNull ConfigurationNode valueAtPath) {
                         return p("two");
                     }
                 });
@@ -213,8 +222,9 @@ public class ConfigurationTransformationTest {
         final ConfigurationNode child = node.getNode("childNode").setValue("something");
         ConfigurationTransformation.builder()
                 .addAction(p("childNode"), new TransformAction() {
+                    @Nullable
                     @Override
-                    public Object[] visitPath(SingleConfigurationTransformation.NodePath inputPath, ConfigurationNode valueAtPath) {
+                    public Object[] visitPath(@NonNull NodePath inputPath, @NonNull ConfigurationNode valueAtPath) {
                         assertEquals(child, valueAtPath);
                         return null;
                     }
@@ -230,24 +240,27 @@ public class ConfigurationTransformationTest {
         final ConfigurationTransformation versionTransform = ConfigurationTransformation.versionedBuilder()
                 .addVersion(0, ConfigurationTransformation.builder()
                         .addAction(p("dummy"), new TransformAction() {
+                            @Nullable
                             @Override
-                            public Object[] visitPath(SingleConfigurationTransformation.NodePath inputPath, ConfigurationNode valueAtPath) {
+                            public Object[] visitPath(@NonNull NodePath inputPath, @NonNull ConfigurationNode valueAtPath) {
                                 updatedVersions.add(0);
                                 return null;
                             }
                         }).build())
                 .addVersion(2, ConfigurationTransformation.builder()
                         .addAction(p("dummy"), new TransformAction() {
+                            @Nullable
                             @Override
-                            public Object[] visitPath(SingleConfigurationTransformation.NodePath inputPath, ConfigurationNode valueAtPath) {
+                            public Object[] visitPath(@NonNull NodePath inputPath, @NonNull ConfigurationNode valueAtPath) {
                                 updatedVersions.add(2);
                                 return null;
                             }
                         }).build())
                 .addVersion(1, ConfigurationTransformation.builder()
                         .addAction(p("dummy"), new TransformAction() {
+                            @Nullable
                             @Override
-                            public Object[] visitPath(SingleConfigurationTransformation.NodePath inputPath, ConfigurationNode valueAtPath) {
+                            public Object[] visitPath(@NonNull NodePath inputPath, @NonNull ConfigurationNode valueAtPath) {
                                 updatedVersions.add(1);
                                 return null;
                             }

--- a/configurate-gson/pom.xml
+++ b/configurate-gson/pom.xml
@@ -18,17 +18,16 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>ninja.leaping.configurate</groupId>
         <artifactId>configurate-parent</artifactId>
         <version>3.4-SNAPSHOT</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
-    <packaging>jar</packaging>
-
     <artifactId>configurate-gson</artifactId>
     <name>Configurate Gson</name>
+    <packaging>jar</packaging>
 
     <dependencies>
         <dependency>

--- a/configurate-gson/src/main/java/ninja/leaping/configurate/gson/GsonConfigurationLoader.java
+++ b/configurate-gson/src/main/java/ninja/leaping/configurate/gson/GsonConfigurationLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-gson/src/main/java/ninja/leaping/configurate/gson/GsonConfigurationLoader.java
+++ b/configurate-gson/src/main/java/ninja/leaping/configurate/gson/GsonConfigurationLoader.java
@@ -28,6 +28,7 @@ import ninja.leaping.configurate.SimpleConfigurationNode;
 import ninja.leaping.configurate.loader.AbstractConfigurationLoader;
 import ninja.leaping.configurate.loader.CommentHandler;
 import ninja.leaping.configurate.loader.CommentHandlers;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -35,54 +36,86 @@ import java.io.Writer;
 import java.util.List;
 import java.util.Map;
 
-
 /**
- * A loader for JSON-formatted configurations, using the jackson library for parsing and generation
+ * A loader for JSON-formatted configurations, using the GSON library for parsing and generation.
  */
 public class GsonConfigurationLoader extends AbstractConfigurationLoader<ConfigurationNode> {
-    private final boolean lenient;
-    private final String indent;
 
+    /**
+     * Creates a new {@link GsonConfigurationLoader} builder.
+     *
+     * @return A new builder
+     */
+    @NonNull
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builds a {@link GsonConfigurationLoader}.
+     */
     public static class Builder extends AbstractConfigurationLoader.Builder<Builder> {
         private boolean lenient = true;
         private int indent = 2;
 
+        protected Builder() {
+        }
+
+        /**
+         * Sets the level of indentation the resultant loader should use.
+         *
+         * @param indent The indent level
+         * @return This builder (for chaining)
+         */
+        @NonNull
         public Builder setIndent(int indent) {
             this.indent = indent;
             return this;
         }
 
+        /**
+         * Gets the level of indentation to be used by the resultant loader.
+         *
+         * @return The indent level
+         */
         public int getIndent() {
             return this.indent;
         }
 
         /**
+         * Sets if the resultant loader should parse leniently.
+         *
          * @see JsonReader#setLenient(boolean)
          * @param lenient Whether the parser should parse leniently
-         * @return this
+         * @return This builder (for chaining)
          */
+        @NonNull
         public Builder setLenient(boolean lenient) {
             this.lenient = lenient;
             return this;
         }
 
+        /**
+         * Gets if the resultant loader should parse leniently.
+         *
+         * @return Whether the parser should parse leniently
+         */
         public boolean isLenient() {
             return this.lenient;
         }
 
+        @NonNull
         @Override
         public GsonConfigurationLoader build() {
             return new GsonConfigurationLoader(this);
         }
     }
 
-    public static Builder builder() {
-        return new Builder();
-    }
+    private final boolean lenient;
+    private final String indent;
 
-    protected GsonConfigurationLoader(Builder builder) {
-        super(builder, new CommentHandler[] {CommentHandlers.DOUBLE_SLASH, CommentHandlers.SLASH_BLOCK,
-                        CommentHandlers.HASH});
+    private GsonConfigurationLoader(Builder builder) {
+        super(builder, new CommentHandler[] {CommentHandlers.DOUBLE_SLASH, CommentHandlers.SLASH_BLOCK, CommentHandlers.HASH});
         this.lenient = builder.isLenient();
         this.indent = Strings.repeat(" ", builder.getIndent());
     }
@@ -184,14 +217,15 @@ public class GsonConfigurationLoader extends AbstractConfigurationLoader<Configu
         }
     }
 
+    @NonNull
     @Override
-    public ConfigurationNode createEmptyNode(ConfigurationOptions options) {
+    public ConfigurationNode createEmptyNode(@NonNull ConfigurationOptions options) {
         options = options.setAcceptedTypes(ImmutableSet.of(Map.class, List.class, Double.class, Float.class,
                 Long.class, Integer.class, Boolean.class, String.class));
         return SimpleConfigurationNode.root(options);
     }
 
-    private void generateValue(JsonWriter generator, ConfigurationNode node) throws IOException {
+    private static void generateValue(JsonWriter generator, ConfigurationNode node) throws IOException {
         if (node.hasMapChildren()) {
             generateObject(generator, node);
         } else if (node.hasListChildren()) {
@@ -211,15 +245,13 @@ public class GsonConfigurationLoader extends AbstractConfigurationLoader<Configu
                 generator.value((Integer) value);
             } else if (value instanceof Boolean) {
                 generator.value((Boolean) value);
-            } else if (value instanceof byte[]) {
-                //generator.value((byte[]) value);
             } else {
                 generator.value(value.toString());
             }
         }
     }
 
-    private void generateObject(JsonWriter generator, ConfigurationNode node) throws IOException {
+    private static void generateObject(JsonWriter generator, ConfigurationNode node) throws IOException {
         if (!node.hasMapChildren()) {
             throw new IOException("Node passed to generateObject does not have map children!");
         }
@@ -229,10 +261,9 @@ public class GsonConfigurationLoader extends AbstractConfigurationLoader<Configu
             generateValue(generator, ent.getValue());
         }
         generator.endObject();
-
     }
 
-    private void generateArray(JsonWriter generator, ConfigurationNode node) throws IOException {
+    private static void generateArray(JsonWriter generator, ConfigurationNode node) throws IOException {
         if (!node.hasListChildren()) {
             throw new IOException("Node passed to generateArray does not have list children!");
         }

--- a/configurate-gson/src/test/java/ninja/leaping/configurate/gson/GsonConfigurationLoaderTest.java
+++ b/configurate-gson/src/test/java/ninja/leaping/configurate/gson/GsonConfigurationLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-hocon/pom.xml
+++ b/configurate-hocon/pom.xml
@@ -18,17 +18,16 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>ninja.leaping.configurate</groupId>
         <artifactId>configurate-parent</artifactId>
         <version>3.4-SNAPSHOT</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
-    <packaging>jar</packaging>
-
     <artifactId>configurate-hocon</artifactId>
     <name>Configurate HOCON</name>
+    <packaging>jar</packaging>
 
     <dependencies>
         <dependency>

--- a/configurate-hocon/src/main/java/ninja/leaping/configurate/hocon/HoconConfigurationLoader.java
+++ b/configurate-hocon/src/main/java/ninja/leaping/configurate/hocon/HoconConfigurationLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-hocon/src/main/java/ninja/leaping/configurate/hocon/HoconConfigurationLoader.java
+++ b/configurate-hocon/src/main/java/ninja/leaping/configurate/hocon/HoconConfigurationLoader.java
@@ -36,6 +36,7 @@ import ninja.leaping.configurate.commented.SimpleCommentedConfigurationNode;
 import ninja.leaping.configurate.loader.AbstractConfigurationLoader;
 import ninja.leaping.configurate.loader.CommentHandler;
 import ninja.leaping.configurate.loader.CommentHandlers;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -47,20 +48,60 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-
 /**
- * A loader for HOCON (Hodor)-formatted configurations, using the typesafe config library for parsing
+ * A loader for HOCON (Hodor)-formatted configurations, using the typesafe config library for
+ * parsing and generation.
  */
 public class HoconConfigurationLoader extends AbstractConfigurationLoader<CommentedConfigurationNode> {
+
+    /**
+     * The pattern used to match newlines.
+     */
     public static final Pattern CRLF_MATCH = Pattern.compile("\r?");
+
+    /**
+     * The default render options used by configurate.
+     */
     private static final ConfigRenderOptions DEFAULT_RENDER_OPTIONS = ConfigRenderOptions.defaults()
             .setOriginComments(false)
             .setJson(false);
+
+    /**
+     * An instance of {@link ConfigOrigin} for configurate.
+     */
     private static final ConfigOrigin CONFIGURATE_ORIGIN = ConfigOriginFactory.newSimple("configurate-hocon");
 
-    private final ConfigRenderOptions render;
-    private final ConfigParseOptions parse;
+    /**
+     * Gets the default {@link ConfigRenderOptions} used by configurate.
+     *
+     * @return The default render options
+     */
+    public static ConfigRenderOptions defaultRenderOptions() {
+        return DEFAULT_RENDER_OPTIONS;
+    }
 
+    /**
+     * Gets the default {@link ConfigParseOptions} used by configurate.
+     *
+     * @return The default parse options
+     */
+    public static ConfigParseOptions defaultParseOptions() {
+        return ConfigParseOptions.defaults();
+    }
+
+    /**
+     * Creates a new {@link HoconConfigurationLoader} builder.
+     *
+     * @return A new builder
+     */
+    @NonNull
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builds a {@link HoconConfigurationLoader}.
+     */
     public static class Builder extends AbstractConfigurationLoader.Builder<Builder> {
         private ConfigRenderOptions render = defaultRenderOptions();
         private ConfigParseOptions parse = defaultParseOptions();
@@ -68,41 +109,59 @@ public class HoconConfigurationLoader extends AbstractConfigurationLoader<Commen
         protected Builder() {
         }
 
-        public ConfigRenderOptions getRenderOptions() {
-            return render;
-        }
-
-        public ConfigParseOptions getParseOptions() {
-            return parse;
-        }
-
-        public Builder setRenderOptions(ConfigRenderOptions options) {
+        /**
+         * Sets the {@link ConfigRenderOptions} the resultant loader should use.
+         *
+         * @param options The render options
+         * @return This builder (for chaining)
+         */
+        @NonNull
+        public Builder setRenderOptions(@NonNull ConfigRenderOptions options) {
             this.render = options;
             return this;
         }
 
+        /**
+         * Gets the {@link ConfigRenderOptions} to be used by the resultant loader.
+         *
+         * @return The render options
+         */
+        @NonNull
+        public ConfigRenderOptions getRenderOptions() {
+            return render;
+        }
+
+        /**
+         * Sets the {@link ConfigParseOptions} the resultant loader should use.
+         *
+         * @param options The parse options
+         * @return This builder (for chaining)
+         */
+        @NonNull
         public Builder setParseOptions(ConfigParseOptions options) {
             this.parse = options;
             return this;
         }
 
+        /**
+         * Gets the {@link ConfigRenderOptions} to be used by the resultant loader.
+         *
+         * @return The render options
+         */
+        @NonNull
+        public ConfigParseOptions getParseOptions() {
+            return parse;
+        }
+
+        @NonNull
         @Override
         public HoconConfigurationLoader build() {
             return new HoconConfigurationLoader(this);
         }
     }
 
-    public static ConfigRenderOptions defaultRenderOptions() {
-        return DEFAULT_RENDER_OPTIONS;
-    }
-
-    public static ConfigParseOptions defaultParseOptions() {
-        return ConfigParseOptions.defaults();
-    }
-
-    public static Builder builder() {
-        return new Builder();
-    }
+    private final ConfigRenderOptions render;
+    private final ConfigParseOptions parse;
 
     private HoconConfigurationLoader(Builder build) {
         super(build, new CommentHandler[] {CommentHandlers.HASH, CommentHandlers.DOUBLE_SLASH});
@@ -119,7 +178,7 @@ public class HoconConfigurationLoader extends AbstractConfigurationLoader<Commen
         }
     }
 
-    private void readConfigValue(ConfigValue value, CommentedConfigurationNode node) {
+    private static void readConfigValue(ConfigValue value, CommentedConfigurationNode node) {
         if (!value.origin().comments().isEmpty()) {
             node.setComment(CRLF_MATCH.matcher(Joiner.on('\n').join(value.origin().comments())).replaceAll(""));
         }
@@ -161,8 +220,7 @@ public class HoconConfigurationLoader extends AbstractConfigurationLoader<Commen
         writer.write(renderedValue);
     }
 
-
-    private ConfigValue fromValue(ConfigurationNode node) {
+    private static ConfigValue fromValue(ConfigurationNode node) {
         ConfigValue ret;
         if (node.hasMapChildren()) {
             Map<String, ConfigValue> children = node.getOptions().getMapFactory().create();
@@ -188,27 +246,26 @@ public class HoconConfigurationLoader extends AbstractConfigurationLoader<Commen
         return ret;
     }
 
-    ConfigValue newConfigObject(Map<String, ConfigValue> vals) {
+    static ConfigValue newConfigObject(Map<String, ConfigValue> vals) {
         try {
             return CONFIG_OBJECT_CONSTRUCTOR.newInstance(CONFIGURATE_ORIGIN, vals);
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
-            throw new RuntimeException(e); // Again,rethrow
+            throw new RuntimeException(e); // rethrow
         }
 
     }
 
-    ConfigValue newConfigList(List<ConfigValue> vals) {
+    static ConfigValue newConfigList(List<ConfigValue> vals) {
         try {
             return CONFIG_LIST_CONSTRUCTOR.newInstance(CONFIGURATE_ORIGIN, vals);
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
-            throw new RuntimeException(e); // Should be rethrown
+            throw new RuntimeException(e); // rethrow
         }
-
     }
 
-
+    @NonNull
     @Override
-    public CommentedConfigurationNode createEmptyNode(ConfigurationOptions options) {
+    public CommentedConfigurationNode createEmptyNode(@NonNull ConfigurationOptions options) {
         options = options.setAcceptedTypes(ImmutableSet.of(Map.class, List.class, Double.class,
                 Long.class, Integer.class, Boolean.class, String.class, Number.class));
         return SimpleCommentedConfigurationNode.root(options);
@@ -235,6 +292,5 @@ public class HoconConfigurationLoader extends AbstractConfigurationLoader<Commen
         } catch (NoSuchMethodException e) {
             throw new ExceptionInInitializerError(e);
         }
-
     }
 }

--- a/configurate-hocon/src/test/java/ninja/leaping/configurate/hocon/HoconConfigurationLoaderTest.java
+++ b/configurate-hocon/src/test/java/ninja/leaping/configurate/hocon/HoconConfigurationLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-hocon/src/test/java/ninja/leaping/configurate/hocon/HoconConfigurationLoaderTest.java
+++ b/configurate-hocon/src/test/java/ninja/leaping/configurate/hocon/HoconConfigurationLoaderTest.java
@@ -113,17 +113,13 @@ public class HoconConfigurationLoaderTest {
 
     @Test
     public void testNewConfigObject() {
-        HoconConfigurationLoader subject = HoconConfigurationLoader.builder().build();
-
         Map<String, ConfigValue> entries = ImmutableMap.of("a", ConfigValueFactory.fromAnyRef("hi"), "b", ConfigValueFactory.fromAnyRef("bye"));
-        subject.newConfigObject(entries);
+        HoconConfigurationLoader.newConfigObject(entries);
     }
 
     @Test
     public void testNewConfigList() {
-        HoconConfigurationLoader subject = HoconConfigurationLoader.builder().build();
-
         List<ConfigValue> entries = ImmutableList.of(ConfigValueFactory.fromAnyRef("hello"), ConfigValueFactory.fromAnyRef("goodbye"));
-        subject.newConfigList(entries);
+        HoconConfigurationLoader.newConfigList(entries);
     }
 }

--- a/configurate-json/pom.xml
+++ b/configurate-json/pom.xml
@@ -18,17 +18,16 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>ninja.leaping.configurate</groupId>
         <artifactId>configurate-parent</artifactId>
         <version>3.4-SNAPSHOT</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
-    <packaging>jar</packaging>
-
     <artifactId>configurate-json</artifactId>
     <name>Configurate Jackson</name>
+    <packaging>jar</packaging>
 
     <dependencies>
         <dependency>

--- a/configurate-json/src/main/java/ninja/leaping/configurate/json/ConfiguratePrettyPrinter.java
+++ b/configurate-json/src/main/java/ninja/leaping/configurate/json/ConfiguratePrettyPrinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-json/src/main/java/ninja/leaping/configurate/json/ConfiguratePrettyPrinter.java
+++ b/configurate-json/src/main/java/ninja/leaping/configurate/json/ConfiguratePrettyPrinter.java
@@ -23,8 +23,10 @@ import com.google.common.base.Strings;
 
 import java.io.IOException;
 
+/**
+ * An extension of {@link DefaultPrettyPrinter} which can be customised by loader settings.
+ */
 class ConfiguratePrettyPrinter extends DefaultPrettyPrinter {
-
     private final FieldValueSeparatorStyle style;
 
     public ConfiguratePrettyPrinter(int indent, FieldValueSeparatorStyle style) {

--- a/configurate-json/src/main/java/ninja/leaping/configurate/json/FieldValueSeparatorStyle.java
+++ b/configurate-json/src/main/java/ninja/leaping/configurate/json/FieldValueSeparatorStyle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-json/src/main/java/ninja/leaping/configurate/json/FieldValueSeparatorStyle.java
+++ b/configurate-json/src/main/java/ninja/leaping/configurate/json/FieldValueSeparatorStyle.java
@@ -16,10 +16,26 @@
  */
 package ninja.leaping.configurate.json;
 
+/**
+ * Enumeration of field value separator styles.
+ */
 public enum FieldValueSeparatorStyle {
+
+    /**
+     * Style which uses spaces either side of the <code>:</code> character.
+     */
     SPACE_BOTH_SIDES(" : "),
+
+    /**
+     * Style which uses a space after the <code>:</code> character.
+     */
     SPACE_AFTER(": "),
+
+    /**
+     * Style which uses no spaces.
+     */
     NO_SPACE(":");
+
     private final String decorationType;
 
     FieldValueSeparatorStyle(String decorationType) {

--- a/configurate-json/src/main/java/ninja/leaping/configurate/json/JSONConfigurationLoader.java
+++ b/configurate-json/src/main/java/ninja/leaping/configurate/json/JSONConfigurationLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-json/src/main/java/ninja/leaping/configurate/json/JSONConfigurationLoader.java
+++ b/configurate-json/src/main/java/ninja/leaping/configurate/json/JSONConfigurationLoader.java
@@ -29,6 +29,7 @@ import ninja.leaping.configurate.commented.SimpleCommentedConfigurationNode;
 import ninja.leaping.configurate.loader.AbstractConfigurationLoader;
 import ninja.leaping.configurate.loader.CommentHandler;
 import ninja.leaping.configurate.loader.CommentHandlers;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -36,15 +37,24 @@ import java.io.Writer;
 import java.util.List;
 import java.util.Map;
 
-
 /**
- * A loader for JSON-formatted configurations, using the jackson library for parsing and generation
+ * A loader for JSON-formatted configurations, using the jackson library for parsing and generation.
  */
 public class JSONConfigurationLoader extends AbstractConfigurationLoader<ConfigurationNode> {
-    private final JsonFactory factory;
-    private final int indent;
-    private final FieldValueSeparatorStyle fieldValueSeparatorStyle;
 
+    /**
+     * Creates a new {@link JSONConfigurationLoader} builder.
+     *
+     * @return A new builder
+     */
+    @NonNull
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builds a {@link JSONConfigurationLoader}.
+     */
     public static class Builder extends AbstractConfigurationLoader.Builder<Builder> {
         private final JsonFactory factory = new JsonFactory();
         private int indent = 2;
@@ -61,41 +71,72 @@ public class JSONConfigurationLoader extends AbstractConfigurationLoader<Configu
             factory.enable(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS);
         }
 
+        /**
+         * Gets the {@link JsonFactory} used to configure the implementation.
+         *
+         * @return The json factory
+         */
+        @NonNull
         public JsonFactory getFactory() {
             return this.factory;
         }
 
+        /**
+         * Sets the level of indentation the resultant loader should use.
+         *
+         * @param indent The indent level
+         * @return This builder (for chaining)
+         */
+        @NonNull
         public Builder setIndent(int indent) {
             this.indent = indent;
             return this;
         }
 
-        public Builder setFieldValueSeparatorStyle(FieldValueSeparatorStyle style) {
+        /**
+         * Gets the level of indentation to be used by the resultant loader.
+         *
+         * @return The indent level
+         */
+        public int getIndent() {
+            return this.indent;
+        }
+
+        /**
+         * Sets the field value separator style the resultant loader should use.
+         *
+         * @param style The style
+         * @return  This builder (for chaining)
+         */
+        @NonNull
+        public Builder setFieldValueSeparatorStyle(@NonNull FieldValueSeparatorStyle style) {
             this.fieldValueSeparatorStyle = style;
             return this;
         }
 
+        /**
+         * Gets the field value separator style to be used by the resultant loader.
+         *
+         * @return The style
+         */
+        @NonNull
+        public FieldValueSeparatorStyle getFieldValueSeparatorStyle() {
+            return fieldValueSeparatorStyle;
+        }
+
+        @NonNull
         @Override
         public JSONConfigurationLoader build() {
             return new JSONConfigurationLoader(this);
         }
-
-        public int getIndent() {
-            return indent;
-        }
-
-        public FieldValueSeparatorStyle getFieldValueSeparatorStyle() {
-            return fieldValueSeparatorStyle;
-        }
     }
 
-    public static Builder builder() {
-        return new Builder();
-    }
+    private final JsonFactory factory;
+    private final int indent;
+    private final FieldValueSeparatorStyle fieldValueSeparatorStyle;
 
-    protected JSONConfigurationLoader(Builder builder) {
-        super(builder, new CommentHandler[]{CommentHandlers.DOUBLE_SLASH, CommentHandlers.SLASH_BLOCK,
-                CommentHandlers.HASH});
+    private JSONConfigurationLoader(Builder builder) {
+        super(builder, new CommentHandler[]{CommentHandlers.DOUBLE_SLASH, CommentHandlers.SLASH_BLOCK, CommentHandlers.HASH});
         this.factory = builder.getFactory();
         this.indent = builder.getIndent();
         this.fieldValueSeparatorStyle = builder.getFieldValueSeparatorStyle();
@@ -109,7 +150,7 @@ public class JSONConfigurationLoader extends AbstractConfigurationLoader<Configu
         }
     }
 
-    private void parseValue(JsonParser parser, ConfigurationNode node) throws IOException {
+    private static void parseValue(JsonParser parser, ConfigurationNode node) throws IOException {
         JsonToken token = parser.getCurrentToken();
         switch (token) {
             case START_OBJECT:
@@ -145,12 +186,11 @@ public class JSONConfigurationLoader extends AbstractConfigurationLoader<Configu
             case FIELD_NAME:
                 break;
             default:
-                throw new IOException("Unsupported token type: " + token + " (at " + parser.getTokenLocation()
-                        + ")");
+                throw new IOException("Unsupported token type: " + token + " (at " + parser.getTokenLocation() + ")");
         }
     }
 
-    private void parseArray(JsonParser parser, ConfigurationNode node) throws IOException {
+    private static void parseArray(JsonParser parser, ConfigurationNode node) throws IOException {
         JsonToken token;
         while ((token = parser.nextToken()) != null) {
             switch (token) {
@@ -160,11 +200,10 @@ public class JSONConfigurationLoader extends AbstractConfigurationLoader<Configu
                     parseValue(parser, node.getAppendedNode());
             }
         }
-        throw new JsonParseException("Reached end of stream with unclosed array!", parser.getCurrentLocation());
-
+        throw new JsonParseException(parser, "Reached end of stream with unclosed array!", parser.getCurrentLocation());
     }
 
-    private void parseObject(JsonParser parser, ConfigurationNode node) throws IOException {
+    private static void parseObject(JsonParser parser, ConfigurationNode node) throws IOException {
         JsonToken token;
         while ((token = parser.nextToken()) != null) {
             switch (token) {
@@ -174,7 +213,7 @@ public class JSONConfigurationLoader extends AbstractConfigurationLoader<Configu
                     parseValue(parser, node.getNode(parser.getCurrentName()));
             }
         }
-            throw new JsonParseException(parser, "Reached end of stream with unclosed array!", parser.getCurrentLocation());
+        throw new JsonParseException(parser, "Reached end of stream with unclosed array!", parser.getCurrentLocation());
     }
 
     @Override
@@ -187,14 +226,15 @@ public class JSONConfigurationLoader extends AbstractConfigurationLoader<Configu
         }
     }
 
+    @NonNull
     @Override
-    public CommentedConfigurationNode createEmptyNode(ConfigurationOptions options) {
+    public CommentedConfigurationNode createEmptyNode(@NonNull ConfigurationOptions options) {
         options = options.setAcceptedTypes(ImmutableSet.of(Map.class, List.class, Double.class, Float.class,
                 Long.class, Integer.class, Boolean.class, String.class, byte[].class));
         return SimpleCommentedConfigurationNode.root(options);
     }
 
-    private void generateValue(JsonGenerator generator, ConfigurationNode node) throws IOException {
+    private static void generateValue(JsonGenerator generator, ConfigurationNode node) throws IOException {
         if (node.hasMapChildren()) {
             generateObject(generator, node);
         } else if (node.hasListChildren()) {
@@ -242,10 +282,9 @@ public class JSONConfigurationLoader extends AbstractConfigurationLoader<Configu
                 }
             }
         }
-
     }*/
 
-    private void generateObject(JsonGenerator generator, ConfigurationNode node) throws IOException {
+    private static void generateObject(JsonGenerator generator, ConfigurationNode node) throws IOException {
         if (!node.hasMapChildren()) {
             throw new IOException("Node passed to generateObject does not have map children!");
         }
@@ -256,10 +295,9 @@ public class JSONConfigurationLoader extends AbstractConfigurationLoader<Configu
             generateValue(generator, ent.getValue());
         }
         generator.writeEndObject();
-
     }
 
-    private void generateArray(JsonGenerator generator, ConfigurationNode node) throws IOException {
+    private static void generateArray(JsonGenerator generator, ConfigurationNode node) throws IOException {
         if (!node.hasListChildren()) {
             throw new IOException("Node passed to generateArray does not have list children!");
         }

--- a/configurate-json/src/test/java/ninja/leaping/configurate/json/JSONConfigurationLoaderTest.java
+++ b/configurate-json/src/test/java/ninja/leaping/configurate/json/JSONConfigurationLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-json/src/test/java/ninja/leaping/configurate/json/JSONConfigurationLoaderTest.java
+++ b/configurate-json/src/test/java/ninja/leaping/configurate/json/JSONConfigurationLoaderTest.java
@@ -27,14 +27,13 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.charset.StandardCharsets.*;
 import static org.junit.Assert.*;
 
 /**

--- a/configurate-yaml/pom.xml
+++ b/configurate-yaml/pom.xml
@@ -18,17 +18,16 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>ninja.leaping.configurate</groupId>
         <artifactId>configurate-parent</artifactId>
         <version>3.4-SNAPSHOT</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
-    <packaging>jar</packaging>
-
     <artifactId>configurate-yaml</artifactId>
     <name>Configurate YAML</name>
+    <packaging>jar</packaging>
 
     <dependencies>
         <dependency>

--- a/configurate-yaml/src/main/java/ninja/leaping/configurate/yaml/YAMLConfigurationLoader.java
+++ b/configurate-yaml/src/main/java/ninja/leaping/configurate/yaml/YAMLConfigurationLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/configurate-yaml/src/main/java/ninja/leaping/configurate/yaml/YAMLConfigurationLoader.java
+++ b/configurate-yaml/src/main/java/ninja/leaping/configurate/yaml/YAMLConfigurationLoader.java
@@ -22,20 +22,33 @@ import ninja.leaping.configurate.SimpleConfigurationNode;
 import ninja.leaping.configurate.loader.AbstractConfigurationLoader;
 import ninja.leaping.configurate.loader.CommentHandler;
 import ninja.leaping.configurate.loader.CommentHandlers;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.DumperOptions.FlowStyle;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Writer;
 
-
 /**
- * A loader for YAML-formatted configurations, using the snakeyaml library for parsing
+ * A loader for YAML-formatted configurations, using the SnakeYAML library for parsing and generation.
  */
 public class YAMLConfigurationLoader extends AbstractConfigurationLoader<ConfigurationNode> {
-    private final ThreadLocal<Yaml> yaml;
 
+    /**
+     * Creates a new {@link YAMLConfigurationLoader} builder.
+     *
+     * @return A new builder
+     */
+    @NonNull
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builds a {@link YAMLConfigurationLoader}.
+     */
     public static class Builder extends AbstractConfigurationLoader.Builder<Builder> {
         private final DumperOptions options = new DumperOptions();
 
@@ -43,13 +56,30 @@ public class YAMLConfigurationLoader extends AbstractConfigurationLoader<Configu
             setIndent(4);
         }
 
+        /**
+         * Sets the level of indentation the resultant loader should use.
+         *
+         * @param indent The indent level
+         * @return This builder (for chaining)
+         */
+        @NonNull
         public Builder setIndent(int indent) {
             options.setIndent(indent);
             return this;
         }
 
         /**
-         * Sets the flow style for this configuration
+         * Gets the level of indentation to be used by the resultant loader.
+         *
+         * @return The indent level
+         */
+        public int getIndent() {
+            return options.getIndent();
+        }
+
+        /**
+         * Sets the flow style the resultant loader should use.
+         *
          * Flow: the compact, json-like representation.<br>
          * Example: <code>
          *     {value: [list, of, elements], another: value}
@@ -64,34 +94,38 @@ public class YAMLConfigurationLoader extends AbstractConfigurationLoader<Configu
          *     another: value
          * </code>
          *
-         * @param style the appropritae flow style to use
-         * @return this
+         * @param style The flow style to use
+         * @return This builder (for chaining)
          */
-        public Builder setFlowStyle(DumperOptions.FlowStyle style) {
+        @NonNull
+        public Builder setFlowStyle(@NonNull FlowStyle style) {
             options.setDefaultFlowStyle(style);
             return this;
         }
 
+        /**
+         * Gets the flow style to be used by the resultant loader.
+         *
+         * @return The flow style
+         */
+        @NonNull
+        public FlowStyle getFlowSyle() {
+            return options.getDefaultFlowStyle();
+        }
 
+        @NonNull
         @Override
         public YAMLConfigurationLoader build() {
             return new YAMLConfigurationLoader(this);
         }
     }
 
-    public static Builder builder() {
-        return new Builder();
-    }
+    private final ThreadLocal<Yaml> yaml;
 
     private YAMLConfigurationLoader(Builder builder) {
         super(builder, new CommentHandler[] {CommentHandlers.HASH});
         final DumperOptions opts = builder.options;
-        this.yaml = new ThreadLocal<Yaml>() {
-            @Override
-            protected Yaml initialValue() {
-                return new Yaml(opts);
-            }
-        };
+        this.yaml = ThreadLocal.withInitial(() -> new Yaml(opts));
     }
 
     @Override
@@ -104,8 +138,9 @@ public class YAMLConfigurationLoader extends AbstractConfigurationLoader<Configu
         yaml.get().dump(node.getValue(), writer);
     }
 
+    @NonNull
     @Override
-    public ConfigurationNode createEmptyNode(ConfigurationOptions options) {
+    public ConfigurationNode createEmptyNode(@NonNull ConfigurationOptions options) {
         return SimpleConfigurationNode.root(options);
     }
 }

--- a/configurate-yaml/src/test/java/ninja/leaping/configurate/yaml/YAMLConfigurationLoaderTest.java
+++ b/configurate-yaml/src/test/java/ninja/leaping/configurate/yaml/YAMLConfigurationLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Configurate
  * Copyright (C) zml and Configurate contributors
  *

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,9 @@
                         <include>src/test/java/**</include>
                     </includes>
                     <useDefaultExcludes>true</useDefaultExcludes>
+                    <mapping>
+                        <java>SLASHSTAR_STYLE</java>
+                    </mapping>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,12 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+            <version>2.4.0</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Configurate
@@ -22,24 +23,37 @@
     <groupId>ninja.leaping.configurate</groupId>
     <artifactId>configurate-parent</artifactId>
     <version>3.4-SNAPSHOT</version>
-    <packaging>pom</packaging>
+
+    <modules>
+        <module>configurate-core</module>
+        <module>configurate-yaml</module>
+        <module>configurate-hocon</module>
+        <module>configurate-json</module>
+        <module>configurate-gson</module>
+    </modules>
+
     <name>Configurate Parent</name>
     <description>A simple configuration library for Java applications that can handle a variety of formats and
         provides a node-based data structure able to handle a wide variety of configuration schemas</description>
     <url>http://configurate.aoeu.xyz/${siteUrlSuffix}/</url>
     <inceptionYear>2014</inceptionYear>
+
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
             <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
+
     <developers>
         <developer>
             <name>zml</name>
             <email>zml@aoeu.xyz</email>
         </developer>
     </developers>
+
+    <packaging>pom</packaging>
+
     <properties>
         <gitUser>SpongePowered</gitUser>
         <gitProject>configurate</gitProject>
@@ -52,8 +66,8 @@
         <connection>scm:git:https://github.com/${gitUrl}.git</connection>
         <developerConnection>scm:git:git@github.com:${gitUrl}.git</developerConnection>
         <url>https://github.com/${gitUrl}</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <distributionManagement>
         <snapshotRepository>
@@ -66,14 +80,6 @@
             <url>github:http://SpongePowered.github.io/configurate/${siteUrlSuffix}/</url> <!-- This is a lie but it's what the wagon-git plugin needs to deploy the site -->
         </site>
     </distributionManagement>
-
-    <modules>
-        <module>configurate-core</module>
-        <module>configurate-yaml</module>
-        <module>configurate-hocon</module>
-        <module>configurate-json</module>
-        <module>configurate-gson</module>
-    </modules>
 
     <reporting>
         <plugins>
@@ -112,6 +118,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>
@@ -213,6 +220,7 @@
             </plugin>
         </plugins>
     </build>
+
     <profiles>
         <profile>
             <id>release</id>


### PR DESCRIPTION
I don't know if any of these changes are wanted (or welcome) or whatever - but I thought I'd PR them anyway. The only thing changed is formatting - there are no behavioural differences.

I've only just noticed that this repo is now under the SpongePowered umbrella. Does that mean it's now being actively maintained by Sponge - or did zml just want to hand over the responsibility?

If "improvement" PRs (as opposed to bug fixes) aren't going to be considered, then I'll stop submitting them & just maintain my own fork :) It would be nice to know the status - I know this probably isn't a priority for the Sponge team.

### Introduce consistent formatting in Maven poms

The current poms have inconsistent formatting and indentation in some places. I rearranged & fixed indentation where it was appropriate to do so - without any change in build behaviour.

### Use the correct "slashstar" style when generating license headers

The current "javadoc" style is reserved for JavaDocs - and is not meant to be used for license headers.

IntelliJ gives this suggestion/warning

![](https://luck.sh/XUd1eg385564A69O2O3RF2uIMNw=)

:-1:
```
/**
 * Configurate
 * Copyright (C) zml and Configurate contributors
 *
 * and so on...
 */
```

:+1:
```
/*
 * Configurate
 * Copyright (C) zml and Configurate contributors
 *
 * and so on...
 */
```

### JavaDoc (and other misc) improvements

These are all still WIP.

I feel like better documentation would go a long way in making configurate easier to use and understand.

#### The only breaking change is...

The method signature of `TransformAction` has been changed from

```java
Object[] visitPath(SingleConfigurationTransformation.NodePath inputPath, ConfigurationNode valueAtPath)
```

to

```java
Object[] visitPath(NodePath inputPath, ConfigurationNode valueAtPath)
```

`SingleConfigurationTransformation` is a package private class - it was previously impossible to implement the interface as a result.

![](https://luck.sh/SHTZisC_bVYINLQsOiiQsSS5qmc=)