### PR TITLE
Ensure the node type is set when loading empty lists and objects

### DIFF
--- a/configurate-gson/src/main/java/ninja/leaping/configurate/gson/GsonConfigurationLoader.java
+++ b/configurate-gson/src/main/java/ninja/leaping/configurate/gson/GsonConfigurationLoader.java
@@ -17,6 +17,8 @@
 package ninja.leaping.configurate.gson;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.JsonParseException;
 import com.google.gson.stream.JsonReader;
@@ -170,14 +172,21 @@ public class GsonConfigurationLoader extends AbstractConfigurationLoader<Configu
 
     private void parseArray(JsonReader parser, ConfigurationNode node) throws IOException {
         parser.beginArray();
+
+        boolean written = false;
         JsonToken token;
         while ((token = parser.peek()) != null) {
             switch (token) {
                 case END_ARRAY:
                     parser.endArray();
+                    // ensure the type is preserved
+                    if (!written) {
+                        node.setValue(ImmutableList.of());
+                    }
                     return;
                 default:
                     parseValue(parser, node.getAppendedNode());
+                    written = true;
             }
         }
         throw new JsonParseException("Reached end of stream with unclosed array at!");
@@ -186,15 +195,22 @@ public class GsonConfigurationLoader extends AbstractConfigurationLoader<Configu
 
     private void parseObject(JsonReader parser, ConfigurationNode node) throws IOException {
         parser.beginObject();
+
+        boolean written = false;
         JsonToken token;
         while ((token = parser.peek()) != null) {
             switch (token) {
                 case END_OBJECT:
                 case END_DOCUMENT:
                     parser.endObject();
+                    // ensure the type is preserved
+                    if (!written) {
+                        node.setValue(ImmutableMap.of());
+                    }
                     return;
                 case NAME:
                     parseValue(parser, node.getNode(parser.nextName()));
+                    written = true;
                     break;
                 default:
                     throw new JsonParseException("Received improper object value " + token);

--- a/configurate-hocon/src/main/java/ninja/leaping/configurate/hocon/HoconConfigurationLoader.java
+++ b/configurate-hocon/src/main/java/ninja/leaping/configurate/hocon/HoconConfigurationLoader.java
@@ -17,6 +17,7 @@
 package ninja.leaping.configurate.hocon;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.typesafe.config.Config;
@@ -184,18 +185,23 @@ public class HoconConfigurationLoader extends AbstractConfigurationLoader<Commen
         }
         switch (value.valueType()) {
             case OBJECT:
-                if (((ConfigObject) value).isEmpty()) {
+                ConfigObject object = (ConfigObject) value;
+                if (object.isEmpty()) {
                     node.setValue(ImmutableMap.of());
                 } else {
-                    for (Map.Entry<String, ConfigValue> ent : ((ConfigObject) value).entrySet()) {
+                    for (Map.Entry<String, ConfigValue> ent : object.entrySet()) {
                         readConfigValue(ent.getValue(), node.getNode(ent.getKey()));
                     }
                 }
                 break;
             case LIST:
-                List<ConfigValue> values = (ConfigList) value;
-                for (int i = 0; i < values.size(); ++i) {
-                    readConfigValue(values.get(i), node.getNode(i));
+                ConfigList list = (ConfigList) value;
+                if (list.isEmpty()) {
+                    node.setValue(ImmutableList.of());
+                } else {
+                    for (int i = 0; i < list.size(); ++i) {
+                        readConfigValue(list.get(i), node.getNode(i));
+                    }
                 }
                 break;
             case NULL:

--- a/configurate-json/src/main/java/ninja/leaping/configurate/json/JSONConfigurationLoader.java
+++ b/configurate-json/src/main/java/ninja/leaping/configurate/json/JSONConfigurationLoader.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.ConfigurationOptions;
@@ -191,26 +193,38 @@ public class JSONConfigurationLoader extends AbstractConfigurationLoader<Configu
     }
 
     private static void parseArray(JsonParser parser, ConfigurationNode node) throws IOException {
+        boolean written = false;
         JsonToken token;
         while ((token = parser.nextToken()) != null) {
             switch (token) {
                 case END_ARRAY:
+                    // ensure the type is preserved
+                    if (!written) {
+                        node.setValue(ImmutableList.of());
+                    }
                     return;
                 default:
                     parseValue(parser, node.getAppendedNode());
+                    written = true;
             }
         }
         throw new JsonParseException(parser, "Reached end of stream with unclosed array!", parser.getCurrentLocation());
     }
 
     private static void parseObject(JsonParser parser, ConfigurationNode node) throws IOException {
+        boolean written = false;
         JsonToken token;
         while ((token = parser.nextToken()) != null) {
             switch (token) {
                 case END_OBJECT:
+                    // ensure the type is preserved
+                    if (!written) {
+                        node.setValue(ImmutableMap.of());
+                    }
                     return;
                 default:
                     parseValue(parser, node.getNode(parser.getCurrentName()));
+                    written = true;
             }
         }
         throw new JsonParseException(parser, "Reached end of stream with unclosed array!", parser.getCurrentLocation());


### PR DESCRIPTION
Relates to #93, #97 

Waiting for a test case before merging. Want to clarify that this does indeed fix the issue reported.