### PR TITLE
Remove Guava immutable collections

### DIFF
--- a/core/src/main/java/org/spongepowered/configurate/AbstractConfigurationNode.java
+++ b/core/src/main/java/org/spongepowered/configurate/AbstractConfigurationNode.java
@@ -18,7 +18,6 @@ package org.spongepowered.configurate;
 
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.TypeParameter;
 import com.google.common.reflect.TypeToken;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -28,6 +27,7 @@ import org.spongepowered.configurate.serialize.TypeSerializer;
 import org.spongepowered.configurate.transformation.NodePath;
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -189,7 +189,7 @@ abstract class AbstractConfigurationNode<N extends ScopedConfigurationNode<N>, A
 
     @Override
     public <V> List<V> getList(final Function<Object, V> transformer) {
-        final ImmutableList.Builder<V> ret = ImmutableList.builder();
+        final List<V> ret = new ArrayList<>();
         final ConfigValue<N, A> value = this.value;
         if (value instanceof ListConfigValue) {
             // transform each value individually if the node is a list
@@ -207,7 +207,7 @@ abstract class AbstractConfigurationNode<N extends ScopedConfigurationNode<N>, A
             }
         }
 
-        return ret.build();
+        return Collections.unmodifiableList(ret);
     }
 
     @Override

--- a/core/src/main/java/org/spongepowered/configurate/ConfigurationNode.java
+++ b/core/src/main/java/org/spongepowered/configurate/ConfigurationNode.java
@@ -16,7 +16,6 @@
  */
 package org.spongepowered.configurate;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.TypeToken;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -27,6 +26,7 @@ import org.spongepowered.configurate.serialize.TypeSerializer;
 import org.spongepowered.configurate.transformation.NodePath;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -425,7 +425,7 @@ public interface ConfigurationNode {
      *                                requested type
      */
     default <V> @NonNull List<V> getList(@NonNull TypeToken<V> type) throws ObjectMappingException {
-        return getList(type, ImmutableList.of());
+        return getList(type, Collections.emptyList());
     }
 
     /**

--- a/core/src/main/java/org/spongepowered/configurate/ConfigurationOptions.java
+++ b/core/src/main/java/org/spongepowered/configurate/ConfigurationOptions.java
@@ -18,7 +18,6 @@ package org.spongepowered.configurate;
 
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Primitives;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -28,7 +27,10 @@ import org.spongepowered.configurate.objectmapping.ObjectMapperFactory;
 import org.spongepowered.configurate.serialize.TypeSerializerCollection;
 import org.spongepowered.configurate.util.MapFactories;
 import org.spongepowered.configurate.util.MapFactory;
+import org.spongepowered.configurate.util.UnmodifiableCollections;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -50,7 +52,7 @@ public final class ConfigurationOptions {
     @NonNull private final MapFactory mapFactory;
     @Nullable private final String header;
     @NonNull private final TypeSerializerCollection serializers;
-    @Nullable private final ImmutableSet<Class<?>> acceptedTypes;
+    @Nullable private final Set<Class<?>> acceptedTypes;
     @NonNull private final ObjectMapperFactory objectMapperFactory;
     private final boolean shouldCopyDefaults;
 
@@ -60,7 +62,7 @@ public final class ConfigurationOptions {
         this.mapFactory = mapFactory;
         this.header = header;
         this.serializers = serializers;
-        this.acceptedTypes = acceptedTypes == null ? null : ImmutableSet.copyOf(acceptedTypes);
+        this.acceptedTypes = acceptedTypes == null ? null : UnmodifiableCollections.copyOf(acceptedTypes);
         this.objectMapperFactory = objectMapperFactory;
         this.shouldCopyDefaults = shouldCopyDefaults;
     }

--- a/core/src/main/java/org/spongepowered/configurate/ListConfigValue.java
+++ b/core/src/main/java/org/spongepowered/configurate/ListConfigValue.java
@@ -16,10 +16,10 @@
  */
 package org.spongepowered.configurate;
 
-import com.google.common.collect.ImmutableList;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.configurate.serialize.Scalars;
+import org.spongepowered.configurate.util.UnmodifiableCollections;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -65,11 +65,11 @@ final class ListConfigValue<N extends ScopedConfigurationNode<N>, T extends Abst
     public List<N> getUnwrapped() {
         final List<T> orig = this.values.get();
         synchronized (orig) {
-            final ImmutableList.Builder<N> ret = ImmutableList.builderWithExpectedSize(orig.size());
+            final List<N> ret = new ArrayList<>(orig.size());
             for (T element : orig) {
                 ret.add(element.self());
             }
-            return ret.build();
+            return Collections.unmodifiableList(ret);
         }
     }
 
@@ -162,7 +162,7 @@ final class ListConfigValue<N extends ScopedConfigurationNode<N>, T extends Abst
     public Iterable<T> iterateChildren() {
         final List<T> values = this.values.get();
         synchronized (values) {
-            return ImmutableList.copyOf(values);
+            return UnmodifiableCollections.copyOf(values);
         }
     }
 

--- a/core/src/main/java/org/spongepowered/configurate/MapConfigValue.java
+++ b/core/src/main/java/org/spongepowered/configurate/MapConfigValue.java
@@ -16,11 +16,11 @@
  */
 package org.spongepowered.configurate;
 
-import com.google.common.collect.ImmutableMap;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -58,9 +58,9 @@ final class MapConfigValue<N extends ScopedConfigurationNode<N>, A extends Abstr
     }
 
     public Map<Object, N> getUnwrapped() {
-        final ImmutableMap.Builder<Object, N> build = ImmutableMap.builderWithExpectedSize(this.values.size());
-        this.values.forEach((k, v) -> build.put(k, v.self()));
-        return build.build();
+        final Map<Object, N> unwrapped = new LinkedHashMap<>();
+        this.values.forEach((k, v) -> unwrapped.put(k, v.self()));
+        return Collections.unmodifiableMap(unwrapped);
     }
 
     @Override

--- a/core/src/main/java/org/spongepowered/configurate/SimpleAttributedConfigurationNode.java
+++ b/core/src/main/java/org/spongepowered/configurate/SimpleAttributedConfigurationNode.java
@@ -17,10 +17,10 @@
 package org.spongepowered.configurate;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -110,7 +110,7 @@ class SimpleAttributedConfigurationNode extends AbstractCommentedConfigurationNo
     @NonNull
     @Override
     public Map<String, String> getAttributes() {
-        return ImmutableMap.copyOf(this.attributes);
+        return Collections.unmodifiableMap(new LinkedHashMap<>(this.attributes));
     }
 
     @Override

--- a/core/src/main/java/org/spongepowered/configurate/loader/AbstractConfigurationLoader.java
+++ b/core/src/main/java/org/spongepowered/configurate/loader/AbstractConfigurationLoader.java
@@ -17,13 +17,13 @@
 package org.spongepowered.configurate.loader;
 
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableList;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.ConfigurationOptions;
 import org.spongepowered.configurate.ScopedConfigurationNode;
 import org.spongepowered.configurate.reference.ConfigurationReference;
+import org.spongepowered.configurate.util.UnmodifiableCollections;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -37,9 +37,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
 
 /**
  * Base class for many stream-based configuration loaders. This class provides
@@ -91,7 +93,7 @@ public abstract class AbstractConfigurationLoader<N extends ScopedConfigurationN
      * The comment handlers defined for this loader.
      */
     @NonNull
-    private final ImmutableList<CommentHandler> commentHandlers;
+    private final List<CommentHandler> commentHandlers;
 
     /**
      * The mode used to read/write configuration headers.
@@ -109,7 +111,7 @@ public abstract class AbstractConfigurationLoader<N extends ScopedConfigurationN
         this.source = builder.getSource();
         this.sink = builder.getSink();
         this.headerMode = builder.getHeaderMode();
-        this.commentHandlers = ImmutableList.copyOf(commentHandlers);
+        this.commentHandlers = UnmodifiableCollections.toList(commentHandlers);
         this.defaultOptions = builder.getDefaultOptions();
     }
 
@@ -166,7 +168,8 @@ public abstract class AbstractConfigurationLoader<N extends ScopedConfigurationN
             if (this.headerMode != HeaderMode.NONE) {
                 final @Nullable String header = node.getOptions().getHeader();
                 if (header != null && !header.isEmpty()) {
-                    for (String line : getDefaultCommentHandler().toComment(ImmutableList.copyOf(LINE_SPLITTER.split(header)))) {
+                    for (String line : getDefaultCommentHandler().toComment(LINE_SPLITTER.splitToList(header))
+                            .collect(Collectors.toList())) {
                         writer.write(line);
                         writer.write(SYSTEM_LINE_SEPARATOR);
                     }

--- a/core/src/main/java/org/spongepowered/configurate/loader/CommentHandler.java
+++ b/core/src/main/java/org/spongepowered/configurate/loader/CommentHandler.java
@@ -23,6 +23,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.stream.Stream;
 
 /**
  * Extracts comments from a buffered reader or collection of lines.
@@ -43,8 +44,8 @@ public interface CommentHandler {
      * Converts the specified lines into a comment.
      *
      * @param lines lines to make a comment
-     * @return transformed lines
+     * @return transformed lines as a stream
      */
-    @NonNull Collection<String> toComment(@NonNull Collection<String> lines);
+    @NonNull Stream<String> toComment(@NonNull Collection<String> lines);
 
 }

--- a/core/src/main/java/org/spongepowered/configurate/loader/CommentHandlers.java
+++ b/core/src/main/java/org/spongepowered/configurate/loader/CommentHandlers.java
@@ -16,7 +16,6 @@
  */
 package org.spongepowered.configurate.loader;
 
-import com.google.common.collect.Collections2;
 import com.google.errorprone.annotations.Immutable;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -24,9 +23,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.CharBuffer;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Defines a number of default {@link CommentHandler}s.
@@ -73,7 +71,7 @@ public enum CommentHandlers implements CommentHandler {
 
     @NonNull
     @Override
-    public Collection<String> toComment(final @NonNull Collection<String> lines) {
+    public Stream<String> toComment(final @NonNull Collection<String> lines) {
         return this.delegate.toComment(lines);
     }
 
@@ -171,15 +169,15 @@ public enum CommentHandlers implements CommentHandler {
 
         @NonNull
         @Override
-        public Collection<String> toComment(final @NonNull Collection<String> lines) {
+        public Stream<String> toComment(final @NonNull Collection<String> lines) {
             if (lines.size() == 1) {
-                return lines.stream().map(i -> this.startSequence + " " + i + " " + this.endSequence).collect(Collectors.toList());
+                return lines.stream().map(i -> this.startSequence + " " + i + " " + this.endSequence);
             } else {
-                final Collection<String> ret = new ArrayList<>();
-                ret.add(this.startSequence);
-                ret.addAll(lines.stream().map(i -> " " + this.lineIndentSequence + " " + i).collect(Collectors.toList()));
-                ret.add(" " + this.endSequence);
-                return ret;
+                return Stream.of(
+                        Stream.of(this.startSequence),
+                        lines.stream().map(i -> " " + this.lineIndentSequence + " " + i),
+                        Stream.of(" " + this.endSequence)
+                ).flatMap(x -> x);
             }
         }
     }
@@ -227,14 +225,15 @@ public enum CommentHandlers implements CommentHandler {
         }
 
         @Override
-        public @NonNull Collection<String> toComment(final @NonNull Collection<String> lines) {
-            return Collections2.transform(lines, s -> {
-                if (s.startsWith(" ")) {
-                    return this.commentPrefix + s;
-                } else {
-                    return this.commentPrefix + " " + s;
-                }
-            });
+        public @NonNull Stream<String> toComment(final @NonNull Collection<String> lines) {
+            return lines.stream()
+                    .map(s -> {
+                        if (s.startsWith(" ")) {
+                            return this.commentPrefix + s;
+                        } else {
+                            return this.commentPrefix + " " + s;
+                        }
+                    });
         }
     }
 

--- a/core/src/main/java/org/spongepowered/configurate/reference/ValueReferenceImpl.java
+++ b/core/src/main/java/org/spongepowered/configurate/reference/ValueReferenceImpl.java
@@ -16,7 +16,6 @@
  */
 package org.spongepowered.configurate.reference;
 
-import com.google.common.collect.Maps;
 import com.google.common.reflect.TypeToken;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.configurate.ScopedConfigurationNode;
@@ -28,6 +27,7 @@ import org.spongepowered.configurate.reactive.TransactionFailedException;
 import org.spongepowered.configurate.reference.ConfigurationReference.ErrorPhase;
 import org.spongepowered.configurate.serialize.TypeSerializer;
 import org.spongepowered.configurate.transformation.NodePath;
+import org.spongepowered.configurate.util.UnmodifiableCollections;
 
 import java.io.IOException;
 import java.util.concurrent.Executor;
@@ -56,7 +56,7 @@ class ValueReferenceImpl<@Nullable T, N extends ScopedConfigurationNode<N>> impl
             try {
                 return deserializedValueFrom(n, def);
             } catch (final ObjectMappingException e) {
-                root.errorListener.submit(Maps.immutableEntry(ErrorPhase.VALUE, e));
+                root.errorListener.submit(UnmodifiableCollections.immutableMapEntry(ErrorPhase.VALUE, e));
                 throw new TransactionFailedException(e);
             }
         }).cache(deserializedValueFrom(root.getNode(), def));
@@ -90,7 +90,7 @@ class ValueReferenceImpl<@Nullable T, N extends ScopedConfigurationNode<N>> impl
             this.deserialized.submit(value);
             return true;
         } catch (final ObjectMappingException e) {
-            this.root.errorListener.submit(Maps.immutableEntry(ErrorPhase.SAVING, e));
+            this.root.errorListener.submit(UnmodifiableCollections.immutableMapEntry(ErrorPhase.SAVING, e));
             return false;
         }
     }
@@ -103,7 +103,7 @@ class ValueReferenceImpl<@Nullable T, N extends ScopedConfigurationNode<N>> impl
                 return true;
             }
         } catch (final IOException e) {
-            this.root.errorListener.submit(Maps.immutableEntry(ErrorPhase.SAVING, e));
+            this.root.errorListener.submit(UnmodifiableCollections.immutableMapEntry(ErrorPhase.SAVING, e));
         }
         return false;
     }
@@ -123,7 +123,7 @@ class ValueReferenceImpl<@Nullable T, N extends ScopedConfigurationNode<N>> impl
         try {
             return set(action.apply(get()));
         } catch (final Exception t) {
-            this.root.errorListener.submit(Maps.immutableEntry(ErrorPhase.VALUE, t));
+            this.root.errorListener.submit(UnmodifiableCollections.immutableMapEntry(ErrorPhase.VALUE, t));
             return false;
         }
     }

--- a/core/src/main/java/org/spongepowered/configurate/reference/WatchingConfigurationReference.java
+++ b/core/src/main/java/org/spongepowered/configurate/reference/WatchingConfigurationReference.java
@@ -16,12 +16,12 @@
  */
 package org.spongepowered.configurate.reference;
 
-import com.google.common.collect.Maps;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.spongepowered.configurate.ScopedConfigurationNode;
 import org.spongepowered.configurate.loader.ConfigurationLoader;
 import org.spongepowered.configurate.reactive.Disposable;
 import org.spongepowered.configurate.reactive.Subscriber;
+import org.spongepowered.configurate.util.UnmodifiableCollections;
 
 import java.io.IOException;
 import java.nio.file.StandardWatchEventKinds;
@@ -67,14 +67,14 @@ class WatchingConfigurationReference<N extends ScopedConfigurationNode<N>>
             try {
                 load();
             } catch (final Exception e) {
-                this.errorListener.submit(Maps.immutableEntry(ErrorPhase.LOADING, e));
+                this.errorListener.submit(UnmodifiableCollections.immutableMapEntry(ErrorPhase.LOADING, e));
             }
         }
     }
 
     @Override
     public void onError(final Throwable e) {
-        this.errorListener.submit(Maps.immutableEntry(ErrorPhase.UNKNOWN, e));
+        this.errorListener.submit(UnmodifiableCollections.immutableMapEntry(ErrorPhase.UNKNOWN, e));
     }
 
     @Override

--- a/core/src/main/java/org/spongepowered/configurate/serialize/AbstractListChildSerializer.java
+++ b/core/src/main/java/org/spongepowered/configurate/serialize/AbstractListChildSerializer.java
@@ -16,7 +16,6 @@
  */
 package org.spongepowered.configurate.serialize;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.TypeToken;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
@@ -24,6 +23,7 @@ import org.spongepowered.configurate.ScopedConfigurationNode;
 import org.spongepowered.configurate.objectmapping.ObjectMappingException;
 import org.spongepowered.configurate.util.CheckedConsumer;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -70,7 +70,7 @@ abstract class AbstractListChildSerializer<T> implements TypeSerializer<T> {
             throw new ObjectMappingException("No applicable type serializer for type " + entryType);
         }
 
-        node.setValue(ImmutableList.of());
+        node.setValue(Collections.emptyList());
         if (obj != null) {
             forEachElement(obj, el -> entrySerial.serialize(entryType, el, node.appendListNode()));
         }

--- a/core/src/main/java/org/spongepowered/configurate/serialize/MapSerializer.java
+++ b/core/src/main/java/org/spongepowered/configurate/serialize/MapSerializer.java
@@ -18,7 +18,6 @@ package org.spongepowered.configurate.serialize;
 
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.reflect.TypeToken;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -27,6 +26,7 @@ import org.spongepowered.configurate.ScopedConfigurationNode;
 import org.spongepowered.configurate.objectmapping.ObjectMappingException;
 
 import java.lang.reflect.ParameterizedType;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -93,7 +93,7 @@ class MapSerializer implements TypeSerializer<Map<?, ?>> {
         }
 
         if (obj == null || obj.isEmpty()) {
-            node.setValue(ImmutableMap.of());
+            node.setValue(Collections.emptyMap());
         } else {
             final Set<Object> unvisitedKeys = new HashSet<>(node.getChildrenMap().keySet());
             final BasicConfigurationNode keyNode = BasicConfigurationNode.root(node.getOptions());

--- a/core/src/main/java/org/spongepowered/configurate/serialize/TypeSerializerCollection.java
+++ b/core/src/main/java/org/spongepowered/configurate/serialize/TypeSerializerCollection.java
@@ -18,10 +18,11 @@ package org.spongepowered.configurate.serialize;
 
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.TypeToken;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.configurate.util.UnmodifiableCollections;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -69,12 +70,12 @@ public final class TypeSerializerCollection {
     }
 
     private final @Nullable TypeSerializerCollection parent;
-    private final ImmutableList<RegisteredSerializer> serializers;
+    private final List<RegisteredSerializer> serializers;
     private final Map<TypeToken<?>, TypeSerializer<?>> typeMatches = new ConcurrentHashMap<>();
 
     private TypeSerializerCollection(final @Nullable TypeSerializerCollection parent, final List<RegisteredSerializer> serializers) {
         this.parent = parent;
-        this.serializers = ImmutableList.copyOf(serializers);
+        this.serializers = UnmodifiableCollections.copyOf(serializers);
     }
 
     /**
@@ -170,7 +171,7 @@ public final class TypeSerializerCollection {
 
     public static class Builder {
         private final @Nullable TypeSerializerCollection parent;
-        private final ImmutableList.Builder<RegisteredSerializer> serializers = ImmutableList.builder();
+        private final List<RegisteredSerializer> serializers = new ArrayList<>();
 
         Builder(final @Nullable TypeSerializerCollection parent) {
             this.parent = parent;
@@ -221,7 +222,7 @@ public final class TypeSerializerCollection {
          * @return The resulting collection
          */
         public TypeSerializerCollection build() {
-            return new TypeSerializerCollection(this.parent, this.serializers.build());
+            return new TypeSerializerCollection(this.parent, this.serializers);
         }
     }
 

--- a/core/src/main/java/org/spongepowered/configurate/transformation/NodePathImpl.java
+++ b/core/src/main/java/org/spongepowered/configurate/transformation/NodePathImpl.java
@@ -18,7 +18,6 @@ package org.spongepowered.configurate.transformation;
 
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.collect.Iterators;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.Arrays;
@@ -78,7 +77,7 @@ final class NodePathImpl implements NodePath {
 
     @Override
     public @NonNull Iterator<Object> iterator() {
-        return Iterators.forArray(this.arr);
+        return Arrays.asList(this.arr).iterator();
     }
 
     @Override

--- a/core/src/main/java/org/spongepowered/configurate/util/EnumLookup.java
+++ b/core/src/main/java/org/spongepowered/configurate/util/EnumLookup.java
@@ -18,9 +18,9 @@ package org.spongepowered.configurate.util;
 
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.collect.ImmutableMap;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -70,7 +70,7 @@ public final class EnumLookup {
                 ret.put(field.name(), field);
                 ret.putIfAbsent(processKey(field.name()), field);
             }
-            return ImmutableMap.copyOf(ret);
+            return Collections.unmodifiableMap(ret);
         });
 
 

--- a/core/src/main/java/org/spongepowered/configurate/util/UnmodifiableCollections.java
+++ b/core/src/main/java/org/spongepowered/configurate/util/UnmodifiableCollections.java
@@ -1,0 +1,124 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spongepowered.configurate.util;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Provides a set of methods that produce unmodifiable copies of collections.
+ */
+public final class UnmodifiableCollections {
+
+    private UnmodifiableCollections() {}
+
+    /**
+     * Creates an unmodifiable copy of the given {@link List} instance.
+     *
+     * @param original the list to be copied
+     * @param <E> the type of every item in the entry
+     * @return a unmodifiable copy of the given {@link List} instance
+     */
+    public static <E> List<E> copyOf(final List<E> original) {
+        switch (original.size()) {
+            case 0:
+                return Collections.emptyList();
+            case 1:
+                return Collections.singletonList(original.get(0));
+            default:
+                return Collections.unmodifiableList(new ArrayList<>(original));
+        }
+    }
+
+    /**
+     * Creates an unmodifiable copy of the given {@link Set} instance.
+     *
+     * @param original the set to be copied
+     * @param <E> the type of every item in the entry
+     * @return a unmodifiable copy of the given {@link Set} instance
+     */
+    public static <E> Set<E> copyOf(final Set<E> original) {
+        switch (original.size()) {
+            case 0:
+                return Collections.emptySet();
+            case 1:
+                return Collections.singleton(original.iterator().next());
+            default:
+                return Collections.unmodifiableSet(new LinkedHashSet<>(original));
+        }
+    }
+
+    /**
+     * Creates an unmodifiable copy of the given array as a list, preserving
+     * order.
+     *
+     * @param original the array to be copied into a list
+     * @param <E> the type of every item in the entry
+     * @return a unmodifiable copy of the given array as a {@link List}
+     *         instance
+     */
+    @SafeVarargs
+    public static <E> List<E> toList(final E... original) {
+        switch (original.length) {
+            case 0:
+                return Collections.emptyList();
+            case 1:
+                return Collections.singletonList(original[0]);
+            default:
+                return Collections.unmodifiableList(new ArrayList<>(Arrays.asList(original)));
+        }
+    }
+
+    /**
+     * Creates an unmodifiable copy of the given array as a set.
+     *
+     * @param original the array to be copied into a set
+     * @param <E> the type of every item in the entry
+     * @return a unmodifiable copy of the given array as a {@link Set} instance
+     */
+    @SafeVarargs
+    public static <E> Set<E> toSet(final E... original) {
+        switch (original.length) {
+            case 0:
+                return Collections.emptySet();
+            case 1:
+                return Collections.singleton(original[0]);
+            default:
+                return Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(original)));
+        }
+    }
+
+    /**
+     * Creates an immutable instance of {@link Map.Entry}.
+     *
+     * @param key the key in the entry
+     * @param value the value in the entry
+     * @param <K> the key's type
+     * @param <V> the value's type
+     * @return the new map entry
+     */
+    public static <K, V> Map.Entry<K, V> immutableMapEntry(final K key, final V value) {
+        return new AbstractMap.SimpleImmutableEntry<>(key, value);
+    }
+
+}

--- a/core/src/test/java/org/spongepowered/configurate/loader/CommentHandlersTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/loader/CommentHandlersTest.java
@@ -34,6 +34,7 @@ import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.Collectors;
 
 @ExtendWith(TempDirectory.class)
 public class CommentHandlersTest {
@@ -52,9 +53,9 @@ public class CommentHandlersTest {
                 + "more header\n"
                 + "even more header", head);
 
-        assertEquals(testDocument, Joiner.on('\n').join(CommentHandlers.SLASH_BLOCK.toComment(AbstractConfigurationLoader
+        assertEquals(testDocument, CommentHandlers.SLASH_BLOCK.toComment(AbstractConfigurationLoader
                 .LINE_SPLITTER
-                .splitToList(head))));
+                .splitToList(head)).collect(Collectors.joining("\n")));
 
     }
 

--- a/format/gson/src/main/java/org/spongepowered/configurate/gson/GsonConfigurationLoader.java
+++ b/format/gson/src/main/java/org/spongepowered/configurate/gson/GsonConfigurationLoader.java
@@ -17,9 +17,6 @@
 package org.spongepowered.configurate.gson;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.gson.JsonParseException;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
@@ -32,12 +29,15 @@ import org.spongepowered.configurate.ConfigurationOptions;
 import org.spongepowered.configurate.loader.AbstractConfigurationLoader;
 import org.spongepowered.configurate.loader.CommentHandler;
 import org.spongepowered.configurate.loader.CommentHandlers;
+import org.spongepowered.configurate.util.UnmodifiableCollections;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Writer;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A loader for JSON-formatted configurations, using the GSON library for
@@ -45,7 +45,7 @@ import java.util.Map;
  */
 public final class GsonConfigurationLoader extends AbstractConfigurationLoader<BasicConfigurationNode> {
 
-    private static final ImmutableSet<Class<?>> NATIVE_TYPES = ImmutableSet.of(Map.class, List.class, Double.class, Float.class,
+    private static final Set<Class<?>> NATIVE_TYPES = UnmodifiableCollections.toSet(Map.class, List.class, Double.class, Float.class,
             Long.class, Integer.class, Boolean.class, String.class);
 
     /**
@@ -193,7 +193,7 @@ public final class GsonConfigurationLoader extends AbstractConfigurationLoader<B
                     parser.endArray();
                     // ensure the type is preserved
                     if (!written) {
-                        node.setValue(ImmutableList.of());
+                        node.setValue(Collections.emptyList());
                     }
                     return;
                 default:
@@ -217,7 +217,7 @@ public final class GsonConfigurationLoader extends AbstractConfigurationLoader<B
                     parser.endObject();
                     // ensure the type is preserved
                     if (!written) {
-                        node.setValue(ImmutableMap.of());
+                        node.setValue(Collections.emptyMap());
                     }
                     return;
                 case NAME:

--- a/format/hocon/src/main/java/org/spongepowered/configurate/hocon/HoconConfigurationLoader.java
+++ b/format/hocon/src/main/java/org/spongepowered/configurate/hocon/HoconConfigurationLoader.java
@@ -17,9 +17,6 @@
 package org.spongepowered.configurate.hocon;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigList;
@@ -39,6 +36,7 @@ import org.spongepowered.configurate.ConfigurationOptions;
 import org.spongepowered.configurate.loader.AbstractConfigurationLoader;
 import org.spongepowered.configurate.loader.CommentHandler;
 import org.spongepowered.configurate.loader.CommentHandlers;
+import org.spongepowered.configurate.util.UnmodifiableCollections;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -46,8 +44,10 @@ import java.io.Writer;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
@@ -56,7 +56,7 @@ import java.util.regex.Pattern;
  */
 public final class HoconConfigurationLoader extends AbstractConfigurationLoader<CommentedConfigurationNode> {
 
-    private static final ImmutableSet<Class<?>> NATIVE_TYPES = ImmutableSet.of(Map.class, List.class, Double.class,
+    private static final Set<Class<?>> NATIVE_TYPES = UnmodifiableCollections.toSet(Map.class, List.class, Double.class,
             Long.class, Integer.class, Boolean.class, String.class, Number.class);
 
     /**
@@ -192,7 +192,7 @@ public final class HoconConfigurationLoader extends AbstractConfigurationLoader<
             case OBJECT:
                 final ConfigObject object = (ConfigObject) value;
                 if (object.isEmpty()) {
-                    node.setValue(ImmutableMap.of());
+                    node.setValue(Collections.emptyMap());
                 } else {
                     for (Map.Entry<String, ConfigValue> ent : object.entrySet()) {
                         readConfigValue(ent.getValue(), node.getNode(ent.getKey()));
@@ -202,7 +202,7 @@ public final class HoconConfigurationLoader extends AbstractConfigurationLoader<
             case LIST:
                 final ConfigList list = (ConfigList) value;
                 if (list.isEmpty()) {
-                    node.setValue(ImmutableList.of());
+                    node.setValue(Collections.emptyList());
                 } else {
                     for (int i = 0; i < list.size(); ++i) {
                         readConfigValue(list.get(i), node.getNode(i));

--- a/format/jackson/src/main/java/org/spongepowered/configurate/jackson/JacksonConfigurationLoader.java
+++ b/format/jackson/src/main/java/org/spongepowered/configurate/jackson/JacksonConfigurationLoader.java
@@ -23,9 +23,6 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.json.JsonReadFeature;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.spongepowered.configurate.BasicConfigurationNode;
 import org.spongepowered.configurate.ConfigurationNode;
@@ -33,12 +30,15 @@ import org.spongepowered.configurate.ConfigurationOptions;
 import org.spongepowered.configurate.loader.AbstractConfigurationLoader;
 import org.spongepowered.configurate.loader.CommentHandler;
 import org.spongepowered.configurate.loader.CommentHandlers;
+import org.spongepowered.configurate.util.UnmodifiableCollections;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Writer;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A loader for JSON-formatted configurations, using the jackson library for
@@ -46,7 +46,7 @@ import java.util.Map;
  */
 public final class JacksonConfigurationLoader extends AbstractConfigurationLoader<BasicConfigurationNode> {
 
-    private static final ImmutableSet<Class<?>> NATIVE_TYPES = ImmutableSet.of(Map.class, List.class, Double.class, Float.class,
+    private static final Set<Class<?>> NATIVE_TYPES = UnmodifiableCollections.toSet(Map.class, List.class, Double.class, Float.class,
             Long.class, Integer.class, Boolean.class, String.class, byte[].class);
 
     /**
@@ -206,7 +206,7 @@ public final class JacksonConfigurationLoader extends AbstractConfigurationLoade
                 case END_ARRAY:
                     // ensure the type is preserved
                     if (!written) {
-                        node.setValue(ImmutableList.of());
+                        node.setValue(Collections.emptyList());
                     }
                     return;
                 default:
@@ -225,7 +225,7 @@ public final class JacksonConfigurationLoader extends AbstractConfigurationLoade
                 case END_OBJECT:
                     // ensure the type is preserved
                     if (!written) {
-                        node.setValue(ImmutableMap.of());
+                        node.setValue(Collections.emptyMap());
                     }
                     return;
                 default:

--- a/format/xml/src/main/java/org/spongepowered/configurate/xml/XmlConfigurationLoader.java
+++ b/format/xml/src/main/java/org/spongepowered/configurate/xml/XmlConfigurationLoader.java
@@ -16,9 +16,6 @@
  */
 package org.spongepowered.configurate.xml;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
 import com.google.common.math.DoubleMath;
@@ -31,6 +28,7 @@ import org.spongepowered.configurate.ConfigurationOptions;
 import org.spongepowered.configurate.loader.AbstractConfigurationLoader;
 import org.spongepowered.configurate.loader.CommentHandler;
 import org.spongepowered.configurate.loader.CommentHandlers;
+import org.spongepowered.configurate.util.UnmodifiableCollections;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
@@ -44,9 +42,11 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.NoSuchFileException;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -66,7 +66,7 @@ import javax.xml.validation.Schema;
  */
 public final class XmlConfigurationLoader extends AbstractConfigurationLoader<AttributedConfigurationNode> {
 
-    private static final ImmutableSet<Class<?>> NATIVE_TYPES = ImmutableSet.of(Double.class, Long.class,
+    private static final Set<Class<?>> NATIVE_TYPES = UnmodifiableCollections.toSet(Double.class, Long.class,
             Integer.class, Boolean.class, String.class, Number.class);
 
     /**
@@ -488,9 +488,9 @@ public final class XmlConfigurationLoader extends AbstractConfigurationLoader<At
         }
 
         if (type == NodeType.MAP) {
-            to.setValue(ImmutableMap.of());
+            to.setValue(Collections.emptyMap());
         } else {
-            to.setValue(ImmutableList.of());
+            to.setValue(Collections.emptyList());
         }
 
         // read out the elements
@@ -554,7 +554,7 @@ public final class XmlConfigurationLoader extends AbstractConfigurationLoader<At
 
     private Element writeNode(final Document document, final ConfigurationNode node, final @Nullable String forcedTag) {
         String tag = this.defaultTagName;
-        Map<String, String> attributes = ImmutableMap.of();
+        Map<String, String> attributes = Collections.emptyMap();
 
         if (node instanceof AttributedConfigurationNode) {
             final AttributedConfigurationNode attributedNode = ((AttributedConfigurationNode) node);

--- a/format/yaml/src/main/java/org/spongepowered/configurate/yaml/YamlConfigurationLoader.java
+++ b/format/yaml/src/main/java/org/spongepowered/configurate/yaml/YamlConfigurationLoader.java
@@ -16,7 +16,6 @@
  */
 package org.spongepowered.configurate.yaml;
 
-import com.google.common.collect.ImmutableSet;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.spongepowered.configurate.BasicConfigurationNode;
 import org.spongepowered.configurate.ConfigurationNode;
@@ -24,6 +23,7 @@ import org.spongepowered.configurate.ConfigurationOptions;
 import org.spongepowered.configurate.loader.AbstractConfigurationLoader;
 import org.spongepowered.configurate.loader.CommentHandler;
 import org.spongepowered.configurate.loader.CommentHandlers;
+import org.spongepowered.configurate.util.UnmodifiableCollections;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.DumperOptions.FlowStyle;
 import org.yaml.snakeyaml.Yaml;
@@ -49,7 +49,7 @@ public final class YamlConfigurationLoader extends AbstractConfigurationLoader<B
      *
      * <p>using SnakeYaml representation: https://bitbucket.org/asomov/snakeyaml/wiki/Documentation#markdown-header-yaml-tags-and-java-types
      */
-    private static final ImmutableSet<Class<?>> NATIVE_TYPES = ImmutableSet.of(
+    private static final Set<Class<?>> NATIVE_TYPES = UnmodifiableCollections.toSet(
             Boolean.class, Integer.class, Long.class, BigInteger.class, Double.class, // numeric
             byte[].class, String.class, Date.class, java.sql.Date.class, Timestamp.class, // complex types
             Set.class, List.class, Map.class); // collections


### PR DESCRIPTION
This PR is a part of #150 and specifically focuses on removing all uses of `com.google.common.collect.Immutable*` classes.