### PR TITLE
Don't check for ConfigurationOptions equality during ConfigurationNode equality check

### DIFF
--- a/configurate-core/src/main/java/ninja/leaping/configurate/SimpleConfigurationNode.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/SimpleConfigurationNode.java
@@ -601,9 +601,7 @@ public class SimpleConfigurationNode implements ConfigurationNode {
 
     @Override
     public int hashCode() {
-        int result = Objects.hashCode(key);
-        result = 31 * result + value.hashCode();
-        return result;
+        return Objects.hashCode(key) ^ value.hashCode();
     }
 
     @Override

--- a/configurate-core/src/main/java/ninja/leaping/configurate/SimpleConfigurationNode.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/SimpleConfigurationNode.java
@@ -596,7 +596,6 @@ public class SimpleConfigurationNode implements ConfigurationNode {
         SimpleConfigurationNode that = (SimpleConfigurationNode) o;
 
         return Objects.equals(this.key, that.key) &&
-                this.options.equals(that.options) &&
                 this.value.equals(that.value);
     }
 

--- a/configurate-core/src/main/java/ninja/leaping/configurate/SimpleConfigurationNode.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/SimpleConfigurationNode.java
@@ -595,13 +595,12 @@ public class SimpleConfigurationNode implements ConfigurationNode {
         if (!(o instanceof SimpleConfigurationNode)) return false;
         SimpleConfigurationNode that = (SimpleConfigurationNode) o;
 
-        return Objects.equals(this.key, that.key) &&
-                this.value.equals(that.value);
+        return Objects.equals(this.key, that.key) && Objects.equals(this.value, that.value);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(key) ^ value.hashCode();
+        return Objects.hashCode(key) ^ Objects.hashCode(value);
     }
 
     @Override

--- a/configurate-core/src/main/java/ninja/leaping/configurate/SimpleConfigurationNode.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/SimpleConfigurationNode.java
@@ -601,8 +601,7 @@ public class SimpleConfigurationNode implements ConfigurationNode {
 
     @Override
     public int hashCode() {
-        int result = options.hashCode();
-        result = 31 * result + Objects.hashCode(key);
+        int result = Objects.hashCode(key);
         result = 31 * result + value.hashCode();
         return result;
     }


### PR DESCRIPTION
I was expecting there to be more to this, but it doesn't appear as though there are any changes required elsewhere to fix this.

Closes #114 