### PR TITLE
Add ConfigurationNode#copy

### DIFF
--- a/configurate-core/src/main/java/ninja/leaping/configurate/ConfigValue.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/ConfigValue.java
@@ -89,6 +89,14 @@ abstract class ConfigValue {
     abstract Iterable<SimpleConfigurationNode> iterateChildren();
 
     /**
+     * Creates a copy of this node
+     *
+     * @return A copy
+     */
+    @NonNull
+    abstract ConfigValue copy(@NonNull SimpleConfigurationNode holder);
+
+    /**
      * Clears the set value (or any attached child values) from this value
      */
     void clear() {

--- a/configurate-core/src/main/java/ninja/leaping/configurate/ConfigurationNode.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/ConfigurationNode.java
@@ -572,16 +572,36 @@ public interface ConfigurationNode {
      * Removes a direct child of this node
      *
      * @param key The key of the node to remove
-     * @return if an actual node was removed
+     * @return If a node was removed
      */
     boolean removeChild(@NonNull Object key);
 
     /**
      * Gets a new child node created as the next entry in the list.
      *
-     * @return a new child created as the next entry in the list when it is attached
+     * @return A new child created as the next entry in the list when it is attached
      */
     @NonNull
     ConfigurationNode getAppendedNode();
+
+    /**
+     * Creates a deep copy of this node.
+     *
+     * <p>If this node has child nodes (is a list or map), the child nodes will
+     * also be copied. This action is performed recursively.</p>
+     *
+     * <p>The resultant node will (initially) contain the same value(s) as this node,
+     * and will therefore be {@link Object#equals(Object) equal}, however, changes made to
+     * the original will not be reflected in the copy, and vice versa.</p>
+     *
+     * <p>The actual scalar values that back the configuration will
+     * <strong>not</strong> be copied - only the node structure that forms the
+     * configuration. This is not a problem in most cases, as the scalar values
+     * stored in configurations are usually immutable. (e.g. strings, numbers, booleans).</p>
+     *
+     * @return A copy of this node
+     */
+    @NonNull
+    ConfigurationNode copy();
 
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/ListConfigValue.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/ListConfigValue.java
@@ -156,6 +156,24 @@ class ListConfigValue extends ConfigValue {
         }
     }
 
+    @NonNull
+    @Override
+    ListConfigValue copy(@NonNull SimpleConfigurationNode holder) {
+        ListConfigValue copy = new ListConfigValue(holder);
+        List<SimpleConfigurationNode> copyValues;
+
+        final List<SimpleConfigurationNode> values = this.values.get();
+        synchronized (values) {
+            copyValues = new ArrayList<>(values.size());
+            for (SimpleConfigurationNode obj : values) {
+                copyValues.add(obj.copy(holder)); // recursively copy
+            }
+        }
+
+        copy.values.set(copyValues);
+        return copy;
+    }
+
     private static void detachNodes(List<SimpleConfigurationNode> children) {
         synchronized (children) {
             for (SimpleConfigurationNode node : children) {
@@ -180,11 +198,16 @@ class ListConfigValue extends ConfigValue {
             return false;
         }
         ListConfigValue that = (ListConfigValue) o;
-        return Objects.equal(values, that.values);
+        return Objects.equal(values.get(), that.values.get());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(values);
+        return values.get().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "ListConfigValue{values=" + this.values.get().toString() + '}';
     }
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/MapConfigValue.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/MapConfigValue.java
@@ -20,7 +20,9 @@ import com.google.common.base.Objects;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 
@@ -104,6 +106,16 @@ class MapConfigValue extends ConfigValue {
         return values.values();
     }
 
+    @NonNull
+    @Override
+    MapConfigValue copy(@NonNull SimpleConfigurationNode holder) {
+        MapConfigValue copy = new MapConfigValue(holder);
+        for (Map.Entry<Object, ? extends SimpleConfigurationNode> ent : this.values.entrySet()) {
+            copy.values.put(ent.getKey(), ent.getValue().copy(holder)); // recursively copy
+        }
+        return copy;
+    }
+
     private static void detachChildren(Map<Object, SimpleConfigurationNode> map) {
         for (SimpleConfigurationNode value : map.values()) {
             value.attached = false;
@@ -134,6 +146,11 @@ class MapConfigValue extends ConfigValue {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(values);
+        return values.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "MapConfigValue{values=" + this.values + '}';
     }
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/NullConfigValue.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/NullConfigValue.java
@@ -63,6 +63,12 @@ class NullConfigValue extends ConfigValue {
         return Collections.emptySet();
     }
 
+    @NonNull
+    @Override
+    NullConfigValue copy(@NonNull SimpleConfigurationNode holder) {
+        return new NullConfigValue(holder);
+    }
+
     @Override
     public void clear() {
 
@@ -76,5 +82,10 @@ class NullConfigValue extends ConfigValue {
     @Override
     public int hashCode() {
         return 1009;
+    }
+
+    @Override
+    public String toString() {
+        return "NullConfigValue{}";
     }
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/ScalarConfigValue.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/ScalarConfigValue.java
@@ -72,6 +72,14 @@ class ScalarConfigValue extends ConfigValue {
         return Collections.emptySet();
     }
 
+    @NonNull
+    @Override
+    ScalarConfigValue copy(@NonNull SimpleConfigurationNode holder) {
+        ScalarConfigValue copy = new ScalarConfigValue(holder);
+        copy.value = this.value;
+        return copy;
+    }
+
     @Override
     public void clear() {
        this.value = null;
@@ -92,5 +100,10 @@ class ScalarConfigValue extends ConfigValue {
     @Override
     public int hashCode() {
         return Objects.hashCode(value);
+    }
+
+    @Override
+    public String toString() {
+        return "ScalarConfigValue{value=" + this.value + '}';
     }
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/SimpleConfigurationNode.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/SimpleConfigurationNode.java
@@ -95,6 +95,14 @@ public class SimpleConfigurationNode implements ConfigurationNode {
         }
     }
 
+    protected SimpleConfigurationNode(SimpleConfigurationNode parent, SimpleConfigurationNode copyOf) {
+        this.options = copyOf.options;
+        this.attached = true; // copies are always attached
+        this.key = copyOf.key;
+        this.parent = parent;
+        this.value = copyOf.value.copy(this);
+    }
+
     /**
      * Handles the copying of applied defaults, if enabled.
      *
@@ -471,6 +479,17 @@ public class SimpleConfigurationNode implements ConfigurationNode {
         return this.options;
     }
 
+    @NonNull
+    @Override
+    public SimpleConfigurationNode copy() {
+        return copy(null);
+    }
+
+    @NonNull
+    protected SimpleConfigurationNode copy(@Nullable SimpleConfigurationNode parent) {
+        return new SimpleConfigurationNode(parent, this);
+    }
+
     /**
      * The same as {@link #getParent()} - but ensuring that 'parent' is attached via
      * {@link #attachChildIfAbsent(SimpleConfigurationNode)}.
@@ -578,19 +597,15 @@ public class SimpleConfigurationNode implements ConfigurationNode {
         if (!(o instanceof SimpleConfigurationNode)) return false;
         SimpleConfigurationNode that = (SimpleConfigurationNode) o;
 
-        return this.attached == that.attached &&
-                Objects.equals(this.key, that.key) &&
+        return Objects.equals(this.key, that.key) &&
                 this.options.equals(that.options) &&
-                Objects.equals(this.parent, that.parent) &&
                 this.value.equals(that.value);
     }
 
     @Override
     public int hashCode() {
         int result = options.hashCode();
-        result = 31 * result + (attached ? 1 : 0);
-        result = 31 * result + (key != null ? key.hashCode() : 0);
-        result = 31 * result + (parent != null ? parent.hashCode() : 0);
+        result = 31 * result + Objects.hashCode(key);
         result = 31 * result + value.hashCode();
         return result;
     }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/commented/CommentedConfigurationNode.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/commented/CommentedConfigurationNode.java
@@ -56,4 +56,5 @@ public interface CommentedConfigurationNode extends ConfigurationNode {
     @NonNull @Override CommentedConfigurationNode mergeValuesFrom(@NonNull ConfigurationNode other);
     @NonNull @Override CommentedConfigurationNode getAppendedNode();
     @NonNull @Override CommentedConfigurationNode getNode(@NonNull Object... path);
+    @NonNull @Override CommentedConfigurationNode copy();
 }

--- a/configurate-core/src/main/java/ninja/leaping/configurate/commented/SimpleCommentedConfigurationNode.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/commented/SimpleCommentedConfigurationNode.java
@@ -47,6 +47,10 @@ public class SimpleCommentedConfigurationNode extends SimpleConfigurationNode im
         super(path, parent, options);
     }
 
+    protected SimpleCommentedConfigurationNode(SimpleConfigurationNode parent, SimpleConfigurationNode copyOf) {
+        super(parent, copyOf);
+    }
+
     @NonNull
     @Override
     public Optional<String> getComment() {
@@ -119,6 +123,20 @@ public class SimpleCommentedConfigurationNode extends SimpleConfigurationNode im
     @Override
     public SimpleCommentedConfigurationNode getAppendedNode() {
         return (SimpleCommentedConfigurationNode) super.getAppendedNode();
+    }
+
+    @NonNull
+    @Override
+    public SimpleCommentedConfigurationNode copy() {
+        return copy(null);
+    }
+
+    @NonNull
+    @Override
+    protected SimpleCommentedConfigurationNode copy(@Nullable SimpleConfigurationNode parent) {
+        SimpleCommentedConfigurationNode copy = new SimpleCommentedConfigurationNode(parent, this);
+        copy.comment.set(this.comment.get());
+        return copy;
     }
 
     @Override

--- a/configurate-core/src/main/java/ninja/leaping/configurate/util/MapFactories.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/util/MapFactories.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -254,6 +255,30 @@ public final class MapFactories {
         public Set<Entry<K, V>> entrySet() {
             synchronized (wrapped) {
                 return ImmutableSet.copyOf(wrapped.entrySet());
+            }
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            synchronized (wrapped) {
+                return wrapped.equals(obj);
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            synchronized (wrapped) {
+                return wrapped.hashCode();
+            }
+        }
+
+        @Override
+        public String toString() {
+            synchronized (wrapped) {
+                return "SynchronizedWrapper{backing=" + wrapped.toString() + '}';
             }
         }
     }

--- a/configurate-core/src/test/java/ninja/leaping/configurate/CopyTest.java
+++ b/configurate-core/src/test/java/ninja/leaping/configurate/CopyTest.java
@@ -1,0 +1,87 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja.leaping.configurate;
+
+import com.google.common.collect.ImmutableList;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CopyTest {
+
+    @Test
+    public void testSimpleCopy() {
+        ConfigurationNode node = SimpleConfigurationNode.root();
+        node.getNode("test").setValue(5);
+        node.getNode("section", "val1").setValue(true);
+        node.getNode("section", "val2").setValue("TEST");
+        ConfigurationNode list = node.getNode("section2", "alist");
+        list.getAppendedNode().setValue("value1");
+        list.getAppendedNode().setValue("value2");
+
+        ConfigurationNode copy = node.copy();
+
+        assertNotSame(node, copy);
+        assertEquals(node, copy);
+
+        assertFalse(node.isVirtual());
+        assertFalse(copy.isVirtual());
+
+        assertEquals(5, copy.getNode("test").getValue());
+        assertEquals(true, copy.getNode("section", "val1").getValue());
+        assertEquals("TEST", copy.getNode("section", "val2").getValue());
+        assertEquals(ImmutableList.of("value1", "value2"), copy.getNode("section2", "alist").getValue());
+
+        // change value on original
+        node.getNode("section", "val2").setValue("NOT TEST");
+
+        // test it's still the same on copy
+        assertEquals("TEST", copy.getNode("section", "val2").getValue());
+
+        // change value on copy
+        copy.getNode("section", "val2").setValue("zzz");
+
+        // test it's still the same on original
+        assertEquals("NOT TEST", node.getNode("section", "val2").getValue());
+    }
+
+    @Test
+    public void testCopyPaths() {
+        ConfigurationNode node = SimpleConfigurationNode.root();
+        node.getNode("test").setValue(5);
+        node.getNode("section", "val1").setValue(true);
+        node.getNode("section", "val2").setValue("TEST");
+
+        ConfigurationNode original = node.getNode("section");
+        ConfigurationNode copy = original.copy();
+
+        assertNotNull(original.getParent());
+        assertNull(copy.getParent());
+
+        ConfigurationNode originalVal = original.getNode("val1");
+        ConfigurationNode copyVal = copy.getNode("val1");
+
+        assertEquals(2, originalVal.getPath().length);
+        assertEquals(1, copyVal.getPath().length);
+
+        assertNotNull(originalVal.getParent());
+        assertNotNull(copyVal.getParent());
+        assertNotSame(originalVal.getParent(), copyVal.getParent());
+    }
+
+}


### PR DESCRIPTION
* Implemented `ConfigurationNode#copy` method
  * This is always a deep copy - shallow copying isn't sensible to implement, as it results in inconsistent state. Nodes always hold a reference to their parent, and should be the only instance which holds a direct reference to any child nodes.
* Also tidied up and fixed the implementations of equals, hashCode and toString for ConfigurationNode and ConfigValue subclasses, some of the old implementations just didn't work