### PR TITLE
Don't register a TypeSerializer for arbitrary Number subclasses

### DIFF
--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializers.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializers.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -69,7 +70,7 @@ public class TypeSerializers {
         DEFAULT_SERIALIZERS.registerType(TypeToken.of(URL.class), new URLSerializer());
         DEFAULT_SERIALIZERS.registerType(TypeToken.of(UUID.class), new UUIDSerializer());
         DEFAULT_SERIALIZERS.registerPredicate(input -> input.getRawType().isAnnotationPresent(ConfigSerializable.class), new AnnotatedObjectSerializer());
-        DEFAULT_SERIALIZERS.registerType(TypeToken.of(Number.class), new NumberSerializer());
+        DEFAULT_SERIALIZERS.registerPredicate(NumberSerializer.getPredicate(), new NumberSerializer());
         DEFAULT_SERIALIZERS.registerType(TypeToken.of(String.class), new StringSerializer());
         DEFAULT_SERIALIZERS.registerType(TypeToken.of(Boolean.class), new BooleanSerializer());
         DEFAULT_SERIALIZERS.registerType(new TypeToken<Map<?, ?>>() {}, new MapSerializer());
@@ -91,6 +92,20 @@ public class TypeSerializers {
     }
 
     private static class NumberSerializer implements TypeSerializer<Number> {
+
+        public static Predicate<TypeToken<Number>> getPredicate() {
+            return (type) -> {
+                type = type.wrap();
+                Class<?> clazz = type.getRawType();
+                return Integer.class.equals(clazz)
+                        || Long.class.equals(clazz)
+                        || Short.class.equals(clazz)
+                        || Byte.class.equals(clazz)
+                        || Float.class.equals(clazz)
+                        || Double.class.equals(clazz);
+            };
+        }
+
         @Override
         public Number deserialize(@NonNull TypeToken<?> type, @NonNull ConfigurationNode value) throws InvalidTypeException {
             type = type.wrap();

--- a/configurate-core/src/test/java/ninja/leaping/configurate/objectmapping/TypeSerializersTest.java
+++ b/configurate-core/src/test/java/ninja/leaping/configurate/objectmapping/TypeSerializersTest.java
@@ -80,6 +80,13 @@ public class TypeSerializersTest {
     }
 
     @Test
+    public void testSerializeCustomNumber() throws ObjectMappingException {
+        final TypeToken<CustomNumber> customNumberType = TypeToken.of(CustomNumber.class);
+        final TypeSerializer<?> serializer = SERIALIZERS.get(customNumberType);
+        assertNull("Type serializer for custom number class should be null!", serializer);
+    }
+
+    @Test
     public void testBooleanSerializer() throws ObjectMappingException {
         final TypeToken<Boolean> booleanType = TypeToken.of(Boolean.class);
 
@@ -315,5 +322,28 @@ public class TypeSerializersTest {
         patternSerializer.serialize(patternType, testPattern, serializeTo);
         assertEquals("(na )+batman", serializeTo.getValue());
         assertEquals(testPattern.pattern(), patternSerializer.deserialize(patternType, serializeTo).pattern());
+    }
+
+    private static class CustomNumber extends Number {
+
+        @Override
+        public int intValue() {
+            return 0;
+        }
+
+        @Override
+        public long longValue() {
+            return 0;
+        }
+
+        @Override
+        public float floatValue() {
+            return 0;
+        }
+
+        @Override
+        public double doubleValue() {
+            return 0;
+        }
     }
 }


### PR DESCRIPTION
We have no way way to construct arbitrary subclasses of Number. By
registering a predicate that accepts only kown subclasses, we ensure
that users attempting to serialize an unknown Number subclass get a
proper exception, instead of a silent deserialization failure.

Fixes #121