### PR TITLE
AnnotatedObjectSerializer no longer removes important type information

### DIFF
--- a/configurate-core/src/main/java/org/spongepowered/configurate/objectmapping/GuiceObjectMapper.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/objectmapping/GuiceObjectMapper.java
@@ -16,9 +16,11 @@
  */
 package org.spongepowered.configurate.objectmapping;
 
+import com.google.common.reflect.TypeToken;
 import com.google.inject.ConfigurationException;
 import com.google.inject.Injector;
 import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
@@ -28,6 +30,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  *
  * <p>Instances of this object should be reached using a {@link GuiceObjectMapperFactory}.</p>
  */
+@SuppressWarnings({"UnstableApiUsage", "unchecked"})
 class GuiceObjectMapper<T> extends ObjectMapper<T> {
     private final Injector injector;
     private final Key<T> typeKey;
@@ -42,6 +45,18 @@ class GuiceObjectMapper<T> extends ObjectMapper<T> {
         super(clazz);
         this.injector = injector;
         this.typeKey = Key.get(clazz);
+    }
+
+    /**
+     * Create a new object mapper of a given type
+     *
+     * @param type The type this object mapper will work with
+     * @throws ObjectMappingException if the provided class is in someway invalid
+     */
+    protected GuiceObjectMapper(@NonNull Injector injector, @NonNull TypeToken<T> type) throws ObjectMappingException {
+        super((Class<T>) type.getRawType());
+        this.injector = injector;
+        this.typeKey = Key.get((TypeLiteral<T>) TypeLiteral.get(type.getType()));
     }
 
     @Override

--- a/configurate-core/src/main/java/org/spongepowered/configurate/objectmapping/GuiceObjectMapperFactory.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/objectmapping/GuiceObjectMapperFactory.java
@@ -19,6 +19,7 @@ package org.spongepowered.configurate.objectmapping;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.reflect.TypeToken;
 import com.google.inject.Injector;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -35,11 +36,11 @@ import static java.util.Objects.requireNonNull;
  */
 @Singleton
 public final class GuiceObjectMapperFactory implements ObjectMapperFactory {
-    private final LoadingCache<Class<?>, ObjectMapper<?>> cache = CacheBuilder.newBuilder()
+    private final LoadingCache<TypeToken<?>, ObjectMapper<?>> cache = CacheBuilder.newBuilder()
             .weakKeys().maximumSize(512)
-            .build(new CacheLoader<Class<?>, ObjectMapper<?>>() {
+            .build(new CacheLoader<TypeToken<?>, ObjectMapper<?>>() {
                 @Override
-                public ObjectMapper<?> load(Class<?> key) throws Exception {
+                public ObjectMapper<?> load(TypeToken<?> key) throws Exception {
                     return new GuiceObjectMapper<>(injector, key);
                 }
             });
@@ -51,10 +52,15 @@ public final class GuiceObjectMapperFactory implements ObjectMapperFactory {
         this.injector = baseInjector;
     }
 
+    @Override
+    public @NonNull <T> ObjectMapper<T> getMapper(@NonNull Class<T> type) throws ObjectMappingException {
+        return getMapper(TypeToken.of(type));
+    }
+
     @NonNull
     @Override
     @SuppressWarnings("unchecked")
-    public <T> ObjectMapper<T> getMapper(@NonNull Class<T> type) throws ObjectMappingException {
+    public <T> ObjectMapper<T> getMapper(@NonNull TypeToken<T> type) throws ObjectMappingException {
         requireNonNull(type, "type");
         try {
             return (ObjectMapper<T>) cache.get(type);

--- a/configurate-core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectMapperFactory.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectMapperFactory.java
@@ -16,11 +16,13 @@
  */
 package org.spongepowered.configurate.objectmapping;
 
+import com.google.common.reflect.TypeToken;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * A factory to produce {@link ObjectMapper} instances
  */
+@SuppressWarnings({"UnstableApiUsage", "unchecked"})
 public interface ObjectMapperFactory {
 
     /**
@@ -34,4 +36,16 @@ public interface ObjectMapperFactory {
     @NonNull
     <T> ObjectMapper<T> getMapper(@NonNull Class<T> type) throws ObjectMappingException;
 
+    /**
+     * Creates an {@link ObjectMapper} for the given type.
+     *
+     * @param type The type
+     * @param <T> The type
+     * @return An object mapper
+     * @throws ObjectMappingException If an exception occured whilst mapping
+     */
+    @NonNull
+    default <T> ObjectMapper<T> getMapper(@NonNull TypeToken<T> type) throws ObjectMappingException {
+        return this.getMapper((Class<T>) type.getRawType());
+    }
 }


### PR DESCRIPTION
This PR modifies AnnotatedObjectSerializer so that important generic type information is not lost.

Some guice bindings require additional generic type information which is lost when you convert the TypeToken to a class.