### PR TITLE
Implement NodeWalker utility for traversing configuration structures

### DIFF
--- a/configurate-core/src/main/java/ninja/leaping/configurate/ConfigValue.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/ConfigValue.java
@@ -36,6 +36,8 @@ abstract class ConfigValue {
         this.holder = holder;
     }
 
+    abstract ValueType getType();
+
     /**
      * Gets the value encapsulated by this instance
      *

--- a/configurate-core/src/main/java/ninja/leaping/configurate/ConfigurationNode.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/ConfigurationNode.java
@@ -36,13 +36,13 @@ import java.util.function.Supplier;
  * <p>All aspects of a configurations structure are represented using instances of
  * {@link ConfigurationNode}, and the links between them.</p>
  *
- * <p>{@link ConfigurationNode}s can:</p>
+ * <p>{@link ConfigurationNode}s can hold different types of {@link ValueType values}. They can:</p>
  * <p>
  * <ul>
- *     <li>Hold a single "scalar" value</li>
- *     <li>Represent a "list" of child {@link ConfigurationNode}s - see {@link #hasListChildren()}</li>
- *     <li>Represent a "map" of child {@link ConfigurationNode}s - see {@link #hasMapChildren()}</li>
- *     <li>Hold no value at all</li>
+ *     <li>Hold a single "scalar" value ({@link ValueType#SCALAR})</li>
+ *     <li>Represent a "list" of child {@link ConfigurationNode}s ({@link ValueType#LIST})</li>
+ *     <li>Represent a "map" of child {@link ConfigurationNode}s ({@link ValueType#MAP})</li>
+ *     <li>Hold no value at all ({@link ValueType#NULL})</li>
  * </ul>
  *
  * <p>The overall configuration stems from a single "root" node, which is provided by the
@@ -136,18 +136,30 @@ public interface ConfigurationNode {
     ConfigurationOptions getOptions();
 
     /**
+     * Gets the value type of this node.
+     *
+     * @return The value type
+     */
+    @NonNull
+    ValueType getValueType();
+
+    /**
      * Gets if this node has "list children".
      *
      * @return if this node has children in the form of a list
      */
-    boolean hasListChildren();
+    default boolean hasListChildren() {
+        return getValueType() == ValueType.LIST;
+    }
 
     /**
      * Gets if this node has "map children".
      *
      * @return if this node has children in the form of a map
      */
-    boolean hasMapChildren();
+    default boolean hasMapChildren() {
+        return getValueType() == ValueType.MAP;
+    }
 
     /**
      * Gets the "list children" attached to this node, if it has any.

--- a/configurate-core/src/main/java/ninja/leaping/configurate/ListConfigValue.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/ListConfigValue.java
@@ -37,6 +37,11 @@ class ListConfigValue extends ConfigValue {
         super(holder);
     }
 
+    @Override
+    ValueType getType() {
+        return ValueType.LIST;
+    }
+
     ListConfigValue(SimpleConfigurationNode holder, Object startValue) {
         super(holder);
 

--- a/configurate-core/src/main/java/ninja/leaping/configurate/MapConfigValue.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/MapConfigValue.java
@@ -20,9 +20,7 @@ import com.google.common.base.Objects;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 
@@ -35,6 +33,11 @@ class MapConfigValue extends ConfigValue {
     public MapConfigValue(SimpleConfigurationNode holder) {
         super(holder);
         values = newMap();
+    }
+
+    @Override
+    ValueType getType() {
+        return ValueType.MAP;
     }
 
     private ConcurrentMap<Object, SimpleConfigurationNode> newMap() {

--- a/configurate-core/src/main/java/ninja/leaping/configurate/NullConfigValue.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/NullConfigValue.java
@@ -29,6 +29,11 @@ class NullConfigValue extends ConfigValue {
         super(holder);
     }
 
+    @Override
+    ValueType getType() {
+        return ValueType.NULL;
+    }
+
     @Nullable
     @Override
     public Object getValue() {

--- a/configurate-core/src/main/java/ninja/leaping/configurate/ScalarConfigValue.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/ScalarConfigValue.java
@@ -33,6 +33,11 @@ class ScalarConfigValue extends ConfigValue {
         super(holder);
     }
 
+    @Override
+    ValueType getType() {
+        return ValueType.SCALAR;
+    }
+
     @Nullable
     @Override
     public Object getValue() {

--- a/configurate-core/src/main/java/ninja/leaping/configurate/SimpleConfigurationNode.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/SimpleConfigurationNode.java
@@ -371,14 +371,10 @@ public class SimpleConfigurationNode implements ConfigurationNode {
         return !attached;
     }
 
+    @NonNull
     @Override
-    public boolean hasListChildren() {
-        return this.value instanceof ListConfigValue;
-    }
-
-    @Override
-    public boolean hasMapChildren() {
-        return this.value instanceof MapConfigValue;
+    public ValueType getValueType() {
+        return this.value.getType();
     }
 
     @NonNull

--- a/configurate-core/src/main/java/ninja/leaping/configurate/ValueType.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/ValueType.java
@@ -1,0 +1,55 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja.leaping.configurate;
+
+/**
+ * An enumeration of the types of value a {@link ConfigurationNode} can hold.
+ */
+public enum ValueType {
+
+    /**
+     * Represents a node that consists of a "single" scalar value
+     */
+    SCALAR,
+
+    /**
+     * Represents a node that consists of a number of child values, each mapped
+     * by a unique key.
+     */
+    MAP,
+
+    /**
+     * Represents a node that consists of a number of child values, in a specific
+     * order, each mapped by an index value.
+     */
+    LIST,
+
+    /**
+     * Represents a node that has no defined value.
+     */
+    NULL;
+
+    /**
+     * Gets if the type can hold child values.
+     *
+     * @return If the type can have children
+     */
+    public boolean canHaveChildren() {
+        return this == MAP || this == LIST;
+    }
+
+}

--- a/configurate-core/src/main/java/ninja/leaping/configurate/util/ConfigurationNodeWalker.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/util/ConfigurationNodeWalker.java
@@ -1,0 +1,330 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja.leaping.configurate.util;
+
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.Iterators;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.transformation.NodePath;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.function.BiConsumer;
+
+/**
+ * Represents a method for "walking" or traversing a {@link ConfigurationNode configuration}
+ * structure.
+ */
+public abstract class ConfigurationNodeWalker {
+
+    /**
+     * A {@link ConfigurationNodeWalker} that implements a breadth-first traversal over
+     * the configuration.
+     *
+     * <p>See <a href="https://en.wikipedia.org/wiki/Breadth-first_search">here</a> for more
+     * info.
+     */
+    public static final ConfigurationNodeWalker BREADTH_FIRST = new ConfigurationNodeWalker() {
+        @NonNull
+        @Override
+        public <T extends ConfigurationNode> Iterator<VisitedNode<T>> walkWithPath(@NonNull T start) {
+            return new BreadthFirstIterator<>(start);
+        }
+    };
+
+    /**
+     * A {@link ConfigurationNodeWalker} that implements a depth-first pre-order traversal over
+     * the configuration.
+     *
+     * <p>See <a href="https://en.wikipedia.org/wiki/Depth-first_search">here</a> for more
+     * info.
+     */
+    public static final ConfigurationNodeWalker DEPTH_FIRST_PRE_ORDER = new ConfigurationNodeWalker() {
+        @NonNull
+        @Override
+        public <T extends ConfigurationNode> Iterator<VisitedNode<T>> walkWithPath(@NonNull T start) {
+            return new DepthFirstPreOrderIterator<>(start);
+        }
+    };
+
+    /**
+     * A {@link ConfigurationNodeWalker} that implements a depth-first post-order traversal over
+     * the configuration.
+     *
+     * <p>See <a href="https://en.wikipedia.org/wiki/Depth-first_search">here</a> for more
+     * info.
+     */
+    public static final ConfigurationNodeWalker DEPTH_FIRST_POST_ORDER = new ConfigurationNodeWalker() {
+        @NonNull
+        @Override
+        public <T extends ConfigurationNode> Iterator<VisitedNode<T>> walkWithPath(@NonNull T start) {
+            return new DepthFirstPostOrderIterator<>(start);
+        }
+    };
+
+    /**
+     * Returns an iterator which will iterate over all paths and nodes in the
+     * configuration, in the order defined by the walker.
+     *
+     * @param start The node to start at
+     * @param <T> The node type
+     * @return An iterator of {@link VisitedNode}s
+     */
+    @NonNull
+    public abstract <T extends ConfigurationNode> Iterator<VisitedNode<T>> walkWithPath(@NonNull T start);
+
+
+    /**
+     * Returns an iterator which will iterate over all nodes in the
+     * configuration, in the order defined by the walker.
+     *
+     * @param start The node to start at
+     * @param <T> The node type
+     * @return An iterator of {@link ConfigurationNode}s
+     */
+    @NonNull
+    public <T extends ConfigurationNode> Iterator<T> walk(@NonNull T start) {
+        return Iterators.transform(walkWithPath(start), VisitedNode::getNode);
+    }
+
+    /**
+     * Walks the configuration, and calls the {@code consumer} for each path and node
+     * visited, in the order defined by the walker.
+     *
+     * @param start The node to start at
+     * @param consumer The consumer to accept the visited nodes
+     * @param <T> The node type
+     */
+    public <T extends ConfigurationNode> void walk(@NonNull T start, @NonNull BiConsumer<? super NodePath, ? super T> consumer) {
+        Iterator<VisitedNode<T>> it = walkWithPath(start);
+        while (it.hasNext()) {
+            VisitedNode<T> next = it.next();
+            consumer.accept(next.getPath(), next.getNode());
+        }
+    }
+
+    /**
+     * Encapsulates a given {@link ConfigurationNode node} visited during a
+     * traversal.
+     *
+     * @param <T> The node type
+     */
+    public interface VisitedNode<T extends ConfigurationNode> {
+
+        /**
+         * Gets the node that was visited.
+         *
+         * @return The visited node
+         */
+        @NonNull
+        T getNode();
+
+        /**
+         * Gets the path of the node that was visited.
+         *
+         * <p>Equivalent to calling {@link ConfigurationNode#getPath()} - except
+         * this method is likely to be more more efficient.</p>
+         *
+         * @return The path of the visited node
+         */
+        @NonNull
+        NodePath getPath();
+
+    }
+
+    private static Object[] calculatePath(Object[] path, Object childKey) {
+        if (path.length == 1 && path[0] == null) {
+            return new Object[]{childKey};
+        }
+
+        Object[] childPath = Arrays.copyOf(path, path.length + 1);
+        childPath[childPath.length - 1] = childKey;
+
+        return childPath;
+    }
+
+    private static <T extends ConfigurationNode> Iterator<VisitedNodeImpl<T>> getChildren(VisitedNodeImpl<T> from) {
+        T node = from.getNode();
+        switch (node.getValueType()) {
+            case LIST: {
+                Object[] path = from.getRawPath();
+                return Iterators.transform(node.getChildrenList().iterator(), child -> {
+                    Objects.requireNonNull(child);
+
+                    //noinspection unchecked
+                    T castedChild = ((T) child);
+                    Object[] childPath = calculatePath(path, child.getKey());
+
+                    return new VisitedNodeImpl<>(childPath, castedChild);
+                });
+            }
+            case MAP: {
+                Object[] path = from.getRawPath();
+                return Iterators.transform(node.getChildrenMap().entrySet().iterator(), child -> {
+                    Objects.requireNonNull(child);
+
+                    //noinspection unchecked
+                    T castedChild = ((T) child.getValue());
+                    Object[] childPath = calculatePath(path, child.getKey());
+
+                    return new VisitedNodeImpl<>(childPath, castedChild);
+                });
+            }
+            default:
+                return Collections.emptyIterator();
+        }
+    }
+
+    private static final class BreadthFirstIterator<N extends ConfigurationNode> implements Iterator<VisitedNode<N>> {
+        private final Queue<VisitedNodeImpl<N>> queue = new ArrayDeque<>();
+
+        BreadthFirstIterator(N root) {
+            this.queue.add(new VisitedNodeImpl<>(root.getPath(), root));
+        }
+
+        @Override
+        public boolean hasNext() {
+            return !this.queue.isEmpty();
+        }
+
+        @Override
+        public VisitedNode<N> next() {
+            VisitedNodeImpl<N> current = this.queue.remove();
+            Iterators.addAll(this.queue, getChildren(current));
+            return current;
+        }
+    }
+
+    private static final class DepthFirstPreOrderIterator<N extends ConfigurationNode> implements Iterator<VisitedNode<N>> {
+        private final Deque<Iterator<VisitedNodeImpl<N>>> stack = new ArrayDeque<>();
+
+        DepthFirstPreOrderIterator(N root) {
+            this.stack.push(Iterators.singletonIterator(new VisitedNodeImpl<>(root.getPath(), root)));
+        }
+
+        @Override
+        public boolean hasNext() {
+            return !this.stack.isEmpty();
+        }
+
+        @Override
+        public VisitedNode<N> next() {
+            Iterator<VisitedNodeImpl<N>> iterator = this.stack.getLast();
+            VisitedNodeImpl<N> result = iterator.next();
+            if (!iterator.hasNext()) {
+                this.stack.removeLast();
+            }
+            Iterator<VisitedNodeImpl<N>> childIterator = getChildren(result);
+            if (childIterator.hasNext()) {
+                this.stack.addLast(childIterator);
+            }
+            return result;
+        }
+    }
+
+    private static final class DepthFirstPostOrderIterator<N extends ConfigurationNode> extends AbstractIterator<VisitedNode<N>> {
+        private final ArrayDeque<NodeAndChildren> stack = new ArrayDeque<>();
+
+        DepthFirstPostOrderIterator(N root) {
+            this.stack.addLast(new NodeAndChildren(null, Iterators.singletonIterator(new VisitedNodeImpl<>(root.getPath(), root))));
+        }
+
+        @Override
+        protected VisitedNode<N> computeNext() {
+            while (!this.stack.isEmpty()) {
+                NodeAndChildren tail = this.stack.getLast();
+                if (tail.children.hasNext()) {
+                    VisitedNodeImpl<N> child = tail.children.next();
+                    this.stack.addLast(new NodeAndChildren(child, getChildren(child)));
+                } else {
+                    this.stack.removeLast();
+                    if (tail.node != null) {
+                        return tail.node;
+                    }
+                }
+            }
+            return endOfData();
+        }
+
+        private final class NodeAndChildren {
+            final VisitedNodeImpl<N> node;
+            final Iterator<VisitedNodeImpl<N>> children;
+
+            NodeAndChildren(VisitedNodeImpl<N> node, Iterator<VisitedNodeImpl<N>> children) {
+                this.node = node;
+                this.children = children;
+            }
+        }
+    }
+
+    private static final class VisitedNodeImpl<T extends ConfigurationNode> implements VisitedNode<T>, NodePath {
+        private final Object[] path;
+        private final T node;
+
+        VisitedNodeImpl(Object[] path, T node) {
+            this.path = path;
+            this.node = node;
+        }
+
+        Object[] getRawPath() {
+            return this.path;
+        }
+
+        // implement VisitedNode
+
+        @NonNull
+        public T getNode() {
+            return this.node;
+        }
+
+        @NonNull
+        @Override
+        public NodePath getPath() {
+            return this;
+        }
+
+        // implement NodePath
+
+        @Override
+        public Object get(int i) {
+            return this.path[i];
+        }
+
+        @Override
+        public int size() {
+            return this.path.length;
+        }
+
+        @Override
+        public Object[] getArray() {
+            return Arrays.copyOf(this.path, this.path.length);
+        }
+
+        @NonNull
+        @Override
+        public Iterator<Object> iterator() {
+            return Iterators.forArray(this.path);
+        }
+    }
+
+}

--- a/configurate-core/src/test/java/ninja/leaping/configurate/ConfigurationNodeWalkerTest.java
+++ b/configurate-core/src/test/java/ninja/leaping/configurate/ConfigurationNodeWalkerTest.java
@@ -1,0 +1,131 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja.leaping.configurate;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
+import org.junit.Test;
+import ninja.leaping.configurate.commented.CommentedConfigurationNode;
+import ninja.leaping.configurate.commented.SimpleCommentedConfigurationNode;
+import ninja.leaping.configurate.util.ConfigurationNodeWalker;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static org.junit.Assert.assertEquals;
+
+public class ConfigurationNodeWalkerTest {
+
+    private static final Function<ConfigurationNodeWalker.VisitedNode, String> PATH_TO_STRING = visitedNode -> {
+        return StreamSupport.stream(visitedNode.getPath().spliterator(), false)
+                .map(o -> {
+                    if (o == null) {
+                        return "root";
+                    }
+                    return o.toString();
+                })
+                .collect(Collectors.joining(" "));
+    };
+
+    private static final List<String> EXPECTED_BREADTH_FIRST_ORDER = ImmutableList.of(
+            "root",
+            "l1-1",
+            "l1-2",
+            "l1-1 l2-1",
+            "l1-1 l2-2",
+            "l1-1 l2-3",
+            "l1-1 l2-4",
+            "l1-2 l2-1",
+            "l1-1 l2-3 l3-1",
+            "l1-1 l2-3 l3-2",
+            "l1-2 l2-1 0",
+            "l1-2 l2-1 1",
+            "l1-2 l2-1 2"
+    );
+
+    private static final List<String> EXPECTED_DEPTH_FIRST_PRE_ORDER = ImmutableList.of(
+            "root",
+            "l1-1",
+            "l1-1 l2-1",
+            "l1-1 l2-2",
+            "l1-1 l2-3",
+            "l1-1 l2-3 l3-1",
+            "l1-1 l2-3 l3-2",
+            "l1-1 l2-4",
+            "l1-2",
+            "l1-2 l2-1",
+            "l1-2 l2-1 0",
+            "l1-2 l2-1 1",
+            "l1-2 l2-1 2"
+    );
+
+    private static final List<String> EXPECTED_DEPTH_FIRST_POST_ORDER = ImmutableList.of(
+            "l1-1 l2-1",
+            "l1-1 l2-2",
+            "l1-1 l2-3 l3-1",
+            "l1-1 l2-3 l3-2",
+            "l1-1 l2-3",
+            "l1-1 l2-4",
+            "l1-1",
+            "l1-2 l2-1 0",
+            "l1-2 l2-1 1",
+            "l1-2 l2-1 2",
+            "l1-2 l2-1",
+            "l1-2",
+            "root"
+    );
+
+    @Test
+    public void testWalker() {
+        CommentedConfigurationNode node = SimpleCommentedConfigurationNode.root();
+
+        node.getNode("l1-1").setValue(1);
+        node.getNode("l1-1", "l2-1").setValue(1);
+        node.getNode("l1-1", "l2-2").setValue(1);
+        node.getNode("l1-1", "l2-3", "l3-1").setValue(1);
+        node.getNode("l1-1", "l2-3", "l3-2").setValue(1);
+        node.getNode("l1-1", "l2-4").setValue(1);
+        node.getNode("l1-2").setValue(1);
+        node.getNode("l1-2", "l2-1").setValue(ImmutableList.of(1, 2, 3));
+
+        List<ConfigurationNodeWalker.VisitedNode<CommentedConfigurationNode>> breadthFirst = new ArrayList<>();
+        Iterators.addAll(breadthFirst, ConfigurationNodeWalker.BREADTH_FIRST.walkWithPath(node));
+
+        List<ConfigurationNodeWalker.VisitedNode<CommentedConfigurationNode>> depthFirstPre = new ArrayList<>();
+        Iterators.addAll(depthFirstPre, ConfigurationNodeWalker.DEPTH_FIRST_PRE_ORDER.walkWithPath(node));
+
+        List<ConfigurationNodeWalker.VisitedNode<CommentedConfigurationNode>> depthFirstPost = new ArrayList<>();
+        Iterators.addAll(depthFirstPost, ConfigurationNodeWalker.DEPTH_FIRST_POST_ORDER.walkWithPath(node));
+
+        assertEquals(13, breadthFirst.size());
+        assertEquals(13, depthFirstPre.size());
+        assertEquals(13, depthFirstPost.size());
+
+        List<String> breadthFirstOrder = breadthFirst.stream().map(PATH_TO_STRING).collect(Collectors.toList());
+        assertEquals(EXPECTED_BREADTH_FIRST_ORDER, breadthFirstOrder);
+
+        List<String> depthFirstPreOrder = depthFirstPre.stream().map(PATH_TO_STRING).collect(Collectors.toList());
+        assertEquals(EXPECTED_DEPTH_FIRST_PRE_ORDER, depthFirstPreOrder);
+
+        List<String> depthFirstPostOrder = depthFirstPost.stream().map(PATH_TO_STRING).collect(Collectors.toList());
+        assertEquals(EXPECTED_DEPTH_FIRST_POST_ORDER, depthFirstPostOrder);
+    }
+
+}


### PR DESCRIPTION
Provides a way to easily iterate over an entire configuration structure, or visit the child nodes in a specific sub section.

Use cases:

* most obvious I can think of is "printing" a configuration to a user
* searching for a specific value (less useful for *configurations*, but configurate can be used for reading and processing data too

I also intend to use this in SpongeCommon & GriefPrevention to exclude entries from being saved if they're already present & set to the same value in a "parent" config. Some sort of DFS post order traversal is needed to implement this behaviour, and I figured it made sense for that code to be in configurate itself, as opposed to being implemented in sub-projects.

Would appreciate any feedback :)