### PR TITLE
Auto-reloading configurations

### DIFF
--- a/buildSrc/src/main/kotlin/org/spongepowered/configurate/build/ConfigurateDevPlugin.kt
+++ b/buildSrc/src/main/kotlin/org/spongepowered/configurate/build/ConfigurateDevPlugin.kt
@@ -55,6 +55,7 @@ class ConfigurateDevPlugin : Plugin<Project> {
                     }
                 }
                 val opts = it.options
+                opts.encoding = "UTF-8"
                 if (opts is StandardJavadocDocletOptions) {
                     opts.links(
                             "https://guava.dev/releases/25.1-jre/api/docs/"

--- a/buildSrc/src/main/kotlin/org/spongepowered/configurate/build/ConfigurateDevPlugin.kt
+++ b/buildSrc/src/main/kotlin/org/spongepowered/configurate/build/ConfigurateDevPlugin.kt
@@ -2,6 +2,7 @@ package org.spongepowered.configurate.build
 
 import net.minecrell.gradle.licenser.LicenseExtension
 import net.minecrell.gradle.licenser.Licenser
+import org.gradle.api.GradleException
 import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -45,7 +46,14 @@ class ConfigurateDevPlugin : Plugin<Project> {
                 it.targetCompatibility = JavaVersion.VERSION_1_8
             }
 
+
             tasks.withType(Javadoc::class.java).configureEach {
+                it.doFirst {_ ->
+                    if (JavaVersion.toVersion(it.toolChain.version) == JavaVersion.VERSION_12) {
+                        throw GradleException("Javadoc cannot be generated on JDK 12 -- " +
+                            "see https://bugs.openjdk.java.net/browse/JDK-8222091")
+                    }
+                }
                 val opts = it.options
                 if (opts is StandardJavadocDocletOptions) {
                     opts.links(

--- a/buildSrc/src/main/kotlin/org/spongepowered/configurate/build/ConfigurateDevPlugin.kt
+++ b/buildSrc/src/main/kotlin/org/spongepowered/configurate/build/ConfigurateDevPlugin.kt
@@ -22,15 +22,18 @@ class ConfigurateDevPlugin : Plugin<Project> {
                 apply(ConfiguratePublishingPlugin::class.java)
             }
 
-            tasks.withType(JavaCompile::class.java) {
+            tasks.withType(JavaCompile::class.java).configureEach {
                 with(it.options) {
                     compilerArgs.addAll(listOf("-Xlint:all", "-Xlint:-path", "-Xlint:-serial", "-parameters"))
+                    if (JavaVersion.toVersion(it.toolChain.version).isJava9Compatible) {
+                        compilerArgs.addAll(listOf("--release", "8"))
+                    }
                     isDeprecation = true
                     encoding = "UTF-8"
                 }
             }
 
-            tasks.withType(AbstractArchiveTask::class.java) {
+            tasks.withType(AbstractArchiveTask::class.java).configureEach {
                 it.isPreserveFileTimestamps = false
                 it.isReproducibleFileOrder = true
             }
@@ -42,7 +45,7 @@ class ConfigurateDevPlugin : Plugin<Project> {
                 it.targetCompatibility = JavaVersion.VERSION_1_8
             }
 
-            tasks.withType(Javadoc::class.java) {
+            tasks.withType(Javadoc::class.java).configureEach {
                 val opts = it.options
                 if (opts is StandardJavadocDocletOptions) {
                     opts.links(
@@ -68,7 +71,7 @@ class ConfigurateDevPlugin : Plugin<Project> {
                 add("testRuntimeOnly", "org.junit.jupiter:junit-jupiter-engine:5.2.0")
             }
 
-            tasks.withType(Test::class.java) {
+            tasks.withType(Test::class.java).configureEach {
                 it.useJUnitPlatform()
             }
 

--- a/configurate-core/build.gradle.kts
+++ b/configurate-core/build.gradle.kts
@@ -13,5 +13,4 @@ dependencies {
   api("com.google.guava:guava:25.1-jre")
   "guiceSupportImplementation"("com.google.inject:guice:4.2.3")
   api("org.checkerframework:checker-qual:2.4.0")
-
 }

--- a/configurate-core/src/main/java/org/spongepowered/configurate/AbstractConfigurationNode.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/AbstractConfigurationNode.java
@@ -100,17 +100,17 @@ abstract class AbstractConfigurationNode<N extends ScopedConfigurationNode<N>, A
      * Handles the copying of applied defaults, if enabled.
      *
      * @param defValue the default value
-     * @param <T> the value type
+     * @param <V> the value type
      * @return the same value
      */
-    private <T> T storeDefault(T defValue) {
+    private <V> V storeDefault(V defValue) {
         if (defValue != null && getOptions().shouldCopyDefaults()) {
             setValue(defValue);
         }
         return defValue;
     }
 
-    private <T> T storeDefault(TypeToken<T> type, T defValue) throws ObjectMappingException {
+    private <V> V storeDefault(TypeToken<V> type, V defValue) throws ObjectMappingException {
         if (defValue != null && getOptions().shouldCopyDefaults()) {
             setValue(type, defValue);
         }
@@ -234,6 +234,9 @@ abstract class AbstractConfigurationNode<N extends ScopedConfigurationNode<N>, A
         // if the value to be set is a configuration node already, unwrap and store the raw data
         if (newValue instanceof ConfigurationNode) {
             ConfigurationNode newValueAsNode = (ConfigurationNode) newValue;
+            if (newValueAsNode == this) { // this would be a no-op whoop
+                return self();
+            }
 
             if (newValueAsNode.isList()) {
                 // handle list

--- a/configurate-core/src/main/java/org/spongepowered/configurate/loader/AbstractConfigurationLoader.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/loader/AbstractConfigurationLoader.java
@@ -22,6 +22,8 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.ConfigurationOptions;
+import org.spongepowered.configurate.ScopedConfigurationNode;
+import org.spongepowered.configurate.reference.ConfigurationReference;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -47,7 +49,7 @@ import java.util.concurrent.Callable;
  *
  * @param <N> The {@link ConfigurationNode} type produced by the loader
  */
-public abstract class AbstractConfigurationLoader<N extends ConfigurationNode> implements ConfigurationLoader<N> {
+public abstract class AbstractConfigurationLoader<N extends ScopedConfigurationNode<N>> implements ConfigurationLoader<N> {
 
     /**
      * The escape sequence used by Configurate to separate comment lines
@@ -116,6 +118,11 @@ public abstract class AbstractConfigurationLoader<N extends ConfigurationNode> i
     @NonNull
     public CommentHandler getDefaultCommentHandler() {
         return this.commentHandlers[0];
+    }
+
+    @Override
+    public ConfigurationReference<N> loadToReference() throws IOException {
+        return ConfigurationReference.createFixed(this);
     }
 
     @NonNull

--- a/configurate-core/src/main/java/org/spongepowered/configurate/loader/AbstractConfigurationLoader.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/loader/AbstractConfigurationLoader.java
@@ -39,6 +39,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.concurrent.Callable;
+import java.util.function.UnaryOperator;
 
 /**
  * Base class for many stream-based configuration loaders. This class provides conversion from a variety of input
@@ -379,6 +380,19 @@ public abstract class AbstractConfigurationLoader<N extends ScopedConfigurationN
         @NonNull
         public T setDefaultOptions(@NonNull ConfigurationOptions defaultOptions) {
             this.defaultOptions = Objects.requireNonNull(defaultOptions, "defaultOptions");
+            return self();
+        }
+
+        /**
+         * Sets the default configuration options to be used by the resultant loader by providing
+         * a function which takes the current default options and applies any applicable changes.
+         *
+         * @param defaultOptions to transform the existing default options
+         * @return This builder (for chaining)
+         */
+        @NonNull
+        public T setDefaultOptions(@NonNull UnaryOperator<ConfigurationOptions> defaultOptions) {
+            this.defaultOptions = Objects.requireNonNull(defaultOptions.apply(this.defaultOptions), "defaultOptions (updated)");
             return self();
         }
 

--- a/configurate-core/src/main/java/org/spongepowered/configurate/loader/ConfigurationLoader.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/loader/ConfigurationLoader.java
@@ -19,8 +19,11 @@ package org.spongepowered.configurate.loader;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.ConfigurationOptions;
+import org.spongepowered.configurate.reference.ConfigurationReference;
 
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.function.Function;
 
 /**
  * Represents an object which can load and save {@link ConfigurationNode} objects in a specific
@@ -57,6 +60,16 @@ public interface ConfigurationLoader<N extends ConfigurationNode> {
     default N load() throws IOException {
         return load(getDefaultOptions());
     }
+
+    /**
+     * Attempts to load data from the defined source into a {@link ConfigurationReference}.
+     * The returned reference will not reload automatically.
+     *
+     * @return The created reference
+     * @throws IOException when an error occurs within the loader
+     * @see org.spongepowered.configurate.reference.WatchServiceListener#listenToConfiguration(Function, Path) to create an auto-reloading configuration.
+     */
+    ConfigurationReference<N> loadToReference() throws IOException;
 
     /**
      * Attempts to load a {@link ConfigurationNode} using this loader, from the defined source.

--- a/configurate-core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectMapper.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectMapper.java
@@ -98,6 +98,7 @@ public class ObjectMapper<T> {
     /**
      * Creates a new object mapper bound to the given object.
      *
+     * @param type The generic type of the object
      * @param obj The object
      * @param <T> The object type
      * @return An appropriate object mapper instance.

--- a/configurate-core/src/main/java/org/spongepowered/configurate/reactive/Processor.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/reactive/Processor.java
@@ -18,6 +18,7 @@ package org.spongepowered.configurate.reactive;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
 
 /**
@@ -35,12 +36,23 @@ import java.util.function.Function;
 public interface Processor<I, O> extends Publisher<O>, Subscriber<I> {
     /**
      * Create a {@link Processor} instance that simply broadcasts submitted values to its
-     * subscribers
+     * subscribers. Broadcasts will occur on the common pool.
      *
      * @param <V> The type
      * @return A new processor instance
      */
     static <V> Processor.Iso<V> create() {
+        return new ProcessorBase<>();
+    }
+
+    /**
+     * Create a {@link Processor} instance that simply broadcasts submitted values to its
+     * subscribers
+     *
+     * @param <V> The type
+     * @return A new processor instance
+     */
+    static <V> Processor.Iso<V> create(ForkJoinPool executor) {
         return new ProcessorBase<>();
     }
 

--- a/configurate-core/src/main/java/org/spongepowered/configurate/reactive/Processor.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/reactive/Processor.java
@@ -44,6 +44,10 @@ public interface Processor<I, O> extends Publisher<O>, Subscriber<I> {
     static <V> Processor.Iso<V> create() {
         return new ProcessorBase<>();
     }
+    
+    static <V> Processor.TransactionalIso<V> createTransactional() {
+        return new TransactionalProcessorBase<>();
+    }
 
     /**
      * Create a {@link Processor} instance that simply broadcasts submitted values to its
@@ -102,4 +106,13 @@ public interface Processor<I, O> extends Publisher<O>, Subscriber<I> {
             submit(element);
         }
     }
+    
+    interface Transactional<I, O> extends Processor<I, O>, Publisher<O>, TransactionalSubscriber<I> {
+
+    }
+    
+    interface TransactionalIso<V> extends Transactional<V, V>, Iso<V> {
+
+    }
+    
 }

--- a/configurate-core/src/main/java/org/spongepowered/configurate/reactive/Publisher.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/reactive/Publisher.java
@@ -50,4 +50,20 @@ public interface Publisher<V> {
     default <R> Publisher<R> map(Function<? super V, ? extends R> mapper) {
         return new ProcessorBase.Mapped<>(mapper, this);
     }
+    
+    default <R> Cached<R> cache() {
+        return cache(null);
+    }
+    
+    default <R> Cached<R> cache(R initialValue) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * A publisher that caches the last value received
+     * @param <V> value type
+     */
+    interface Cached<V> extends Publisher<V> {
+       V get();
+    }
 }

--- a/configurate-core/src/main/java/org/spongepowered/configurate/reactive/TransactionFailedException.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/reactive/TransactionFailedException.java
@@ -1,0 +1,28 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spongepowered.configurate.reactive;
+
+public class TransactionFailedException extends Exception {
+    private static final long serialVersionUID = -3726752009864775844L;
+    public TransactionFailedException() {
+        super();
+    }
+    
+    public TransactionFailedException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/configurate-core/src/main/java/org/spongepowered/configurate/reactive/TransactionalProcessorBase.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/reactive/TransactionalProcessorBase.java
@@ -1,0 +1,68 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spongepowered.configurate.reactive;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Iterator;
+
+class TransactionalProcessorBase<V> extends ProcessorBase<V> implements Processor.TransactionalIso<V> {
+
+    @Override
+    public void beginTransaction(final V newValue) throws TransactionFailedException {
+        if (this.subscriberCount.get() >= 0) {
+            boolean handled = false;
+            for (Iterator<Registration> it = this.registrations.iterator(); it.hasNext(); ) {
+                Registration reg = it.next();
+                try {
+                    handled = true;
+                    reg.subscriber.submit(newValue);
+                } catch (Throwable t) {
+                    it.remove();
+                    subscriberCount.getAndDecrement();
+                    reg.subscriber.onError(t);
+                }
+            }
+            if (!handled) {
+                @Nullable Subscriber<V> fallback = this.fallbackHandler;
+                if (fallback != null) {
+                    fallback.submit(newValue);
+                }
+            }
+        }
+
+    }
+
+    @Override
+    public void commit() {
+        this.registrations.forEach(r -> {
+            if (r.subscriber instanceof TransactionalSubscriber<?>) {
+                ((TransactionalSubscriber<?>) r.subscriber).commit();
+            }
+        });
+
+    }
+
+    @Override
+    public void rollback() {
+        this.registrations.forEach(r -> {
+            /*if (r instanceof TransactionalWrapperRegistration) {
+                ((TransactionalSubscriber<?>) r.subscriber).rollback();
+            }*/
+        });
+    }
+}

--- a/configurate-core/src/main/java/org/spongepowered/configurate/reactive/TransactionalSubscriber.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/reactive/TransactionalSubscriber.java
@@ -1,0 +1,62 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spongepowered.configurate.reactive;
+
+/**
+ * A subscriber that is transaction-aware. As opposed to standard Subscribers which receive simple
+ * value events, transactional subscribers receive a series of events: first, a {@code
+ * beginTransaction}, followed by a {@code commit} or {@code rollback}.
+ *
+ * @param <V> The value handled by this subscriber
+ */
+public interface TransactionalSubscriber<V> extends Subscriber<V> {
+    @Override
+    default void submit(V item) {
+        try {
+            beginTransaction(item);
+            commit();
+        } catch (TransactionFailedException ex) {
+            rollback();
+        }
+    }
+
+    /**
+     * Receive a new value, and validate it. The received value must not be made available outside
+     * of to other transaction-aware viewers until {@link #commit()} has been called.
+     *
+     * @param newValue The new value
+     * @throws TransactionFailedException if the new value does not validate
+     */
+    void beginTransaction(V newValue) throws TransactionFailedException;
+
+    /**
+     * Expose a transaction's result
+     * <p>
+     * This method will be called on all transactional subscribers in a system have received and
+     * validated any new data. Calling this method when a transaction is not in progress should
+     * result in a noop.
+     */
+    void commit();
+
+    /**
+     * Called when a transaction has failed, to revert any prepared changes
+     * <p>
+     * This event indicates that it is safe for clients to discard any prepared information from an
+     * in-progress transaction. If there is no transaction in progress, this must be a no-op.
+     */
+    void rollback();
+}

--- a/configurate-core/src/main/java/org/spongepowered/configurate/reference/ConfigurationReference.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/reference/ConfigurationReference.java
@@ -215,7 +215,9 @@ public interface ConfigurationReference<N extends ConfigurationNode> extends Aut
      * @return A deserializing reference to the node at the given path
      * @throws ObjectMappingException if a type serializer could not be found for the provided type
      */
-    <T> ValueReference<T, N> referenceTo(TypeToken<T> type, NodePath path) throws ObjectMappingException;
+    default <T> ValueReference<T, N> referenceTo(TypeToken<T> type, NodePath path) throws ObjectMappingException {
+        return referenceTo(type, path, null);
+    }
 
     /**
      * Create a reference to the node at the provided path. The value will be deserialized according to type of the
@@ -230,10 +232,45 @@ public interface ConfigurationReference<N extends ConfigurationNode> extends Aut
      * @return A deserializing reference to the node at the given path
      * @throws ObjectMappingException if a type serializer could not be found for the provided type
      */
-    <T> ValueReference<T, N> referenceTo(Class<T> type, NodePath path) throws ObjectMappingException;
+    default <T> ValueReference<T, N> referenceTo(Class<T> type, NodePath path) throws ObjectMappingException {
+        return referenceTo(type, path, null);
+    }
+    
+    /**
+     * Create a reference to the node at the provided path. The value will be deserialized according to the provided
+     * TypeToken.
+     *
+     * The returned reference will update with reloads of and changes to the value of the provided configuration.
+     * Any serialization errors encountered will be submitted to the {@link #errors()} stream
+     *
+     * @param type The value's type.
+     * @param path The path from the root node to the node a value will be gotten from.
+     * @param defaultValue The value to use when there is no data present in the targeted node.
+     * @param <T> The value type
+     * @return A deserializing reference to the node at the given path
+     * @throws ObjectMappingException if a type serializer could not be found for the provided type
+     */
+    <T> ValueReference<T, N> referenceTo(TypeToken<T> type, NodePath path, @Nullable T defaultValue) throws ObjectMappingException;
 
     /**
-     * Access the {@link Publisher} that will broadcast update events, providing the newly created node
+     * Create a reference to the node at the provided path. The value will be deserialized according to type of the
+     * provided Class.
+     *
+     * The returned reference will update with reloads of and changes to the value of the provided configuration.
+     * Any serialization errors encountered will be submitted to the {@link #errors()} stream
+     *
+     * @param type The value's type
+     * @param path The path from the root node to the node a value will be gotten from
+     * @param defaultValue The value to use when there is no data present in the targeted node.
+     * @param <T> The value type
+     * @return A deserializing reference to the node at the given path
+     * @throws ObjectMappingException if a type serializer could not be found for the provided type
+     */
+    <T> ValueReference<T, N> referenceTo(Class<T> type, NodePath path, @Nullable T defaultValue) throws ObjectMappingException;
+
+    /**
+     * Access the {@link Publisher} that will broadcast update events, providing the newly created node.
+     * The returned publisher will be transaction-aware, i.e. any {@link org.spongepowered.configurate.reactive.TransactionalSubscriber} attached will progress through their phases appropriately
      *
      * @return The publisher
      */

--- a/configurate-core/src/main/java/org/spongepowered/configurate/reference/ConfigurationReference.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/reference/ConfigurationReference.java
@@ -1,0 +1,261 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spongepowered.configurate.reference;
+
+import com.google.common.reflect.TypeToken;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.configurate.ConfigurationNode;
+import org.spongepowered.configurate.ScopedConfigurationNode;
+import org.spongepowered.configurate.loader.ConfigurationLoader;
+import org.spongepowered.configurate.objectmapping.ObjectMappingException;
+import org.spongepowered.configurate.transformation.NodePath;
+import org.spongepowered.configurate.reactive.Publisher;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * An updating reference to a base configuration node
+ *
+ * @param <N> The type of node to work with
+ */
+public interface ConfigurationReference<N extends ConfigurationNode> extends AutoCloseable {
+    /**
+     * Create a new configuration reference that will only update when loaded
+     *
+     * @param loader The loader to load and save from
+     * @param <T> The type of node
+     * @return The newly created reference, with an initial load performed
+     * @throws IOException If the configuration contained fails to load
+     */
+    static <T extends ScopedConfigurationNode<T>> ConfigurationReference<T> createFixed(ConfigurationLoader<T> loader) throws IOException {
+        ConfigurationReference<T> ret = new ManualConfigurationReference<>(loader);
+        ret.load();
+        return ret;
+    }
+
+    /**
+     * Create a new configuration reference that will automatically update when triggered by the provided {@link WatchServiceListener}
+     *
+     * @param loaderCreator A function that can create a {@link ConfigurationLoader}
+     * @param file The file to load this configuration from
+     * @param listener The watch service listener that will receive events
+     * @param <T> The node type
+     * @return The created reference
+     * @throws IOException If the underlying loader fails to load a configuration
+     * @see WatchServiceListener#listenToConfiguration(Function, Path)
+     */
+    static <T extends ScopedConfigurationNode<T>> ConfigurationReference<T> createWatching(Function<Path, ConfigurationLoader<T>> loaderCreator, Path file, WatchServiceListener listener) throws IOException {
+        final WatchingConfigurationReference<T> ret = new WatchingConfigurationReference<>(loaderCreator.apply(file));
+        ret.load();
+        ret.setDisposable(listener.listenToFile(file, ret));
+
+        return ret;
+    }
+
+    /**
+     * Reload a configuration using the provided loader.
+     *
+     * If the load fails, this reference will continue pointing to old configuration values
+     *
+     * @throws IOException When an error occurs
+     */
+    void load() throws IOException;
+
+    /**
+     * Save this configuration using the provided loader.
+     *
+     * @throws IOException When an error occurs in the underlying ID
+     */
+    void save() throws IOException;
+
+    /**
+     * Update the configuration node pointed to by this reference, and save it using the reference's loader
+     *
+     * Even if the loader fails to save this new node, the node pointed to by this reference will be updated.
+     *
+     * @param newNode The new node to save
+     * @throws IOException When an error occurs within the loader
+     */
+    void save(N newNode) throws IOException;
+
+    /**
+     * Get the base node this reference refers to.
+     *
+     * @return The node
+     */
+    N getNode();
+
+    /**
+     * Get the loader this reference uses to load and save its' node
+     *
+     * @return The loader
+     */
+    ConfigurationLoader<N> getLoader();
+
+    /**
+     * Get the node at the given path, using the root node
+     *
+     * @param path The path, a series of path elements
+     * @return A child node
+     * @see ConfigurationNode#getNode(Object...)
+     */
+    N get(Object... path);
+
+    /**
+     * Update the value of the node at the given path, using the root node as a base.
+     *
+     * @param path The path to get the child at
+     * @param value The value to set the child node to
+     */
+    default void set(Object[] path, @Nullable Object value) {
+        getNode().getNode(path).setValue(value);
+    }
+
+    /**
+     * Set the value of the node at {@code path} to the given value,
+     * using the appropriate {@link org.spongepowered.configurate.objectmapping.serialize.TypeSerializer} to serialize the data if it's
+     * not directly supported by the provided configuration.
+     *
+     * @param path The path to set the value at
+     * @param type The type of data to serialize
+     * @param value The value to set
+     * @param <T> The type parameter for the value
+     * @throws ObjectMappingException If thrown by the serialization mechanism
+     */
+    default <T> void set(Object[] path, TypeToken<T> type, @Nullable T value) throws ObjectMappingException {
+        getNode().getNode(path).setValue(type, value);
+    }
+
+    /**
+     * Update the value of the node at the given path, using the root node as a base.
+     *
+     * @param path The path to get the child at
+     * @param value The value to set the child node to
+     */
+    default void set(NodePath path, @Nullable Object value) {
+        getNode().getNode(path).setValue(value);
+    }
+
+    /**
+     * Set the value of the node at {@code path} to the given value,
+     * using the appropriate {@link org.spongepowered.configurate.objectmapping.serialize.TypeSerializer} to
+     * serialize the data if it's not directly supported by the provided configuration.
+     *
+     * @param path The path to set the value at
+     * @param type The type of data to serialize
+     * @param value The value to set
+     * @param <T> The type parameter for the value
+     * @throws ObjectMappingException If thrown by the serialization mechanism
+     */
+    default <T> void set(NodePath path, TypeToken<T> type, @Nullable T value) throws ObjectMappingException {
+        getNode().getNode(path).setValue(type, value);
+    }
+
+    /**
+     * Create a reference to the node at the provided path. The value will be deserialized according to the provided
+     * TypeToken.
+     *
+     * The returned reference will update with reloads of and changes to the value of the provided configuration.
+     * Any serialization errors encountered will be submitted to the {@link #errors()} stream
+     *
+     * @param type The value's type
+     * @param path The path from the root node to the node a value will be gotten from
+     * @param <T> The value type
+     * @return A deserializing reference to the node at the given path
+     * @throws ObjectMappingException if a type serializer could not be found for the provided type
+     */
+    default <T> ValueReference<T, N> referenceTo(TypeToken<T> type, Object... path) throws ObjectMappingException {
+        return referenceTo(type, NodePath.create(path));
+    }
+
+    /**
+     * Create a reference to the node at the provided path. The value will be deserialized according to type of the
+     * provided Class.
+     *
+     * The returned reference will update with reloads of and changes to the value of the provided configuration.
+     * Any serialization errors encountered will be submitted to the {@link #errors()} stream
+     *
+     * @param type The value's type
+     * @param path The path from the root node to the node a value will be gotten from
+     * @param <T> The value type
+     * @return A deserializing reference to the node at the given path
+     * @throws ObjectMappingException if a type serializer could not be found for the provided type
+     */
+    default <T> ValueReference<T, N> referenceTo(Class<T> type, Object... path) throws ObjectMappingException {
+        return referenceTo(type, NodePath.create(path));
+    }
+
+    /**
+     * Create a reference to the node at the provided path. The value will be deserialized according to the provided
+     * TypeToken.
+     *
+     * The returned reference will update with reloads of and changes to the value of the provided configuration.
+     * Any serialization errors encountered will be submitted to the {@link #errors()} stream
+     *
+     * @param type The value's type
+     * @param path The path from the root node to the node a value will be gotten from
+     * @param <T> The value type
+     * @return A deserializing reference to the node at the given path
+     * @throws ObjectMappingException if a type serializer could not be found for the provided type
+     */
+    <T> ValueReference<T, N> referenceTo(TypeToken<T> type, NodePath path) throws ObjectMappingException;
+
+    /**
+     * Create a reference to the node at the provided path. The value will be deserialized according to type of the
+     * provided Class.
+     *
+     * The returned reference will update with reloads of and changes to the value of the provided configuration.
+     * Any serialization errors encountered will be submitted to the {@link #errors()} stream
+     *
+     * @param type The value's type
+     * @param path The path from the root node to the node a value will be gotten from
+     * @param <T> The value type
+     * @return A deserializing reference to the node at the given path
+     * @throws ObjectMappingException if a type serializer could not be found for the provided type
+     */
+    <T> ValueReference<T, N> referenceTo(Class<T> type, NodePath path) throws ObjectMappingException;
+
+    /**
+     * Access the {@link Publisher} that will broadcast update events, providing the newly created node
+     *
+     * @return The publisher
+     */
+    Publisher<N> updates();
+
+    /**
+     * A stream that will receive errors that occur while loading or saving to this reference
+     *
+     * @return The publisher
+     */
+    Publisher<Map.Entry<ErrorPhase, Throwable>> errors();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    void close();
+
+    /**
+     * Representing the phase where an error occurred
+     */
+    enum ErrorPhase {
+        LOADING, SAVING, UNKNOWN;
+    }
+}

--- a/configurate-core/src/main/java/org/spongepowered/configurate/reference/DirectoryListenerRegistration.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/reference/DirectoryListenerRegistration.java
@@ -1,0 +1,149 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spongepowered.configurate.reference;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.configurate.reactive.Disposable;
+import org.spongepowered.configurate.reactive.Processor;
+import org.spongepowered.configurate.reactive.Subscriber;
+
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Data class holding listeners for a base directory and its children
+ */
+class DirectoryListenerRegistration implements Subscriber<WatchEvent<?>> {
+    private final Lock lock = new ReentrantLock();
+    private final WatchKey key;
+    private final ConcurrentHashMap<Path, Processor<WatchEvent<?>, WatchEvent<?>>> fileListeners
+        = new ConcurrentHashMap<>();
+    private final Processor<WatchEvent<?>, WatchEvent<?>> dirListeners = Processor.create();
+
+    DirectoryListenerRegistration(WatchKey key) {
+        this.key = requireNonNull(key, "key");
+    }
+
+    public WatchKey getKey() {
+        return key;
+    }
+
+    @Override
+    public void submit(WatchEvent<?> item) {
+        final Path file = (Path) item.context();
+        lock.lock();
+        try {
+            @Nullable Processor<WatchEvent<?>, WatchEvent<?>> fileListeners
+                = this.fileListeners.computeIfPresent(file,
+                (key, old) -> old.closeIfUnsubscribed() ? null : old);
+            dirListeners.submit(item);
+            if (fileListeners != null) {
+                fileListeners.submit(item);
+            }
+
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void onClose() {
+        lock.lock();
+        try {
+            try {
+                dirListeners.onClose();
+            } catch (Throwable t) {
+                dirListeners.onError(t);
+            }
+
+            fileListeners.forEach((k, v) -> {
+                try {
+                    v.onClose();
+                } catch (Throwable t) {
+                    v.onError(t);
+                }
+            });
+
+            fileListeners.clear();
+            key.cancel();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public Disposable subscribe(Subscriber<WatchEvent<?>> subscriber) {
+        lock.lock();
+        try {
+            return dirListeners.subscribe(subscriber);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public Disposable subscribe(Path file, Subscriber<WatchEvent<?>> subscriber) {
+        lock.lock();
+        try {
+            return fileListeners.computeIfAbsent(file, f -> Processor.create()).subscribe(subscriber);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public boolean hasSubscribers() {
+        lock.lock();
+        try {
+            return dirListeners.hasSubscribers() || !fileListeners.isEmpty();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DirectoryListenerRegistration)) return false;
+        DirectoryListenerRegistration that = (DirectoryListenerRegistration) o;
+        return getKey().equals(that.getKey()) &&
+            fileListeners.equals(that.fileListeners) &&
+            dirListeners.equals(that.dirListeners);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getKey(), fileListeners, dirListeners);
+    }
+
+    public boolean closeIfEmpty() {
+        lock.lock();
+        try {
+            if (!hasSubscribers()) {
+                onClose();
+                return true;
+            }
+        } finally {
+            lock.unlock();
+        }
+        return false;
+    }
+}

--- a/configurate-core/src/main/java/org/spongepowered/configurate/reference/ManualConfigurationReference.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/reference/ManualConfigurationReference.java
@@ -1,0 +1,111 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spongepowered.configurate.reference;
+
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.spongepowered.configurate.ScopedConfigurationNode;
+import com.google.common.reflect.TypeToken;
+import org.spongepowered.configurate.loader.ConfigurationLoader;
+import org.spongepowered.configurate.objectmapping.ObjectMappingException;
+import org.spongepowered.configurate.transformation.NodePath;
+import org.spongepowered.configurate.reactive.Publisher;
+import org.spongepowered.configurate.reactive.Processor;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A reference to a configuration node, that may or may not be updating
+ */
+class ManualConfigurationReference<N extends ScopedConfigurationNode<N>> implements ConfigurationReference<N> {
+    protected volatile @MonotonicNonNull N node;
+    private final ConfigurationLoader<N> loader;
+    protected final Processor.Iso<N> updateListener = Processor.create();
+    protected final Processor.Iso<Map.Entry<ErrorPhase, Throwable>> errorListener =
+        Processor.create();
+
+    ManualConfigurationReference(ConfigurationLoader<N> loader) {
+        this.loader = loader;
+        errorListener.setFallbackHandler(it -> {
+            System.out.println("Unhandled error while performing a " + it.getKey() + " for a " +
+                "configuration reference: " + it.getValue());
+            it.getValue().printStackTrace();
+        });
+    }
+
+    @Override
+    public void load() throws IOException {
+        synchronized (this.loader) {
+            updateListener.submit(node = loader.load());
+        }
+    }
+
+    @Override
+    public void save() throws IOException {
+        save(this.node);
+    }
+
+    @Override
+    public void save(N newNode) throws IOException {
+        synchronized (this.loader) {
+            loader.save(this.node = requireNonNull(newNode));
+        }
+    }
+
+    @Override
+    public N getNode() {
+        return this.node;
+    }
+
+    @Override
+    public ConfigurationLoader<N> getLoader() {
+        return this.loader;
+    }
+
+    @Override
+    public N get(Object... path) {
+        return getNode().getNode(path);
+    }
+
+    @Override
+    public <T> ValueReference<T, N> referenceTo(TypeToken<T> type, NodePath path) throws ObjectMappingException {
+        return new ValueReferenceImpl<>(this, path, type);
+    }
+
+    @Override
+    public <T> ValueReference<T, N> referenceTo(Class<T> type, NodePath path) throws ObjectMappingException {
+        return new ValueReferenceImpl<>(this, path, type);
+    }
+
+    @Override
+    public Publisher<N> updates() {
+        return updateListener;
+    }
+
+    @Override
+    public Publisher<Map.Entry<ErrorPhase, Throwable>> errors() {
+        return errorListener;
+    }
+
+    @Override
+    public void close() {
+        updateListener.onClose();
+    }
+
+}

--- a/configurate-core/src/main/java/org/spongepowered/configurate/reference/ManualConfigurationReference.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/reference/ManualConfigurationReference.java
@@ -17,6 +17,7 @@
 package org.spongepowered.configurate.reference;
 
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.configurate.ScopedConfigurationNode;
 import com.google.common.reflect.TypeToken;
 import org.spongepowered.configurate.loader.ConfigurationLoader;
@@ -36,7 +37,7 @@ import static java.util.Objects.requireNonNull;
 class ManualConfigurationReference<N extends ScopedConfigurationNode<N>> implements ConfigurationReference<N> {
     protected volatile @MonotonicNonNull N node;
     private final ConfigurationLoader<N> loader;
-    protected final Processor.Iso<N> updateListener = Processor.create();
+    protected final Processor.TransactionalIso<N> updateListener = Processor.createTransactional();
     protected final Processor.Iso<Map.Entry<ErrorPhase, Throwable>> errorListener =
         Processor.create();
 
@@ -84,13 +85,13 @@ class ManualConfigurationReference<N extends ScopedConfigurationNode<N>> impleme
     }
 
     @Override
-    public <T> ValueReference<T, N> referenceTo(TypeToken<T> type, NodePath path) throws ObjectMappingException {
-        return new ValueReferenceImpl<>(this, path, type);
+    public <T> ValueReference<T, N> referenceTo(TypeToken<T> type, NodePath path, @Nullable T def) throws ObjectMappingException {
+        return new ValueReferenceImpl<>(this, path, type, def);
     }
 
     @Override
-    public <T> ValueReference<T, N> referenceTo(Class<T> type, NodePath path) throws ObjectMappingException {
-        return new ValueReferenceImpl<>(this, path, type);
+    public <T> ValueReference<T, N> referenceTo(Class<T> type, NodePath path, @Nullable T def) throws ObjectMappingException {
+        return new ValueReferenceImpl<>(this, path, type, def);
     }
 
     @Override

--- a/configurate-core/src/main/java/org/spongepowered/configurate/reference/PrefixedNameThreadFactory.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/reference/PrefixedNameThreadFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spongepowered.configurate.reference;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class PrefixedNameThreadFactory implements ThreadFactory {
+    private final String name;
+    private final boolean daemon;
+    private final AtomicInteger counter = new AtomicInteger();
+
+    PrefixedNameThreadFactory(final String prefix, final boolean daemon) {
+        this.name = prefix.endsWith("-") ? prefix : (prefix + "-");
+        this.daemon = daemon;
+    }
+    
+    @Override
+    public Thread newThread(final Runnable runnable) {
+        Thread ret = new Thread(runnable, name + counter.getAndIncrement());
+        ret.setDaemon(this.daemon);
+        return ret;
+    }
+}

--- a/configurate-core/src/main/java/org/spongepowered/configurate/reference/ValueReference.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/reference/ValueReference.java
@@ -1,0 +1,67 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spongepowered.configurate.reference;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.configurate.ConfigurationNode;
+import org.spongepowered.configurate.reactive.Publisher;
+
+/**
+ * A pointer to a node within a configuration tree.
+ *
+ * This value will update
+ *
+ * @param <T> The type of value to return
+ * @param <N> The type of node
+ */
+public interface ValueReference<T, N extends ConfigurationNode> extends Publisher<T> {
+    /**
+     * Get the current value at this node
+     *
+     * Any deserialization failures will be submitted to the owning {@link ConfigurationReference}'s error callback
+     *
+     * @return the deserialized value, or null if deserialization fails.
+     */
+    @Nullable T get();
+
+    /**
+     * Set the new value of this node. The configuration won't be saved.
+     *
+     * Any serialization errors will be provided to the error callback of the owning {@link ConfigurationReference}
+     *
+     * @param value The value
+     * @return true if successful, false if serialization fails
+     */
+    boolean set(@Nullable T value);
+
+    /**
+     * Set the new value of this node. The configuration won't be saved.
+     *
+     * Any serialization errors will be provided to the error callback of the owning {@link ConfigurationReference}
+     *
+     * @param value The value
+     * @return true if successful, false if serialization fails
+     */
+    boolean setAndSave(@Nullable T value) ;
+
+    /**
+     * Get the node this value reference points to.
+     *
+     * @return The node
+     */
+    N getNode();
+}

--- a/configurate-core/src/main/java/org/spongepowered/configurate/reference/ValueReferenceImpl.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/reference/ValueReferenceImpl.java
@@ -1,0 +1,123 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spongepowered.configurate.reference;
+
+import com.google.common.collect.Maps;
+import com.google.common.reflect.TypeToken;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.configurate.ScopedConfigurationNode;
+import org.spongepowered.configurate.objectmapping.ObjectMappingException;
+import org.spongepowered.configurate.objectmapping.serialize.TypeSerializer;
+import org.spongepowered.configurate.reference.ConfigurationReference.ErrorPhase;
+import org.spongepowered.configurate.transformation.NodePath;
+import org.spongepowered.configurate.reactive.Disposable;
+import org.spongepowered.configurate.reactive.Processor;
+import org.spongepowered.configurate.reactive.Subscriber;
+
+import java.io.IOException;
+
+class ValueReferenceImpl<@Nullable T, N extends ScopedConfigurationNode<N>> implements ValueReference<T, N>, Subscriber<T> {
+    // Information about the reference
+    private final ManualConfigurationReference<N> root;
+    private final NodePath path;
+    private final TypeToken<T> type;
+    private final TypeSerializer<T> serializer;
+    private final Processor<N, T> updateListener;
+
+    // State
+    private @Nullable T deserializedValue;
+
+    ValueReferenceImpl(ManualConfigurationReference<N> root, NodePath path, TypeToken<T> type) throws ObjectMappingException {
+        this.root = root;
+        this.path = path;
+        this.type = type;
+        serializer = root.getNode().getOptions().getSerializers().get(type);
+        if (serializer == null) {
+            throw new ObjectMappingException("Unsupported type" + type);
+        }
+
+        updateListener = root.updateListener.map(n -> {
+            N node = n.getNode(path);
+            try {
+                return serializer.deserialize(type, node);
+            } catch (ObjectMappingException e) {
+                root.errorListener.submit(Maps.immutableEntry(ErrorPhase.LOADING, e));
+                return null;
+            }
+        });
+        updateListener.subscribe(this);
+    }
+
+    ValueReferenceImpl(ManualConfigurationReference<N> root, NodePath path, Class<T> type) throws ObjectMappingException {
+        this(root, path, TypeToken.of(type));
+    }
+
+    @Override
+    public @Nullable T get() {
+        return deserializedValue;
+    }
+
+    @Override
+    public boolean set(@Nullable T value) {
+        try {
+            serializer.serialize(type, value, getNode());
+            updateListener.inject(value);
+            return true;
+        } catch (ObjectMappingException e) {
+            root.errorListener.submit(Maps.immutableEntry(ErrorPhase.SAVING, e));
+            return false;
+        }
+    }
+
+    @Override
+    public boolean setAndSave(@Nullable T value) {
+        try {
+            if (set(value)) {
+                root.save();
+                return true;
+            }
+        } catch (IOException e) {
+            root.errorListener.submit(Maps.immutableEntry(ErrorPhase.SAVING, e));
+        }
+        return false;
+    }
+
+    @Override
+    public N getNode() {
+        return root.getNode().getNode(path);
+    }
+
+    @Override
+    public void submit(T item) {
+        deserializedValue = item;
+    }
+
+    @Override
+    public void onError(Throwable e) {
+        root.errorListener.submit(Maps.immutableEntry(ErrorPhase.UNKNOWN, e));
+    }
+
+    @Override
+    public Disposable subscribe(final Subscriber<? super T> subscriber) {
+        return updateListener.subscribe(subscriber);
+    }
+
+    @Override
+    public boolean hasSubscribers() {
+        return updateListener.hasSubscribers();
+    }
+}

--- a/configurate-core/src/main/java/org/spongepowered/configurate/reference/WatchServiceListener.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/reference/WatchServiceListener.java
@@ -1,0 +1,245 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spongepowered.configurate.reference;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.configurate.ScopedConfigurationNode;
+import org.spongepowered.configurate.loader.ConfigurationLoader;
+import org.spongepowered.configurate.reactive.Disposable;
+import org.spongepowered.configurate.reactive.Subscriber;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.function.Function;
+
+/**
+ * A wrapper around NIO's {@link WatchService} that uses the provided event loop to poll for changes, and calls listeners once an event occurs.
+ *
+ * Some deduplication is performed because Windows can be fairly spammy with its events, so one callback may receive multiple events at one time.
+ *
+ * Callback functions take a
+ */
+public class WatchServiceListener implements AutoCloseable {
+    @SuppressWarnings("rawtypes") // IntelliJ says it's unnecessary, but the compiler shows warnings
+    private static final WatchEvent.Kind<?>[] DEFAULT_WATCH_EVENTS = new WatchEvent.Kind[] {StandardWatchEventKinds.OVERFLOW,
+            StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY};
+    private static final int PARALLEL_THRESHOLD = 100;
+    private final ExecutorService executor;
+    private final WatchService watchService;
+    private final ConcurrentHashMap<Path, DirectoryListenerRegistration> activeListeners = new ConcurrentHashMap<>();
+    private static final ThreadLocal<IOException> exceptionHolder = new ThreadLocal<>();
+
+    /**
+     * Create a new builder for a WatchServiceListener to create a customized listener
+     * @return A builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Create a new {@link WatchServiceListener} using a new cached thread pool executor and the default filesystem.
+     *
+     * @return A new instance with default values
+     * @throws IOException If a watch service cannot be created
+     * @see #builder() for customization
+     */
+    public static WatchServiceListener create() throws IOException {
+        return new WatchServiceListener(ForkJoinPool.commonPool(), FileSystems.getDefault());
+    }
+
+    private WatchServiceListener(ExecutorService executor, FileSystem fileSystem) throws IOException {
+        this.executor = executor;
+        this.watchService = fileSystem.newWatchService();
+        executor.submit(() -> {
+            while (!executor.isShutdown()) {
+                WatchKey key;
+                try {
+                    key = watchService.take();
+                } catch (InterruptedException e) {
+                    break;
+                }
+                Path watched = (Path) key.watchable();
+                DirectoryListenerRegistration registration = activeListeners.get(watched);
+                if (registration != null) {
+                    final Set<Object> seenContexts = new HashSet<>();
+                    for (WatchEvent<?> event : key.pollEvents()) {
+                        if (!key.isValid()) {
+                            break;
+                        }
+
+                        if (!seenContexts.add(event.context())) {
+                            continue;
+                        }
+
+                        // Process listeners
+                        executor.submit(() -> {
+                            registration.submit(event);
+                            if (registration.closeIfEmpty()) {
+                                key.cancel();
+                            }
+                        });
+                    }
+
+                    // If the watch key is no longer valid, send all listeners a close event
+                    if (!key.reset()) {
+                        DirectoryListenerRegistration oldListeners = activeListeners.remove(watched);
+                        oldListeners.onClose();
+                    }
+                }
+            }
+        });
+    }
+
+    /**
+     * Gets or creates a registration holder for a specific directory. This handles registering with the watch service if necessary.
+     *
+     * @param directory The directory to listen to
+     * @return A registration, created new if necessary.
+     * @throws IOException If produced while registering the path with our WatchService
+     */
+    private DirectoryListenerRegistration getRegistration(Path directory) throws IOException {
+        @Nullable DirectoryListenerRegistration reg = activeListeners.computeIfAbsent(directory, dir -> {
+            try {
+                return new DirectoryListenerRegistration(dir.register(watchService, DEFAULT_WATCH_EVENTS));
+            } catch (IOException ex) {
+                exceptionHolder.set(ex);
+                return null;
+            }
+        });
+
+        if (reg == null) {
+            throw exceptionHolder.get();
+        }
+        return reg;
+    }
+
+    /**
+     * Listen for changes to a specific file or directory.
+     *
+     * @param file The path of the file or directory to listen for changes on.
+     * @param callback A callback function that will be called when changes are made. If return value is false, we will stop monitoring for changes.
+     * @return A {@link Disposable} that can be used to cancel this subscription
+     * @throws IOException if a filesystem error occurs.
+     * @throws IllegalArgumentException if the provided path is a directory.
+     */
+    public Disposable listenToFile(Path file, Subscriber<WatchEvent<?>> callback) throws IOException, IllegalArgumentException {
+        if (Files.isDirectory(file)) {
+            throw new IllegalArgumentException("Path " + file + " must be a file");
+        }
+
+        Path fileName = file.getFileName();
+        return getRegistration(file.getParent()).subscribe(fileName, callback);
+    }
+
+    /**
+     * Listen to a directory. Callbacks will receive events both for the directory and for its contents.
+     *
+     * @param directory The directory to listen to
+     * @param callback A callback function that will be called when changes are made. If return value is false, we will stop monitoring for changes.
+     * @return A {@link Disposable} that can be used to cancel this subscription
+     * @throws IOException When an error occurs registering with the underlying watch service.
+     * @throws IllegalArgumentException If the provided path is not a directory
+     */
+    public Disposable listenToDirectory(Path directory, Subscriber<WatchEvent<?>> callback) throws IOException, IllegalArgumentException {
+        if (!(Files.isDirectory(directory) || !Files.exists(directory))) {
+            throw new IllegalArgumentException("Path " + directory + " must be a directory");
+        }
+
+        return getRegistration(directory).subscribe(callback);
+    }
+
+    public <N extends ScopedConfigurationNode<N>> ConfigurationReference<N> listenToConfiguration(Function<Path, ConfigurationLoader<N>> loaderFunc, Path path) throws IOException {
+        return ConfigurationReference.createWatching(loaderFunc, path, this);
+    }
+
+    @Override
+    public void close() throws IOException {
+        watchService.close();
+        activeListeners.forEachValue(PARALLEL_THRESHOLD, DirectoryListenerRegistration::onClose);
+        activeListeners.clear();
+    }
+
+    /**
+     * Set the parameters needed to create a {@link WatchServiceListener}. All params are optional
+     * and defaults will be used if no values are specified.
+     */
+    public static class Builder {
+        private @Nullable ExecutorService executor;
+        private @Nullable FileSystem fileSystem;
+
+        private Builder() {
+
+        }
+
+        /**
+         * Set the executor to be used for polling and callbacks.
+         *
+         * If an executor is provided, it will must be managed outside of the watch service. If no executor is set, one will be created by the watch service.
+         *
+         * @param executor The executor to be used for the created service
+         * @return thus
+         */
+        public Builder setExecutor(ExecutorService executor) {
+            this.executor = executor;
+            return this;
+        }
+
+        /**
+         * Set the filesystem expected to be used for paths. A separate {@link WatchServiceListener} should be
+         * created to listen to events on a different file system.
+         *
+         * @param system The file system to use.
+         * @return this
+         */
+        public Builder setFileSystem(FileSystem system) {
+            this.fileSystem = system;
+            return this;
+        }
+
+        /**
+         * Create a new listener, using default values for any unset parameters.
+         *
+         * @return A newly created executor
+         * @throws IOException if thrown by {@link WatchServiceListener}'s constructor
+         */
+        public WatchServiceListener build() throws IOException {
+            if (executor == null) {
+                executor = ForkJoinPool.commonPool();
+                assert executor != null; // shush
+            }
+
+            if (fileSystem == null) {
+                fileSystem = FileSystems.getDefault();
+            }
+
+            return new WatchServiceListener(executor, fileSystem);
+        }
+    }
+}

--- a/configurate-core/src/main/java/org/spongepowered/configurate/reference/WatchServiceListener.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/reference/WatchServiceListener.java
@@ -16,7 +16,6 @@
  */
 package org.spongepowered.configurate.reference;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.configurate.ScopedConfigurationNode;
 import org.spongepowered.configurate.loader.ConfigurationLoader;
@@ -55,10 +54,7 @@ public class WatchServiceListener implements AutoCloseable {
     private static final WatchEvent.Kind<?>[] DEFAULT_WATCH_EVENTS = new WatchEvent.Kind[]{StandardWatchEventKinds.OVERFLOW,
             StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY};
     private static final int PARALLEL_THRESHOLD = 100;
-    private static final ThreadFactory DEFAULT_THREAD_FACTORY = new ThreadFactoryBuilder()
-            .setNameFormat("Configurate-WatchService-%d")
-            .setDaemon(true)
-            .build();
+    private static final ThreadFactory DEFAULT_THREAD_FACTORY = new PrefixedNameThreadFactory("Configurate-WatchService", true);
 
     private final WatchService watchService;
     private volatile boolean open = true;

--- a/configurate-core/src/main/java/org/spongepowered/configurate/reference/WatchingConfigurationReference.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/reference/WatchingConfigurationReference.java
@@ -1,0 +1,87 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spongepowered.configurate.reference;
+
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.spongepowered.configurate.ScopedConfigurationNode;
+import com.google.common.collect.Maps;
+import org.spongepowered.configurate.loader.ConfigurationLoader;
+import org.spongepowered.configurate.reactive.Disposable;
+import org.spongepowered.configurate.reactive.Subscriber;
+
+import java.io.IOException;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A reference to a configuration node, that may or may not be updating
+ */
+class WatchingConfigurationReference<N extends ScopedConfigurationNode<N>> extends ManualConfigurationReference<N> implements Subscriber<WatchEvent<?>> {
+    private volatile boolean saveSuppressed = false;
+    private @MonotonicNonNull Disposable disposable;
+
+    WatchingConfigurationReference(ConfigurationLoader<N> loader) {
+        super(loader);
+    }
+
+    @Override
+    public void save(N newNode) throws IOException {
+        synchronized (getLoader()) {
+            try {
+                saveSuppressed = true;
+                getLoader().save(this.node = requireNonNull(newNode));
+            } finally {
+                saveSuppressed = false;
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        super.close();
+        if (disposable != null) {
+            disposable.dispose();
+        }
+    }
+
+    @Override
+    public void submit(WatchEvent<?> item) {
+        if (!saveSuppressed || item.kind() == StandardWatchEventKinds.ENTRY_MODIFY) {
+            try {
+                load();
+            } catch (Exception e) {
+                errorListener.submit(Maps.immutableEntry(ErrorPhase.LOADING, e));
+            }
+        }
+    }
+
+    @Override
+    public void onError(Throwable e) {
+        errorListener.submit(Maps.immutableEntry(ErrorPhase.UNKNOWN, e));
+    }
+
+    @Override
+    public void onClose() {
+        close();
+    }
+
+    void setDisposable(Disposable disposable) {
+        this.disposable = disposable;
+    }
+}

--- a/configurate-core/src/main/java/org/spongepowered/configurate/reference/package-info.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/reference/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@DefaultQualifier(value = NonNull.class)
+package org.spongepowered.configurate.reference;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/configurate-core/src/main/java/org/spongepowered/configurate/transformation/NodePath.java
+++ b/configurate-core/src/main/java/org/spongepowered/configurate/transformation/NodePath.java
@@ -85,5 +85,10 @@ public interface NodePath extends Iterable<Object>, Cloneable {
         return new NodePathImpl(path.toArray(), false);
     }
 
+    /**
+     * Create a new node path with the same data as this path
+     *
+     * @return The resulting path
+     */
     NodePath clone();
 }

--- a/configurate-core/src/test/java/org/spongepowered/configurate/reference/WatchServiceListenerTest.java
+++ b/configurate-core/src/test/java/org/spongepowered/configurate/reference/WatchServiceListenerTest.java
@@ -1,0 +1,127 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spongepowered.configurate.reference;
+
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.spongepowered.configurate.reactive.Disposable;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Collections;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class WatchServiceListenerTest {
+    private static @MonotonicNonNull WatchServiceListener listener;
+
+    @BeforeAll
+    public static void setUpClass() throws IOException {
+        listener = WatchServiceListener.create();
+    }
+
+    @AfterAll
+    public static void tearDownClass() throws IOException {
+        listener.close();
+    }
+
+    @Test
+    public void testListenToPath() throws IOException, InterruptedException,
+        BrokenBarrierException {
+        Path tempFolder = Files.createTempDirectory("configurate-test");
+        Path testFile = tempFolder.resolve("listenPath.txt");
+        Files.write(testFile, Collections.singleton("version one"), StandardOpenOption.SYNC,
+            StandardOpenOption.CREATE);
+
+        final AtomicInteger callCount = new AtomicInteger(0);
+        final Object condition = new Object();
+        final AtomicReference<Disposable> disposer = new AtomicReference<>();
+        disposer.set(listener.listenToFile(testFile, event -> {
+            synchronized (condition) {
+                int oldVal = callCount.getAndIncrement();
+                if (oldVal > 1) {
+                    disposer.get().dispose();
+                    return;
+                }
+                condition.notify();
+                if (oldVal >= 1) {
+                    disposer.get().dispose();
+                }
+            }
+        }));
+
+        assertEquals(0, callCount.get());
+
+
+        synchronized (condition) {
+            Files.write(testFile, Collections.singleton("version two"), StandardOpenOption.SYNC);
+            condition.wait();
+            assertEquals(1, callCount.get());
+
+            Files.write(testFile, Collections.singleton("version three"), StandardOpenOption.SYNC);
+            condition.wait();
+            assertEquals(2, callCount.get());
+        }
+
+        Files.write(testFile, Collections.singleton("version four"), StandardOpenOption.SYNC);
+        assertEquals(2, callCount.get());
+    }
+
+    @Test
+    public void testListenToDirectory() throws IOException, BrokenBarrierException,
+        InterruptedException {
+        Path tempFolder = Files.createTempDirectory("configurate-test");
+        final Path test1 = tempFolder.resolve("test1");
+        final Path test2 = tempFolder.resolve("test2");
+        Files.createFile(test1);
+        Files.createFile(test2);
+
+        final AtomicReference<Path> lastPath = new AtomicReference<>();
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+
+        listener.listenToDirectory(tempFolder, event -> {
+            if (event.context() instanceof Path) {
+                lastPath.set(((Path) event.context()));
+            } else {
+                throw new RuntimeException("Event " + event + " received, was not expected");
+            }
+            try {
+                barrier.await();
+            } catch (InterruptedException | BrokenBarrierException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        Files.write(test1, Collections.singleton("version one"), StandardOpenOption.SYNC);
+
+        barrier.await();
+        assertEquals(test1.getFileName(), lastPath.get());
+        barrier.reset();
+
+        Files.write(test2, Collections.singleton("version two"), StandardOpenOption.SYNC);
+        barrier.await();
+        assertEquals(test2.getFileName(), lastPath.get());
+    }
+}

--- a/configurate-ext-kotlin/build.gradle.kts
+++ b/configurate-ext-kotlin/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 tasks.withType(KotlinCompile::class).configureEach {
+    kotlinOptions.jvmTarget = "1.8"
     kotlinOptions.freeCompilerArgs += listOf("-Xopt-in=kotlin.RequiresOptIn")
 }
 

--- a/configurate-ext-kotlin/src/main/kotlin/org/spongepowered/configurate/kotlin/ReferenceExtensions.kt
+++ b/configurate-ext-kotlin/src/main/kotlin/org/spongepowered/configurate/kotlin/ReferenceExtensions.kt
@@ -1,0 +1,41 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spongepowered.configurate.kotlin
+
+import com.google.common.reflect.TypeToken
+import kotlinx.coroutines.flow.Flow
+import org.spongepowered.configurate.ScopedConfigurationNode
+import org.spongepowered.configurate.objectmapping.ObjectMappingException
+import org.spongepowered.configurate.objectmapping.serialize.TypeSerializer
+import org.spongepowered.configurate.reference.ConfigurationReference
+import org.spongepowered.configurate.reference.ValueReference
+import org.spongepowered.configurate.transformation.NodePath
+import java.io.IOException
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty
+import kotlin.reflect.jvm.javaType
+
+
+inline fun <reified T: Any, N: ScopedConfigurationNode<N>> ConfigurationReference<N>.flowOf(vararg path: Any): Flow<T> {
+    return this.referenceTo<T>(typeTokenOf(), *path).asFlow()
+}
+
+inline fun <reified T: Any, N: ScopedConfigurationNode<N>> ConfigurationReference<N>.referenceTo(vararg path: Any): ValueReference<T, N> {
+    return this.referenceTo(typeTokenOf(), *path)
+}
+

--- a/etc/git-hook-pre-commit
+++ b/etc/git-hook-pre-commit
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [ -n "$IN_NIX_SHELL" ]; then # We are using an appropriate gradle version
+gradle licenseCheck
+else # Just use he wrapper
+./gradlew licenseCheck
+fi


### PR DESCRIPTION
This PR adds a WatchService listener, plus the API to hold references to configurations and specific values within configurations so that automatically reloading can happen easily.

Outstanding to-dos that I currently see are:

- update the wiki
- add a way for others to perform actions when the config is reloaded -- by adding their own listeners
- let the changes be worked through in a few plugins