### PR TITLE
Support implicit node initialization

### DIFF
--- a/core/src/main/java/org/spongepowered/configurate/AbstractConfigurationNode.java
+++ b/core/src/main/java/org/spongepowered/configurate/AbstractConfigurationNode.java
@@ -117,7 +117,7 @@ abstract class AbstractConfigurationNode<N extends ScopedConfigurationNode<N>, A
      */
     static <V> V storeDefault(final ConfigurationNode node, final V defValue) {
         requireNonNull(defValue, "defValue");
-        if (node.getOptions().shouldCopyDefaults()) {
+        if (node.getOptions().getShouldCopyDefaults()) {
             node.setValue(defValue);
         }
         return defValue;
@@ -125,7 +125,7 @@ abstract class AbstractConfigurationNode<N extends ScopedConfigurationNode<N>, A
 
     static <V> V storeDefault(final ConfigurationNode node, final Type type, final V defValue) throws ObjectMappingException {
         requireNonNull(defValue, "defValue");
-        if (node.getOptions().shouldCopyDefaults()) {
+        if (node.getOptions().getShouldCopyDefaults()) {
             node.setValue(type, defValue);
         }
         return defValue;

--- a/core/src/main/java/org/spongepowered/configurate/AbstractConfigurationNode.java
+++ b/core/src/main/java/org/spongepowered/configurate/AbstractConfigurationNode.java
@@ -143,11 +143,17 @@ abstract class AbstractConfigurationNode<N extends ScopedConfigurationNode<N>, A
             throw new IllegalArgumentException("Raw types are not supported");
         }
 
-        if (isVirtual()) {
+        final @Nullable TypeSerializer<?> serial = getOptions().getSerializers().get(type);
+        if (this.value instanceof NullConfigValue) {
+            if (serial != null && getOptions().isImplicitInitialization()) {
+                final @Nullable Object emptyValue = serial.emptyValue(type, this.options);
+                if (emptyValue != null) {
+                    return storeDefault(this, type, emptyValue);
+                }
+            }
             return null;
         }
 
-        final @Nullable TypeSerializer<?> serial = getOptions().getSerializers().get(type);
         if (serial == null) {
             final @Nullable Object value = getValue();
             final Class<?> erasure = erase(type);

--- a/core/src/main/java/org/spongepowered/configurate/ConfigurationNode.java
+++ b/core/src/main/java/org/spongepowered/configurate/ConfigurationNode.java
@@ -634,7 +634,7 @@ public interface ConfigurationNode {
         if (value != null) {
             return value;
         }
-        if (getOptions().shouldCopyDefaults()) {
+        if (getOptions().getShouldCopyDefaults()) {
             setValue(def);
         }
         return def;
@@ -662,7 +662,7 @@ public interface ConfigurationNode {
         if (val != null) {
             return val;
         }
-        if (getOptions().shouldCopyDefaults() && def != NUMBER_DEF) {
+        if (getOptions().getShouldCopyDefaults() && def != NUMBER_DEF) {
             setValue(def);
         }
         return def;
@@ -690,7 +690,7 @@ public interface ConfigurationNode {
         if (val != null) {
             return val;
         }
-        if (getOptions().shouldCopyDefaults() && def != NUMBER_DEF) {
+        if (getOptions().getShouldCopyDefaults() && def != NUMBER_DEF) {
             setValue(def);
         }
         return def;
@@ -718,7 +718,7 @@ public interface ConfigurationNode {
         if (val != null) {
             return val;
         }
-        if (getOptions().shouldCopyDefaults() && def != NUMBER_DEF) {
+        if (getOptions().getShouldCopyDefaults() && def != NUMBER_DEF) {
             setValue(def);
         }
         return def;
@@ -746,7 +746,7 @@ public interface ConfigurationNode {
         if (val != null) {
             return val;
         }
-        if (getOptions().shouldCopyDefaults() && def != NUMBER_DEF) {
+        if (getOptions().getShouldCopyDefaults() && def != NUMBER_DEF) {
             setValue(def);
         }
         return def;
@@ -774,7 +774,7 @@ public interface ConfigurationNode {
         if (val != null) {
             return val;
         }
-        if (getOptions().shouldCopyDefaults()) {
+        if (getOptions().getShouldCopyDefaults()) {
             setValue(def);
         }
         return def;

--- a/core/src/main/java/org/spongepowered/configurate/ConfigurationOptions.java
+++ b/core/src/main/java/org/spongepowered/configurate/ConfigurationOptions.java
@@ -18,6 +18,7 @@ package org.spongepowered.configurate;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.auto.value.AutoValue;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.configurate.loader.ConfigurationLoader;
 import org.spongepowered.configurate.serialize.TypeSerializerCollection;
@@ -40,24 +41,19 @@ import java.util.function.Consumer;
  *
  * <p>This class is immutable.</p>
  */
-public final class ConfigurationOptions {
+@AutoValue
+public abstract class ConfigurationOptions {
 
-    private static final ConfigurationOptions DEFAULTS = new ConfigurationOptions(MapFactories.insertionOrdered(), null,
-        TypeSerializerCollection.defaults(), null, false);
+    static class Lazy {
 
-    private final MapFactory mapFactory;
-    private final @Nullable String header;
-    private final TypeSerializerCollection serializers;
-    private final @Nullable Set<Class<?>> acceptedTypes;
-    private final boolean shouldCopyDefaults;
+        // avoid initialization cycles
 
-    private ConfigurationOptions(final MapFactory mapFactory, final @Nullable String header, final TypeSerializerCollection serializers,
-            final @Nullable Set<Class<?>> acceptedTypes, final boolean shouldCopyDefaults) {
-        this.mapFactory = mapFactory;
-        this.header = header;
-        this.serializers = serializers;
-        this.acceptedTypes = acceptedTypes == null ? null : UnmodifiableCollections.copyOf(acceptedTypes);
-        this.shouldCopyDefaults = shouldCopyDefaults;
+        static final ConfigurationOptions DEFAULTS = new AutoValue_ConfigurationOptions(MapFactories.insertionOrdered(), null,
+                TypeSerializerCollection.defaults(), null, false);
+
+    }
+
+    ConfigurationOptions() {
     }
 
     /**
@@ -69,7 +65,7 @@ public final class ConfigurationOptions {
      * @return the default options
      */
     public static ConfigurationOptions defaults() {
-        return DEFAULTS;
+        return Lazy.DEFAULTS;
     }
 
     /**
@@ -77,9 +73,7 @@ public final class ConfigurationOptions {
      *
      * @return The map factory
      */
-    public MapFactory getMapFactory() {
-        return this.mapFactory;
-    }
+    public abstract MapFactory getMapFactory();
 
     /**
      * Creates a new {@link ConfigurationOptions} instance, with the specified
@@ -90,10 +84,10 @@ public final class ConfigurationOptions {
      */
     public ConfigurationOptions withMapFactory(final MapFactory mapFactory) {
         requireNonNull(mapFactory, "mapFactory");
-        if (this.mapFactory == mapFactory) {
+        if (this.getMapFactory() == mapFactory) {
             return this;
         }
-        return new ConfigurationOptions(mapFactory, this.header, this.serializers, this.acceptedTypes, this.shouldCopyDefaults);
+        return new AutoValue_ConfigurationOptions(mapFactory, getHeader(), getSerializers(), getNativeTypes(), shouldCopyDefaults());
     }
 
     /**
@@ -101,9 +95,7 @@ public final class ConfigurationOptions {
      *
      * @return The current header. Lines are split by \n,
      */
-    public @Nullable String getHeader() {
-        return this.header;
-    }
+    public abstract @Nullable String getHeader();
 
     /**
      * Creates a new {@link ConfigurationOptions} instance, with the specified
@@ -113,10 +105,10 @@ public final class ConfigurationOptions {
      * @return The new options object
      */
     public ConfigurationOptions withHeader(final @Nullable String header) {
-        if (Objects.equals(this.header, header)) {
+        if (Objects.equals(this.getHeader(), header)) {
             return this;
         }
-        return new ConfigurationOptions(this.mapFactory, header, this.serializers, this.acceptedTypes, this.shouldCopyDefaults);
+        return new AutoValue_ConfigurationOptions(getMapFactory(), header, getSerializers(), getNativeTypes(), shouldCopyDefaults());
     }
 
     /**
@@ -124,9 +116,7 @@ public final class ConfigurationOptions {
      *
      * @return The type serializers
      */
-    public TypeSerializerCollection getSerializers() {
-        return this.serializers;
-    }
+    public abstract TypeSerializerCollection getSerializers();
 
     /**
      * Creates a new {@link ConfigurationOptions} instance, with the specified {@link TypeSerializerCollection}
@@ -137,10 +127,10 @@ public final class ConfigurationOptions {
      */
     public ConfigurationOptions withSerializers(final TypeSerializerCollection serializers) {
         requireNonNull(serializers, "serializers");
-        if (this.serializers.equals(serializers)) {
+        if (this.getSerializers().equals(serializers)) {
             return this;
         }
-        return new ConfigurationOptions(this.mapFactory, this.header, serializers, this.acceptedTypes, this.shouldCopyDefaults);
+        return new AutoValue_ConfigurationOptions(getMapFactory(), getHeader(), serializers, getNativeTypes(), shouldCopyDefaults());
     }
 
     /**
@@ -153,12 +143,15 @@ public final class ConfigurationOptions {
      *                          be used in the returned options object.
      * @return The new options object
      */
-    public ConfigurationOptions withSerializers(final Consumer<TypeSerializerCollection.Builder> serializerBuilder) {
+    public final ConfigurationOptions withSerializers(final Consumer<TypeSerializerCollection.Builder> serializerBuilder) {
         requireNonNull(serializerBuilder, "serializerBuilder");
-        final TypeSerializerCollection.Builder builder = this.serializers.childBuilder();
+        final TypeSerializerCollection.Builder builder = this.getSerializers().childBuilder();
         serializerBuilder.accept(builder);
-        return new ConfigurationOptions(this.mapFactory, this.header, builder.build(), this.acceptedTypes, this.shouldCopyDefaults);
+        return withSerializers(builder.build());
     }
+
+    @SuppressWarnings("AutoValueImmutableFields") // we don't use guava
+    abstract @Nullable Set<Class<?>> getNativeTypes();
 
     /**
      * Gets whether objects of the provided type are natively accepted as values
@@ -167,26 +160,29 @@ public final class ConfigurationOptions {
      * @param type The type to check
      * @return Whether the type is accepted
      */
-    public boolean acceptsType(final Class<?> type) {
+    public final boolean acceptsType(final Class<?> type) {
         requireNonNull(type, "type");
 
-        if (this.acceptedTypes == null) {
-            return true;
-        }
-        if (this.acceptedTypes.contains(type)) {
+        final @Nullable Set<Class<?>> nativeTypes = getNativeTypes();
+
+        if (nativeTypes == null) {
             return true;
         }
 
-        if (type.isPrimitive() && this.acceptedTypes.contains(Typing.box(type))) {
+        if (nativeTypes.contains(type)) {
+            return true;
+        }
+
+        if (type.isPrimitive() && nativeTypes.contains(Typing.box(type))) {
             return true;
         }
 
         final Type unboxed = Typing.unbox(type);
-        if (unboxed != type && this.acceptedTypes.contains(unboxed)) {
+        if (unboxed != type && nativeTypes.contains(unboxed)) {
             return true;
         }
 
-        for (Class<?> clazz : this.acceptedTypes) {
+        for (Class<?> clazz : nativeTypes) {
             if (clazz.isAssignableFrom(type)) {
                 return true;
             }
@@ -204,14 +200,15 @@ public final class ConfigurationOptions {
      *
      * <p>Null indicates that all types are accepted.</p>
      *
-     * @param acceptedTypes The types that will be accepted to a call to {@link ConfigurationNode#setValue(Object)}
+     * @param nativeTypes The types that will be accepted to a call to {@link ConfigurationNode#setValue(Object)}
      * @return updated options object
      */
-    public ConfigurationOptions withNativeTypes(final @Nullable Set<Class<?>> acceptedTypes) {
-        if (Objects.equals(this.acceptedTypes, acceptedTypes)) {
+    public ConfigurationOptions withNativeTypes(final @Nullable Set<Class<?>> nativeTypes) {
+        if (Objects.equals(this.getNativeTypes(), nativeTypes)) {
             return this;
         }
-        return new ConfigurationOptions(this.mapFactory, this.header, this.serializers, acceptedTypes, this.shouldCopyDefaults);
+        return new AutoValue_ConfigurationOptions(getMapFactory(), getHeader(), getSerializers(),
+                nativeTypes == null ? null : UnmodifiableCollections.copyOf(nativeTypes), shouldCopyDefaults());
     }
 
     /**
@@ -220,9 +217,7 @@ public final class ConfigurationOptions {
      *
      * @return Whether defaults should be copied into value
      */
-    public boolean shouldCopyDefaults() {
-        return this.shouldCopyDefaults;
-    }
+    public abstract boolean shouldCopyDefaults();
 
     /**
      * Creates a new {@link ConfigurationOptions} instance, with the specified 'copy defaults' setting
@@ -233,44 +228,11 @@ public final class ConfigurationOptions {
      * @return updated options object
      */
     public ConfigurationOptions withShouldCopyDefaults(final boolean shouldCopyDefaults) {
-        if (this.shouldCopyDefaults == shouldCopyDefaults) {
+        if (this.shouldCopyDefaults() == shouldCopyDefaults) {
             return this;
         }
-        return new ConfigurationOptions(this.mapFactory, this.header, this.serializers, this.acceptedTypes, shouldCopyDefaults);
-    }
 
-    @Override
-    public boolean equals(final Object other) {
-        if (this == other) {
-            return true;
-        }
-
-        if (!(other instanceof ConfigurationOptions)) {
-            return false;
-        }
-
-        final ConfigurationOptions that = (ConfigurationOptions) other;
-        return Objects.equals(this.shouldCopyDefaults, that.shouldCopyDefaults)
-                && Objects.equals(this.mapFactory, that.mapFactory)
-                && Objects.equals(this.header, that.header)
-                && Objects.equals(this.serializers, that.serializers)
-                && Objects.equals(this.acceptedTypes, that.acceptedTypes);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(this.mapFactory, this.header, this.serializers, this.acceptedTypes, this.shouldCopyDefaults);
-    }
-
-    @Override
-    public String toString() {
-        return "ConfigurationOptions{"
-                + "mapFactory=" + this.mapFactory
-                + ", header='" + this.header + '\''
-                + ", serializers=" + this.serializers
-                + ", acceptedTypes=" + this.acceptedTypes
-                + ", shouldCopyDefaults=" + this.shouldCopyDefaults
-                + '}';
+        return new AutoValue_ConfigurationOptions(getMapFactory(), getHeader(), getSerializers(), getNativeTypes(), shouldCopyDefaults);
     }
 
 }

--- a/core/src/main/java/org/spongepowered/configurate/ConfigurationOptions.java
+++ b/core/src/main/java/org/spongepowered/configurate/ConfigurationOptions.java
@@ -88,7 +88,7 @@ public abstract class ConfigurationOptions {
             return this;
         }
         return new AutoValue_ConfigurationOptions(mapFactory, getHeader(), getSerializers(), getNativeTypes(),
-                shouldCopyDefaults(), isImplicitInitialization());
+                getShouldCopyDefaults(), isImplicitInitialization());
     }
 
     /**
@@ -110,7 +110,7 @@ public abstract class ConfigurationOptions {
             return this;
         }
         return new AutoValue_ConfigurationOptions(getMapFactory(), header, getSerializers(), getNativeTypes(),
-                shouldCopyDefaults(), isImplicitInitialization());
+                getShouldCopyDefaults(), isImplicitInitialization());
     }
 
     /**
@@ -133,7 +133,7 @@ public abstract class ConfigurationOptions {
             return this;
         }
         return new AutoValue_ConfigurationOptions(getMapFactory(), getHeader(), serializers, getNativeTypes(),
-                shouldCopyDefaults(), isImplicitInitialization());
+                getShouldCopyDefaults(), isImplicitInitialization());
     }
 
     /**
@@ -211,7 +211,7 @@ public abstract class ConfigurationOptions {
             return this;
         }
         return new AutoValue_ConfigurationOptions(getMapFactory(), getHeader(), getSerializers(),
-                nativeTypes == null ? null : UnmodifiableCollections.copyOf(nativeTypes), shouldCopyDefaults(), isImplicitInitialization());
+                nativeTypes == null ? null : UnmodifiableCollections.copyOf(nativeTypes), getShouldCopyDefaults(), isImplicitInitialization());
     }
 
     /**
@@ -220,19 +220,19 @@ public abstract class ConfigurationOptions {
      *
      * @return Whether defaults should be copied into value
      */
-    public abstract boolean shouldCopyDefaults();
+    public abstract boolean getShouldCopyDefaults();
 
     /**
      * Creates a new {@link ConfigurationOptions} instance, with the specified
      * 'copy defaults' setting set, and all other settings copied from
      * this instance.
      *
-     * @see #shouldCopyDefaults() for information on what this method does
+     * @see #getShouldCopyDefaults() for information on what this method does
      * @param shouldCopyDefaults whether to copy defaults
      * @return updated options object
      */
     public ConfigurationOptions withShouldCopyDefaults(final boolean shouldCopyDefaults) {
-        if (this.shouldCopyDefaults() == shouldCopyDefaults) {
+        if (this.getShouldCopyDefaults() == shouldCopyDefaults) {
             return this;
         }
 
@@ -267,7 +267,7 @@ public abstract class ConfigurationOptions {
         }
 
         return new AutoValue_ConfigurationOptions(getMapFactory(), getHeader(), getSerializers(), getNativeTypes(),
-                shouldCopyDefaults(), implicitInitialization);
+                getShouldCopyDefaults(), implicitInitialization);
     }
 
 }

--- a/core/src/main/java/org/spongepowered/configurate/ConfigurationOptions.java
+++ b/core/src/main/java/org/spongepowered/configurate/ConfigurationOptions.java
@@ -49,7 +49,7 @@ public abstract class ConfigurationOptions {
         // avoid initialization cycles
 
         static final ConfigurationOptions DEFAULTS = new AutoValue_ConfigurationOptions(MapFactories.insertionOrdered(), null,
-                TypeSerializerCollection.defaults(), null, false);
+                TypeSerializerCollection.defaults(), null, false, false);
 
     }
 
@@ -87,7 +87,8 @@ public abstract class ConfigurationOptions {
         if (this.getMapFactory() == mapFactory) {
             return this;
         }
-        return new AutoValue_ConfigurationOptions(mapFactory, getHeader(), getSerializers(), getNativeTypes(), shouldCopyDefaults());
+        return new AutoValue_ConfigurationOptions(mapFactory, getHeader(), getSerializers(), getNativeTypes(),
+                shouldCopyDefaults(), isImplicitInitialization());
     }
 
     /**
@@ -108,7 +109,8 @@ public abstract class ConfigurationOptions {
         if (Objects.equals(this.getHeader(), header)) {
             return this;
         }
-        return new AutoValue_ConfigurationOptions(getMapFactory(), header, getSerializers(), getNativeTypes(), shouldCopyDefaults());
+        return new AutoValue_ConfigurationOptions(getMapFactory(), header, getSerializers(), getNativeTypes(),
+                shouldCopyDefaults(), isImplicitInitialization());
     }
 
     /**
@@ -130,7 +132,8 @@ public abstract class ConfigurationOptions {
         if (this.getSerializers().equals(serializers)) {
             return this;
         }
-        return new AutoValue_ConfigurationOptions(getMapFactory(), getHeader(), serializers, getNativeTypes(), shouldCopyDefaults());
+        return new AutoValue_ConfigurationOptions(getMapFactory(), getHeader(), serializers, getNativeTypes(),
+                shouldCopyDefaults(), isImplicitInitialization());
     }
 
     /**
@@ -208,7 +211,7 @@ public abstract class ConfigurationOptions {
             return this;
         }
         return new AutoValue_ConfigurationOptions(getMapFactory(), getHeader(), getSerializers(),
-                nativeTypes == null ? null : UnmodifiableCollections.copyOf(nativeTypes), shouldCopyDefaults());
+                nativeTypes == null ? null : UnmodifiableCollections.copyOf(nativeTypes), shouldCopyDefaults(), isImplicitInitialization());
     }
 
     /**
@@ -220,8 +223,9 @@ public abstract class ConfigurationOptions {
     public abstract boolean shouldCopyDefaults();
 
     /**
-     * Creates a new {@link ConfigurationOptions} instance, with the specified 'copy defaults' setting
-     * set, and all other settings copied from this instance.
+     * Creates a new {@link ConfigurationOptions} instance, with the specified
+     * 'copy defaults' setting set, and all other settings copied from
+     * this instance.
      *
      * @see #shouldCopyDefaults() for information on what this method does
      * @param shouldCopyDefaults whether to copy defaults
@@ -232,7 +236,38 @@ public abstract class ConfigurationOptions {
             return this;
         }
 
-        return new AutoValue_ConfigurationOptions(getMapFactory(), getHeader(), getSerializers(), getNativeTypes(), shouldCopyDefaults);
+        return new AutoValue_ConfigurationOptions(getMapFactory(), getHeader(), getSerializers(), getNativeTypes(),
+                shouldCopyDefaults, isImplicitInitialization());
+    }
+
+    /**
+     * Get whether values should be implicitly initialized.
+     *
+     * <p>When this is true, any value get operations will return an empty value
+     * rather than null. This extends through to fields loaded into
+     * object-mapped classes.</p>
+     *
+     * <p>This option is disabled by default</p>
+     *
+     * @return if implicit initialization is enabled.
+     */
+    public abstract boolean isImplicitInitialization();
+
+    /**
+     * Create a new {@link ConfigurationOptions} instance with the specified
+     * implicit initialization setting.
+     *
+     * @param implicitInitialization whether to initialize implicitly
+     * @return a new options object
+     * @see #isImplicitInitialization() for more details
+     */
+    public ConfigurationOptions withImplicitInitialization(final boolean implicitInitialization) {
+        if (this.isImplicitInitialization() == implicitInitialization) {
+            return this;
+        }
+
+        return new AutoValue_ConfigurationOptions(getMapFactory(), getHeader(), getSerializers(), getNativeTypes(),
+                shouldCopyDefaults(), implicitInitialization);
     }
 
 }

--- a/core/src/main/java/org/spongepowered/configurate/objectmapping/FieldDiscoverer.java
+++ b/core/src/main/java/org/spongepowered/configurate/objectmapping/FieldDiscoverer.java
@@ -23,7 +23,6 @@ import org.spongepowered.configurate.util.CheckedFunction;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.AnnotatedType;
-import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 /**
@@ -155,7 +154,7 @@ public interface FieldDiscoverer<I> {
          * @param serializer a function to extract a value from a completed
          *                   object instance.
          */
-        void accept(String name, AnnotatedType type, AnnotatedElement enclosing, BiConsumer<I, Object> deserializer,
+        void accept(String name, AnnotatedType type, AnnotatedElement enclosing, FieldData.Deserializer<I> deserializer,
                 CheckedFunction<V, Object, Exception> serializer);
     }
 

--- a/core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectMapperImpl.java
+++ b/core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectMapperImpl.java
@@ -76,7 +76,7 @@ class ObjectMapperImpl<I, V> implements ObjectMapper<V> {
                 // load field into intermediate object
                 field.deserializer().accept(intermediate, newVal, implicitInitializer);
 
-                if (newVal == null && source.getOptions().shouldCopyDefaults()) {
+                if (newVal == null && source.getOptions().getShouldCopyDefaults()) {
                     if (unseenFields == null) {
                         unseenFields = new ArrayList<>();
                     }

--- a/core/src/main/java/org/spongepowered/configurate/objectmapping/RecordFieldDiscoverer.java
+++ b/core/src/main/java/org/spongepowered/configurate/objectmapping/RecordFieldDiscoverer.java
@@ -114,7 +114,13 @@ final class RecordFieldDiscoverer implements FieldDiscoverer<Object[]> {
                         final AnnotatedElement annotationContainer = Typing.combinedAnnotations(component, backingField, accessor);
                         final int targetIdx = i;
                         collector.accept(name, resolvedType, annotationContainer,
-                            (intermediate, el) -> intermediate[targetIdx] = el, accessor::invoke);
+                            (intermediate, el, implicitSupplier) -> {
+                                if (el != null) {
+                                    intermediate[targetIdx] = el;
+                                } else {
+                                    intermediate[targetIdx] = implicitSupplier.get();
+                                }
+                            }, accessor::invoke);
                     }
 
                     // canonical constructor, which we'll use to make new instances
@@ -127,7 +133,8 @@ final class RecordFieldDiscoverer implements FieldDiscoverer<Object[]> {
                             return new Object[recordComponents.length];
                         }
 
-                        @Override public Object complete(final Object[] intermediate) throws ObjectMappingException {
+                        @Override
+                        public Object complete(final Object[] intermediate) throws ObjectMappingException {
                             try {
                                 return clazzConstructor.newInstance(intermediate);
                             } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
@@ -135,7 +142,8 @@ final class RecordFieldDiscoverer implements FieldDiscoverer<Object[]> {
                             }
                         }
 
-                        @Override public boolean canCreateInstances() {
+                        @Override
+                        public boolean canCreateInstances() {
                             return true;
                         }
                     };

--- a/core/src/main/java/org/spongepowered/configurate/reference/ValueReferenceImpl.java
+++ b/core/src/main/java/org/spongepowered/configurate/reference/ValueReferenceImpl.java
@@ -72,7 +72,7 @@ class ValueReferenceImpl<@Nullable T, N extends ScopedConfigurationNode<N>> impl
         final @Nullable T possible = this.serializer.deserialize(this.type.getType(), node);
         if (possible != null) {
             return possible;
-        } else if (defaultVal != null && node.getOptions().shouldCopyDefaults()) {
+        } else if (defaultVal != null && node.getOptions().getShouldCopyDefaults()) {
             this.serializer.serialize(this.type.getType(), defaultVal, node);
         }
         return defaultVal;

--- a/core/src/main/java/org/spongepowered/configurate/serialize/AbstractListChildSerializer.java
+++ b/core/src/main/java/org/spongepowered/configurate/serialize/AbstractListChildSerializer.java
@@ -18,6 +18,7 @@ package org.spongepowered.configurate.serialize;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
+import org.spongepowered.configurate.ConfigurationOptions;
 import org.spongepowered.configurate.objectmapping.ObjectMappingException;
 import org.spongepowered.configurate.util.CheckedConsumer;
 
@@ -71,6 +72,15 @@ abstract class AbstractListChildSerializer<T> implements TypeSerializer<T> {
         node.setValue(Collections.emptyList());
         if (obj != null) {
             forEachElement(obj, el -> entrySerial.serialize(entryType, el, node.appendListNode()));
+        }
+    }
+
+    @Override
+    public @Nullable T emptyValue(final Type specificType, final ConfigurationOptions options) {
+        try {
+            return this.createNew(0, getElementType(specificType));
+        } catch (final ObjectMappingException ex) {
+            return null;
         }
     }
 

--- a/core/src/main/java/org/spongepowered/configurate/serialize/ConfigurationNodeSerializer.java
+++ b/core/src/main/java/org/spongepowered/configurate/serialize/ConfigurationNodeSerializer.java
@@ -18,7 +18,9 @@ package org.spongepowered.configurate.serialize;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.configurate.BasicConfigurationNode;
 import org.spongepowered.configurate.ConfigurationNode;
+import org.spongepowered.configurate.ConfigurationOptions;
 
 import java.lang.reflect.Type;
 
@@ -41,6 +43,11 @@ class ConfigurationNodeSerializer implements TypeSerializer<ConfigurationNode> {
     @Override
     public void serialize(final @NonNull Type type, final @Nullable ConfigurationNode obj, final @NonNull ConfigurationNode node) {
         node.setValue(obj);
+    }
+
+    @Override
+    public @Nullable ConfigurationNode emptyValue(final Type specificType, final ConfigurationOptions options) {
+        return BasicConfigurationNode.root(options);
     }
 
 }

--- a/core/src/main/java/org/spongepowered/configurate/serialize/MapSerializer.java
+++ b/core/src/main/java/org/spongepowered/configurate/serialize/MapSerializer.java
@@ -22,6 +22,7 @@ import io.leangen.geantyref.TypeToken;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.configurate.BasicConfigurationNode;
 import org.spongepowered.configurate.ConfigurationNode;
+import org.spongepowered.configurate.ConfigurationOptions;
 import org.spongepowered.configurate.objectmapping.ObjectMappingException;
 
 import java.lang.reflect.ParameterizedType;
@@ -109,6 +110,11 @@ final class MapSerializer implements TypeSerializer<Map<?, ?>> {
                 node.removeChild(unusedChild);
             }
         }
+    }
+
+    @Override
+    public Map<?, ?> emptyValue(final Type specificType, final ConfigurationOptions options) {
+        return new LinkedHashMap<>();
     }
 
 }

--- a/core/src/main/java/org/spongepowered/configurate/serialize/TypeSerializer.java
+++ b/core/src/main/java/org/spongepowered/configurate/serialize/TypeSerializer.java
@@ -18,6 +18,7 @@ package org.spongepowered.configurate.serialize;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
+import org.spongepowered.configurate.ConfigurationOptions;
 import org.spongepowered.configurate.objectmapping.ObjectMappingException;
 import org.spongepowered.configurate.util.CheckedFunction;
 
@@ -92,5 +93,19 @@ public interface TypeSerializer<T> {
      * @throws ObjectMappingException If the object cannot be serialized
      */
     void serialize(Type type, @Nullable T obj, ConfigurationNode node) throws ObjectMappingException;
+
+    /**
+     * Create an empty value of the appropriate type.
+     *
+     * <p>This method is for the most part designed to create empty collection
+     * types, though it may be useful for scalars in limited cases.</p>
+     *
+     * @param specificType specific subtype to create an empty value of
+     * @param options options used from the loading node
+     * @return new empty value
+     */
+    default @Nullable T emptyValue(final Type specificType, ConfigurationOptions options) {
+        return null;
+    }
 
 }

--- a/core/src/test/java/org/spongepowered/configurate/AbstractConfigurationNodeTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/AbstractConfigurationNodeTest.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.leangen.geantyref.TypeToken;
 import org.junit.jupiter.api.Test;
+import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 import org.spongepowered.configurate.objectmapping.ObjectMappingException;
 import org.spongepowered.configurate.transformation.NodePath;
 import org.spongepowered.configurate.util.UnmodifiableCollections;
@@ -36,9 +37,11 @@ import org.spongepowered.configurate.util.UnmodifiableCollections;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.IntStream;
 
@@ -399,7 +402,32 @@ public class AbstractConfigurationNodeTest {
                 .collect(BasicConfigurationNode.factory().toListCollector(Integer.class));
 
         assertEquals(ImmutableList.of(1, 2, 3, 4, 8), target.getList(TypeToken.get(Integer.class)));
+    }
 
+    @ConfigSerializable
+    static class Empty {
+        String ignoreMe = "hello";
+
+        @Override
+        public boolean equals(final Object that) {
+            return that instanceof Empty
+                    && Objects.equals(this.ignoreMe, ((Empty) that).ignoreMe);
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * Objects.hashCode(this.ignoreMe);
+        }
+    }
+
+    @Test
+    void testImplicitInitialization() throws ObjectMappingException {
+        final BasicConfigurationNode node = BasicConfigurationNode.root(ConfigurationOptions.defaults().withImplicitInitialization(true));
+
+        assertNull(node.getValue());
+        assertEquals(Collections.emptyList(), node.getValue(new TypeToken<List<String>>() {}));
+        assertEquals(Collections.emptyMap(), node.getValue(new TypeToken<Map<String, Integer>>() {}));
+        assertEquals(new Empty(), node.getValue(Empty.class));
     }
 
 }

--- a/core/src/test/java/org/spongepowered/configurate/objectmapping/DefaultsTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/objectmapping/DefaultsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spongepowered.configurate.objectmapping;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.spongepowered.configurate.BasicConfigurationNode;
+import org.spongepowered.configurate.ConfigurationNode;
+import org.spongepowered.configurate.ConfigurationOptions;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Tests for application of defaults
+ */
+public class DefaultsTest {
+
+    public static final ConfigurationOptions IMPLICIT_OPTS = ConfigurationOptions.defaults()
+            .withImplicitInitialization(true);
+
+    @ConfigSerializable
+    static class ImplicitDefaultsOnly {
+        List<String> myStrings;
+        AnotherThing funTimes;
+        int[] items;
+    }
+
+    @ConfigSerializable
+    static class AnotherThing {
+
+    }
+
+    @Test
+    void testFieldsInitialized() throws ObjectMappingException {
+        final ImplicitDefaultsOnly instance = ObjectMapper.factory().get(ImplicitDefaultsOnly.class).load(BasicConfigurationNode.root(IMPLICIT_OPTS));
+        assertEquals(Collections.emptyList(), instance.myStrings);
+        assertNotNull(instance.funTimes);
+        assertNotNull(instance.items);
+        assertEquals(0, instance.items.length);
+    }
+
+    @Test
+    void testImplicitDefaultsSaved() throws ObjectMappingException {
+        final BasicConfigurationNode node = BasicConfigurationNode.root(IMPLICIT_OPTS.withShouldCopyDefaults(true));
+        node.getValue(ImplicitDefaultsOnly.class);
+
+        assertPresentAndEmpty(node.getNode("my-strings"));
+        assertPresentAndEmpty(node.getNode("fun-times"));
+        assertPresentAndEmpty(node.getNode("items"));
+    }
+
+    private void assertPresentAndEmpty(final ConfigurationNode node) {
+        assertFalse(node.isVirtual());
+        assertTrue(node.isEmpty());
+    }
+
+}

--- a/etc/checkstyle/checkstyle.xml
+++ b/etc/checkstyle/checkstyle.xml
@@ -72,6 +72,7 @@
         <property name="message" value="Leave empty row before end of class/interface/enum!"/>
         <property name="fileExtensions" value="groovy,java"/>
     </module>
+    <module name="SuppressWarningsFilter"/>
 
     <module name="TreeWalker">
         <module name="RedundantImport"/>
@@ -99,6 +100,7 @@
         <module name="IllegalType">
             <property name="illegalClassNames" value="java.util.Optional"/>
         </module>
+        <module name="SuppressWarningsHolder"/>
 
 
         <!-- Standard Google style checks -->

--- a/extra/kotlin/src/test/kotlin/org/spongepowered/configurate/kotlin/ObjectMappingTest.kt
+++ b/extra/kotlin/src/test/kotlin/org/spongepowered/configurate/kotlin/ObjectMappingTest.kt
@@ -91,9 +91,11 @@ class ObjectMappingTest {
 
     @Test
     fun `collections are initialized implicitly`() {
-        val node = CommentedConfigurationNode.root(ConfigurationOptions.defaults()
+        val node = CommentedConfigurationNode.root(
+            ConfigurationOptions.defaults()
                 .withImplicitInitialization(true)
-                .withSerializers { it.registerAnnotatedObjects(objectMapperFactory()) })
+                .withSerializers { it.registerAnnotatedObjects(objectMapperFactory()) }
+        )
 
         val tester = objectMapper<ImplicitTest>().load(node)
 

--- a/extra/kotlin/src/test/kotlin/org/spongepowered/configurate/kotlin/ObjectMappingTest.kt
+++ b/extra/kotlin/src/test/kotlin/org/spongepowered/configurate/kotlin/ObjectMappingTest.kt
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.spongepowered.configurate.BasicConfigurationNode
 import org.spongepowered.configurate.CommentedConfigurationNode
+import org.spongepowered.configurate.ConfigurationOptions
+import org.spongepowered.configurate.objectmapping.ConfigSerializable
 import org.spongepowered.configurate.objectmapping.ObjectMappingException
 import org.spongepowered.configurate.objectmapping.meta.Comment
 import org.spongepowered.configurate.objectmapping.meta.Matches
@@ -78,5 +80,25 @@ class ObjectMappingTest {
                 }
             )
         }
+    }
+
+    // can't be local to the function: https://youtrack.jetbrains.com/issue/KT-42440
+    @ConfigSerializable
+    data class Empty(val empty: String?)
+
+    @ConfigSerializable
+    data class ImplicitTest(val test: Set<String>, val help: Map<String, String>, val empty: Empty)
+
+    @Test
+    fun `collections are initialized implicitly`() {
+        val node = CommentedConfigurationNode.root(ConfigurationOptions.defaults()
+                .withImplicitInitialization(true)
+                .withSerializers { it.registerAnnotatedObjects(objectMapperFactory()) })
+
+        val tester = objectMapper<ImplicitTest>().load(node)
+
+        assertEquals(setOf<String>(), tester.test)
+        assertEquals(mapOf<String, String>(), tester.help)
+        assertEquals(null, tester.empty.empty)
     }
 }


### PR DESCRIPTION
Originally requested for the object mapper, but implemented on the node level for consistent behaviour.