### PR TITLE
Add "addition strategies" to `newChild()` for #132

### DIFF
--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializerCollection.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializerCollection.java
@@ -20,7 +20,9 @@ import com.google.common.base.Preconditions;
 import com.google.common.reflect.TypeToken;
 
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;

--- a/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializerCollection.java
+++ b/configurate-core/src/main/java/ninja/leaping/configurate/objectmapping/serialize/TypeSerializerCollection.java
@@ -64,7 +64,7 @@ public class TypeSerializerCollection {
     public <T> TypeSerializerCollection registerType(TypeToken<T> type, TypeSerializer<? super T> serializer) {
         Preconditions.checkNotNull(type, "type");
         Preconditions.checkNotNull(serializer, "serializer");
-        serializers.add(0, new RegisteredSerializer(type, serializer));
+        serializers.add(new RegisteredSerializer(type, serializer));
         typeMatches.clear();
         return this;
     }
@@ -81,7 +81,7 @@ public class TypeSerializerCollection {
     public <T> TypeSerializerCollection registerPredicate(Predicate<TypeToken<T>> test, TypeSerializer<? super T> serializer) {
         Preconditions.checkNotNull(test, "test");
         Preconditions.checkNotNull(serializer, "serializer");
-        serializers.add(0, new RegisteredSerializer((Predicate) test, serializer));
+        serializers.add(new RegisteredSerializer((Predicate) test, serializer));
         typeMatches.clear();
         return this;
     }


### PR DESCRIPTION
See https://github.com/SpongePowered/configurate/issues/132#issuecomment-478535831

Can't say I'm really a fan of the serialiser that tries to sort based on dependencies. I added tests but it feels like a horrible hack. I may just remove it and have first/last wins and suggest we reconsider for 4.x. It's not really open to others extending this due to `RegisteredSerializer` being private, we could open that up easily but I opted not to for the moment. Thoughts on that are welcome.

I'm sure that this will get nit-picked to death because this is a relatively quick thing I threw together and I'm sure that I'm rubbish at naming things - but I'd like some comment on the actual function please.