### PR TITLE
all: Drop get- and set- prefixes from method names

### DIFF
--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -122,6 +122,23 @@
         </module>
         <module name="InterfaceIsType"/>
 
+        <!-- https://checkstyle.org/config_naming.html#MethodName -->
+        <module name="MethodName">
+            <property name="id" value="NoGetSetPrefix"/>
+            <property name="format" value="^(?:(?:.{1,3})|(?:[gs]et[^A-Z].*)|(?:(?:[^gsA-Z]..|.[^e].|..[^t]).+))$"/>
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <property name="id" value="JavadocNoCaptializedStarts"/>
+            <property name="format" value="\s+\*\s@((?:(?:param|throws)\s\S+)|return)\s+[A-Z]"/>
+            <property name="message" value="Javadoc at-tag descriptions should not start with a capital letter"/>
+        </module>
+        <module name="RegexpSinglelineJava">
+            <property name="id" value="JavadocNotJustThis"/>
+            <property name="format" value="\s+\*\s@((?:(?:param|throws)\s\S+)|return)\s+this$"/>
+            <property name="message" value="Javadoc at-tag descriptions should not just be 'this'."/>
+        </module>
+
         <!-- https://checkstyle.org/config_coding.html#SimplifyBooleanExpression -->
         <module name="SimplifyBooleanExpression"/>
 
@@ -134,6 +151,12 @@
         </module>
 
         <module name="SuppressWarningsHolder"/>
+
+        <module name="SuppressWithNearbyCommentFilter">
+            <property name="commentFormat" value="@cs-: (\w+) \(.*\)"/>
+            <property name="idFormat" value="$1"/>
+            <property name="influenceFormat" value="1"/>
+        </module>
 
         <!-- https://checkstyle.org/config_coding.html#UnnecessaryParentheses -->
         <module name="UnnecessaryParentheses"/>
@@ -148,16 +171,6 @@
         <module name="UnnecessarySemicolonInTryWithResources"/>
 
         <module name="UnusedImports"/>
-        <module name="RegexpSinglelineJava">
-            <property name="id" value="JavadocNoCaptializedStarts"/>
-            <property name="format" value="\s+\*\s@((?:(?:param|throws)\s\S+)|return)\s+[A-Z]"/>
-            <property name="message" value="Javadoc at-tag descriptions should not start with a captial letter"/>
-        </module>
-        <module name="RegexpSinglelineJava">
-            <property name="id" value="JavadocNotJustThis"/>
-            <property name="format" value="\s+\*\s@((?:(?:param|throws)\s\S+)|return)\s+this$"/>
-            <property name="message" value="Javadoc at-tag descriptions should not just be 'this'."/>
-        </module>
 
         <!-- Standard Google style checks -->
 

--- a/core/src/main/java/org/spongepowered/configurate/AbstractCommentedConfigurationNode.java
+++ b/core/src/main/java/org/spongepowered/configurate/AbstractCommentedConfigurationNode.java
@@ -36,12 +36,12 @@ abstract class AbstractCommentedConfigurationNode<N extends CommentedConfigurati
     }
 
     @Override
-    public @Nullable String getComment() {
+    public @Nullable String comment() {
         return this.comment.get();
     }
 
     @Override
-    public @NonNull N setComment(final @Nullable String comment) {
+    public @NonNull N comment(final @Nullable String comment) {
         if (!Objects.equals(this.comment.getAndSet(comment), comment)) {
             attachIfNecessary();
         }
@@ -49,7 +49,7 @@ abstract class AbstractCommentedConfigurationNode<N extends CommentedConfigurati
     }
 
     @Override
-    public @NonNull N setCommentIfAbsent(final String comment) {
+    public @NonNull N commentIfAbsent(final String comment) {
         if (this.comment.compareAndSet(null, comment)) {
             attachIfNecessary();
         }
@@ -57,25 +57,25 @@ abstract class AbstractCommentedConfigurationNode<N extends CommentedConfigurati
     }
 
     @Override
-    public @NonNull N setValue(final @Nullable Object value) {
+    public @NonNull N set(final @Nullable Object value) {
         if (value instanceof CommentedConfigurationNodeIntermediary<?>) {
-            final @Nullable String otherComment = ((CommentedConfigurationNodeIntermediary<?>) value).getComment();
+            final @Nullable String otherComment = ((CommentedConfigurationNodeIntermediary<?>) value).comment();
             if (otherComment != null) {
-                setComment(otherComment);
+                comment(otherComment);
             }
         }
-        return super.setValue(value);
+        return super.set(value);
     }
 
     @Override
-    public @NonNull N mergeValuesFrom(final @NonNull ConfigurationNode other) {
+    public @NonNull N mergeFrom(final @NonNull ConfigurationNode other) {
         if (other instanceof CommentedConfigurationNodeIntermediary<?>) {
-            final @Nullable String otherComment = ((CommentedConfigurationNodeIntermediary<?>) other).getComment();
+            final @Nullable String otherComment = ((CommentedConfigurationNodeIntermediary<?>) other).comment();
             if (otherComment != null) {
-                setCommentIfAbsent(otherComment);
+                commentIfAbsent(otherComment);
             }
         }
-        return super.mergeValuesFrom(other);
+        return super.mergeFrom(other);
     }
 
     @Override

--- a/core/src/main/java/org/spongepowered/configurate/AttributedConfigurationNode.java
+++ b/core/src/main/java/org/spongepowered/configurate/AttributedConfigurationNode.java
@@ -130,19 +130,19 @@ public interface AttributedConfigurationNode extends CommentedConfigurationNodeI
      *
      * @return the tag name
      */
-    String getTagName();
+    String tagName();
 
     /**
      * Sets the tag name of this node.
      *
      * <p>Will have no effect when called on nodes which are direct values of a
-     * {@link #getChildrenMap() child map}, as the corresponding key is used as
+     * {@link #childrenMap() child map}, as the corresponding key is used as
      * the tag name.</p>
      *
      * @param name the name to set, cannot be null
      * @return this node
      */
-    AttributedConfigurationNode setTagName(String name);
+    AttributedConfigurationNode tagName(String name);
 
     /**
      * Adds an attribute to this node.
@@ -167,7 +167,16 @@ public interface AttributedConfigurationNode extends CommentedConfigurationNodeI
      * @param attributes the attributes to set
      * @return this node
      */
-    AttributedConfigurationNode setAttributes(Map<String, String> attributes);
+    AttributedConfigurationNode attributes(Map<String, String> attributes);
+
+    /**
+     * Gets the attributes this node has.
+     *
+     * <p>The returned map is immutable.</p>
+     *
+     * @return the map of attributes
+     */
+    Map<String, String> attributes();
 
     /**
      * Gets if this node has any attributes.
@@ -183,15 +192,6 @@ public interface AttributedConfigurationNode extends CommentedConfigurationNodeI
      * @param name the name of the attribute to get
      * @return this node
      */
-    @Nullable String getAttribute(String name);
-
-    /**
-     * Gets the attributes this node has.
-     *
-     * <p>The returned map is immutable.</p>
-     *
-     * @return the map of attributes
-     */
-    Map<String, String> getAttributes();
+    @Nullable String attribute(String name);
 
 }

--- a/core/src/main/java/org/spongepowered/configurate/CommentedConfigurationNodeIntermediary.java
+++ b/core/src/main/java/org/spongepowered/configurate/CommentedConfigurationNodeIntermediary.java
@@ -33,7 +33,7 @@ public interface CommentedConfigurationNodeIntermediary<N extends CommentedConfi
      *
      * @return the configuration's current comment
      */
-    @Nullable String getComment();
+    @Nullable String comment();
 
     /**
      * Sets the comment for this configuration node.
@@ -42,7 +42,7 @@ public interface CommentedConfigurationNodeIntermediary<N extends CommentedConfi
      *                LFs (\n)
      * @return this node
      */
-    N setComment(@Nullable String comment);
+    N comment(@Nullable String comment);
 
     /**
      * Set a comment on this node if it does not presently have a comment.
@@ -54,6 +54,6 @@ public interface CommentedConfigurationNodeIntermediary<N extends CommentedConfi
      *                LFs (\n)
      * @return this node
      */
-    N setCommentIfAbsent(String comment);
+    N commentIfAbsent(String comment);
 
 }

--- a/core/src/main/java/org/spongepowered/configurate/ConfigValue.java
+++ b/core/src/main/java/org/spongepowered/configurate/ConfigValue.java
@@ -29,8 +29,7 @@ abstract class ConfigValue<N extends ScopedConfigurationNode<N>, T extends Abstr
     /**
      * The node this value "belongs" to.
      */
-    @NonNull
-    protected final T holder;
+    protected final @NonNull T holder;
 
     protected ConfigValue(final @NonNull T holder) {
         this.holder = holder;
@@ -41,14 +40,14 @@ abstract class ConfigValue<N extends ScopedConfigurationNode<N>, T extends Abstr
      *
      * @return the value
      */
-    abstract @Nullable Object getValue();
+    abstract @Nullable Object get();
 
     /**
      * Sets the value encapsulated by this instance.
      *
      * @param value the value
      */
-    abstract void setValue(@Nullable Object value);
+    abstract void set(@Nullable Object value);
 
     /**
      * Put a child value, or null to remove value at that key.
@@ -78,7 +77,7 @@ abstract class ConfigValue<N extends ScopedConfigurationNode<N>, T extends Abstr
      * @return the child if any
      */
     @Nullable
-    abstract T getChild(@Nullable Object key);
+    abstract T child(@Nullable Object key);
 
     /**
      * Returns an iterable over all child nodes.
@@ -111,7 +110,7 @@ abstract class ConfigValue<N extends ScopedConfigurationNode<N>, T extends Abstr
             final T node = it.next();
             node.attached = false;
             it.remove();
-            if (node.getParentEnsureAttached().equals(this.holder)) {
+            if (node.parentEnsureAttached().equals(this.holder)) {
                 node.clear();
             }
         }

--- a/core/src/main/java/org/spongepowered/configurate/ConfigurationNodeFactory.java
+++ b/core/src/main/java/org/spongepowered/configurate/ConfigurationNodeFactory.java
@@ -104,12 +104,12 @@ public interface ConfigurationNodeFactory<N extends ConfigurationNode> {
     default <V> Collector<Map.Entry<?, V>, N, N> toMapCollector(final TypeToken<V> valueType) {
         return Collector.of(this::createNode, (node, entry) -> {
             try {
-                node.getNode(entry.getKey()).setValue(valueType, entry.getValue());
+                node.node(entry.getKey()).set(valueType, entry.getValue());
             } catch (ObjectMappingException e) {
                 throw new IllegalArgumentException(e);
             }
         }, (a, b) -> {
-                a.mergeValuesFrom(b);
+                a.mergeFrom(b);
                 return a;
             });
     }
@@ -127,12 +127,12 @@ public interface ConfigurationNodeFactory<N extends ConfigurationNode> {
     default <V> Collector<Map.Entry<?, V>, N, N> toMapCollector(final Class<V> valueType) {
         return Collector.of(this::createNode, (node, entry) -> {
             try {
-                node.getNode(entry.getKey()).setValue(valueType, entry.getValue());
+                node.node(entry.getKey()).set(valueType, entry.getValue());
             } catch (ObjectMappingException e) {
                 throw new IllegalArgumentException(e);
             }
         }, (a, b) -> {
-                a.mergeValuesFrom(b);
+                a.mergeFrom(b);
                 return a;
             });
     }
@@ -150,12 +150,12 @@ public interface ConfigurationNodeFactory<N extends ConfigurationNode> {
     default <V> Collector<V, N, N> toListCollector(final TypeToken<V> valueType) {
         return Collector.of(this::createNode, (node, value) -> {
             try {
-                node.appendListNode().setValue(valueType, value);
+                node.appendListNode().set(valueType, value);
             } catch (ObjectMappingException e) {
                 throw new IllegalArgumentException(e);
             }
         }, (a, b) -> {
-                a.mergeValuesFrom(b);
+                a.mergeFrom(b);
                 return a;
             });
     }
@@ -173,12 +173,12 @@ public interface ConfigurationNodeFactory<N extends ConfigurationNode> {
     default <V> Collector<V, N, N> toListCollector(final Class<V> valueType) {
         return Collector.of(this::createNode, (node, value) -> {
             try {
-                node.appendListNode().setValue(valueType, value);
+                node.appendListNode().set(valueType, value);
             } catch (ObjectMappingException e) {
                 throw new IllegalArgumentException(e);
             }
         }, (a, b) -> {
-                a.mergeValuesFrom(b);
+                a.mergeFrom(b);
                 return a;
             });
     }

--- a/core/src/main/java/org/spongepowered/configurate/ConfigurationOptions.java
+++ b/core/src/main/java/org/spongepowered/configurate/ConfigurationOptions.java
@@ -73,7 +73,7 @@ public abstract class ConfigurationOptions {
      *
      * @return the map factory
      */
-    public abstract MapFactory getMapFactory();
+    public abstract MapFactory mapFactory();
 
     /**
      * Creates a new {@link ConfigurationOptions} instance, with the specified
@@ -82,13 +82,13 @@ public abstract class ConfigurationOptions {
      * @param mapFactory the new factory to use to create a map
      * @return the new options object
      */
-    public ConfigurationOptions withMapFactory(final MapFactory mapFactory) {
+    public ConfigurationOptions mapFactory(final MapFactory mapFactory) {
         requireNonNull(mapFactory, "mapFactory");
-        if (this.getMapFactory() == mapFactory) {
+        if (this.mapFactory() == mapFactory) {
             return this;
         }
-        return new AutoValue_ConfigurationOptions(mapFactory, getHeader(), getSerializers(), getNativeTypes(),
-                getShouldCopyDefaults(), isImplicitInitialization());
+        return new AutoValue_ConfigurationOptions(mapFactory, header(), serializers(), nativeTypes(),
+                shouldCopyDefaults(), implicitInitialization());
     }
 
     /**
@@ -97,7 +97,7 @@ public abstract class ConfigurationOptions {
      * @return the current header. Lines are split by \n, with no
      *         trailing newline
      */
-    public abstract @Nullable String getHeader();
+    public abstract @Nullable String header();
 
     /**
      * Creates a new {@link ConfigurationOptions} instance, with the specified
@@ -106,12 +106,12 @@ public abstract class ConfigurationOptions {
      * @param header the new header to use
      * @return the new options object
      */
-    public ConfigurationOptions withHeader(final @Nullable String header) {
-        if (Objects.equals(this.getHeader(), header)) {
+    public ConfigurationOptions header(final @Nullable String header) {
+        if (Objects.equals(this.header(), header)) {
             return this;
         }
-        return new AutoValue_ConfigurationOptions(getMapFactory(), header, getSerializers(), getNativeTypes(),
-                getShouldCopyDefaults(), isImplicitInitialization());
+        return new AutoValue_ConfigurationOptions(mapFactory(), header, serializers(), nativeTypes(),
+                shouldCopyDefaults(), implicitInitialization());
     }
 
     /**
@@ -119,7 +119,7 @@ public abstract class ConfigurationOptions {
      *
      * @return the type serializers
      */
-    public abstract TypeSerializerCollection getSerializers();
+    public abstract TypeSerializerCollection serializers();
 
     /**
      * Creates a new {@link ConfigurationOptions} instance, with the specified {@link TypeSerializerCollection}
@@ -128,13 +128,13 @@ public abstract class ConfigurationOptions {
      * @param serializers the serializers to use
      * @return the new options object
      */
-    public ConfigurationOptions withSerializers(final TypeSerializerCollection serializers) {
+    public ConfigurationOptions serializers(final TypeSerializerCollection serializers) {
         requireNonNull(serializers, "serializers");
-        if (this.getSerializers().equals(serializers)) {
+        if (this.serializers().equals(serializers)) {
             return this;
         }
-        return new AutoValue_ConfigurationOptions(getMapFactory(), getHeader(), serializers, getNativeTypes(),
-                getShouldCopyDefaults(), isImplicitInitialization());
+        return new AutoValue_ConfigurationOptions(mapFactory(), header(), serializers, nativeTypes(),
+                shouldCopyDefaults(), implicitInitialization());
     }
 
     /**
@@ -147,15 +147,36 @@ public abstract class ConfigurationOptions {
      *                          be used in the returned options object.
      * @return the new options object
      */
-    public final ConfigurationOptions withSerializers(final Consumer<TypeSerializerCollection.Builder> serializerBuilder) {
+    public final ConfigurationOptions serializers(final Consumer<TypeSerializerCollection.Builder> serializerBuilder) {
         requireNonNull(serializerBuilder, "serializerBuilder");
-        final TypeSerializerCollection.Builder builder = this.getSerializers().childBuilder();
+        final TypeSerializerCollection.Builder builder = this.serializers().childBuilder();
         serializerBuilder.accept(builder);
-        return withSerializers(builder.build());
+        return serializers(builder.build());
     }
 
     @SuppressWarnings("AutoValueImmutableFields") // we don't use guava
-    abstract @Nullable Set<Class<?>> getNativeTypes();
+    abstract @Nullable Set<Class<?>> nativeTypes();
+
+    /**
+     * Creates a new {@link ConfigurationOptions} instance, with the specified native types
+     * set, and all other settings copied from this instance.
+     *
+     * <p>Native types are format-dependent, and must be provided by a
+     * configuration loader's {@link ConfigurationLoader#defaultOptions() default options}</p>
+     *
+     * <p>Null indicates that all types are accepted.</p>
+     *
+     * @param nativeTypes the types that will be accepted to a
+     *                     call to {@link ConfigurationNode#set(Object)}
+     * @return updated options object
+     */
+    public ConfigurationOptions nativeTypes(final @Nullable Set<Class<?>> nativeTypes) {
+        if (Objects.equals(this.nativeTypes(), nativeTypes)) {
+            return this;
+        }
+        return new AutoValue_ConfigurationOptions(mapFactory(), header(), serializers(),
+                nativeTypes == null ? null : UnmodifiableCollections.copyOf(nativeTypes), shouldCopyDefaults(), implicitInitialization());
+    }
 
     /**
      * Gets whether objects of the provided type are natively accepted as values
@@ -167,7 +188,7 @@ public abstract class ConfigurationOptions {
     public final boolean acceptsType(final Class<?> type) {
         requireNonNull(type, "type");
 
-        final @Nullable Set<Class<?>> nativeTypes = getNativeTypes();
+        final @Nullable Set<Class<?>> nativeTypes = nativeTypes();
 
         if (nativeTypes == null) {
             return true;
@@ -196,32 +217,12 @@ public abstract class ConfigurationOptions {
     }
 
     /**
-     * Creates a new {@link ConfigurationOptions} instance, with the specified native types
-     * set, and all other settings copied from this instance.
-     *
-     * <p>Native types are format-dependent, and must be provided by a
-     * configuration loader's {@link ConfigurationLoader#defaultOptions() default options}</p>
-     *
-     * <p>Null indicates that all types are accepted.</p>
-     *
-     * @param nativeTypes the types that will be accepted to a call to {@link ConfigurationNode#setValue(Object)}
-     * @return updated options object
-     */
-    public ConfigurationOptions withNativeTypes(final @Nullable Set<Class<?>> nativeTypes) {
-        if (Objects.equals(this.getNativeTypes(), nativeTypes)) {
-            return this;
-        }
-        return new AutoValue_ConfigurationOptions(getMapFactory(), getHeader(), getSerializers(),
-                nativeTypes == null ? null : UnmodifiableCollections.copyOf(nativeTypes), getShouldCopyDefaults(), isImplicitInitialization());
-    }
-
-    /**
      * Gets whether or not default parameters provided to {@link ConfigurationNode} getter methods
      * should be set to the node when used.
      *
      * @return whether defaults should be copied into value
      */
-    public abstract boolean getShouldCopyDefaults();
+    public abstract boolean shouldCopyDefaults();
 
     /**
      * Creates a new {@link ConfigurationOptions} instance, with the specified
@@ -230,15 +231,15 @@ public abstract class ConfigurationOptions {
      *
      * @param shouldCopyDefaults whether to copy defaults
      * @return updated options object
-     * @see #getShouldCopyDefaults() for information on what this method does
+     * @see #shouldCopyDefaults() for information on what this method does
      */
-    public ConfigurationOptions withShouldCopyDefaults(final boolean shouldCopyDefaults) {
-        if (this.getShouldCopyDefaults() == shouldCopyDefaults) {
+    public ConfigurationOptions shouldCopyDefaults(final boolean shouldCopyDefaults) {
+        if (this.shouldCopyDefaults() == shouldCopyDefaults) {
             return this;
         }
 
-        return new AutoValue_ConfigurationOptions(getMapFactory(), getHeader(), getSerializers(), getNativeTypes(),
-                shouldCopyDefaults, isImplicitInitialization());
+        return new AutoValue_ConfigurationOptions(mapFactory(), header(), serializers(), nativeTypes(),
+                shouldCopyDefaults, implicitInitialization());
     }
 
     /**
@@ -252,7 +253,7 @@ public abstract class ConfigurationOptions {
      *
      * @return if implicit initialization is enabled.
      */
-    public abstract boolean isImplicitInitialization();
+    public abstract boolean implicitInitialization();
 
     /**
      * Create a new {@link ConfigurationOptions} instance with the specified
@@ -260,15 +261,15 @@ public abstract class ConfigurationOptions {
      *
      * @param implicitInitialization whether to initialize implicitly
      * @return a new options object
-     * @see #isImplicitInitialization() for more details
+     * @see #implicitInitialization() for more details
      */
-    public ConfigurationOptions withImplicitInitialization(final boolean implicitInitialization) {
-        if (this.isImplicitInitialization() == implicitInitialization) {
+    public ConfigurationOptions implicitInitialization(final boolean implicitInitialization) {
+        if (this.implicitInitialization() == implicitInitialization) {
             return this;
         }
 
-        return new AutoValue_ConfigurationOptions(getMapFactory(), getHeader(), getSerializers(), getNativeTypes(),
-                getShouldCopyDefaults(), implicitInitialization);
+        return new AutoValue_ConfigurationOptions(mapFactory(), header(), serializers(), nativeTypes(),
+                shouldCopyDefaults(), implicitInitialization);
     }
 
 }

--- a/core/src/main/java/org/spongepowered/configurate/ConfigurationVisitor.java
+++ b/core/src/main/java/org/spongepowered/configurate/ConfigurationVisitor.java
@@ -116,11 +116,11 @@ public interface ConfigurationVisitor<N extends ConfigurationNode, S, T, E exten
                 if (current.isMap()) {
                     enterMappingNode(current, state);
                     toVisit.addFirst(new VisitorNodeEnd(current, true));
-                    toVisit.addAll(0, current.getChildrenMap().values());
+                    toVisit.addAll(0, current.childrenMap().values());
                 } else if (current.isList()) {
                     enterListNode(current, state);
                     toVisit.addFirst(new VisitorNodeEnd(current, false));
-                    toVisit.addAll(0, current.getChildrenList());
+                    toVisit.addAll(0, current.childrenList());
                 } else {
                     enterScalarNode(current, state);
                 }

--- a/core/src/main/java/org/spongepowered/configurate/ListConfigValue.java
+++ b/core/src/main/java/org/spongepowered/configurate/ListConfigValue.java
@@ -44,25 +44,25 @@ final class ListConfigValue<N extends ScopedConfigurationNode<N>, T extends Abst
         if (startValue != null) {
             final T child = holder.createNode(0);
             child.attached = true;
-            child.setValue(startValue);
+            child.set(startValue);
             this.values.get().add(child);
         }
     }
 
     @Nullable
     @Override
-    public Object getValue() {
+    public Object get() {
         final List<T> values = this.values.get();
         synchronized (values) {
             final List<Object> ret = new ArrayList<>(values.size());
             for (T obj : values) {
-                ret.add(obj.getValue()); // unwrap
+                ret.add(obj.get()); // unwrap
             }
             return ret;
         }
     }
 
-    public List<N> getUnwrapped() {
+    public List<N> unwrapped() {
         final List<T> orig = this.values.get();
         synchronized (orig) {
             final List<N> ret = new ArrayList<>(orig.size());
@@ -74,7 +74,7 @@ final class ListConfigValue<N extends ScopedConfigurationNode<N>, T extends Abst
     }
 
     @Override
-    public void setValue(@Nullable Object value) {
+    public void set(@Nullable Object value) {
         if (!(value instanceof Collection)) {
             value = Collections.singleton(value);
         }
@@ -90,7 +90,7 @@ final class ListConfigValue<N extends ScopedConfigurationNode<N>, T extends Abst
             final T child = this.holder.createNode(count);
             newValue.add(count, child);
             child.attached = true;
-            child.setValue(o);
+            child.set(o);
             ++count;
         }
         detachNodes(this.values.getAndSet(newValue));
@@ -143,7 +143,7 @@ final class ListConfigValue<N extends ScopedConfigurationNode<N>, T extends Abst
     }
 
     @Override
-    public @Nullable T getChild(final @Nullable Object key) {
+    public @Nullable T child(final @Nullable Object key) {
         final @Nullable Integer value = Scalars.INTEGER.tryDeserialize(key);
         if (value == null || value < 0) {
             return null;

--- a/core/src/main/java/org/spongepowered/configurate/MapConfigValue.java
+++ b/core/src/main/java/org/spongepowered/configurate/MapConfigValue.java
@@ -38,7 +38,7 @@ final class MapConfigValue<N extends ScopedConfigurationNode<N>, A extends Abstr
     }
 
     private Map<Object, A> newMap() {
-        final Map<Object, A> ret = this.holder.getOptions().getMapFactory().create();
+        final Map<Object, A> ret = this.holder.options().mapFactory().create();
         if (!(ret instanceof ConcurrentMap)) {
             return Collections.synchronizedMap(ret);
         } else {
@@ -48,22 +48,22 @@ final class MapConfigValue<N extends ScopedConfigurationNode<N>, A extends Abstr
 
     @Nullable
     @Override
-    public Object getValue() {
+    public Object get() {
         final Map<Object, Object> value = new LinkedHashMap<>();
         for (Map.Entry<Object, A> ent : this.values.entrySet()) {
-            value.put(ent.getKey(), ent.getValue().getValue()); // unwrap key from the backing node
+            value.put(ent.getKey(), ent.getValue().get()); // unwrap key from the backing node
         }
         return value;
     }
 
-    public Map<Object, N> getUnwrapped() {
+    public Map<Object, N> unwrapped() {
         final Map<Object, N> unwrapped = new LinkedHashMap<>();
         this.values.forEach((k, v) -> unwrapped.put(k, v.self()));
         return Collections.unmodifiableMap(unwrapped);
     }
 
     @Override
-    public void setValue(final @Nullable Object value) {
+    public void set(final @Nullable Object value) {
         if (value instanceof Map) {
             final Map<Object, A> newValue = newMap();
             for (Map.Entry<?, ?> ent : ((Map<?, ?>) value).entrySet()) {
@@ -73,7 +73,7 @@ final class MapConfigValue<N extends ScopedConfigurationNode<N>, A extends Abstr
                 final A child = this.holder.createNode(ent.getKey());
                 newValue.put(ent.getKey(), child);
                 child.attached = true;
-                child.setValue(ent.getValue());
+                child.set(ent.getValue());
             }
             synchronized (this) {
                 final Map<Object, A> oldMap = this.values;
@@ -107,7 +107,7 @@ final class MapConfigValue<N extends ScopedConfigurationNode<N>, A extends Abstr
 
     @Nullable
     @Override
-    public A getChild(final @Nullable Object key) {
+    public A child(final @Nullable Object key) {
         return this.values.get(key);
     }
 

--- a/core/src/main/java/org/spongepowered/configurate/NullConfigValue.java
+++ b/core/src/main/java/org/spongepowered/configurate/NullConfigValue.java
@@ -41,12 +41,12 @@ final class NullConfigValue<N extends ScopedConfigurationNode<N>, T extends Abst
 
     @Nullable
     @Override
-    public Object getValue() {
+    public Object get() {
         return null;
     }
 
     @Override
-    public void setValue(final @Nullable Object value) {
+    public void set(final @Nullable Object value) {
         throw new UnsupportedOperationException("Value should be changed from null type before setting value");
     }
 
@@ -64,7 +64,7 @@ final class NullConfigValue<N extends ScopedConfigurationNode<N>, T extends Abst
 
     @Nullable
     @Override
-    public T getChild(final @Nullable Object key) {
+    public T child(final @Nullable Object key) {
         return null;
     }
 

--- a/core/src/main/java/org/spongepowered/configurate/RepresentationHint.java
+++ b/core/src/main/java/org/spongepowered/configurate/RepresentationHint.java
@@ -44,7 +44,7 @@ public abstract class RepresentationHint<V> {
      * @return a new hint
      */
     public static <V> RepresentationHint<V> of(final String identifier, final Class<V> valueType) {
-        return RepresentationHint.<V>builder().setIdentifier(identifier).setValueType(valueType).build();
+        return RepresentationHint.<V>builder().identifier(identifier).valueType(valueType).build();
     }
 
     /**
@@ -59,7 +59,7 @@ public abstract class RepresentationHint<V> {
      * @return a new hint
      */
     public static <V> RepresentationHint<V> of(final String identifier, final TypeToken<V> valueType) {
-        return RepresentationHint.<V>builder().setIdentifier(identifier).setValueType(valueType).build();
+        return RepresentationHint.<V>builder().identifier(identifier).valueType(valueType).build();
     }
 
     /**
@@ -79,14 +79,14 @@ public abstract class RepresentationHint<V> {
      *
      * @return the identifier
      */
-    public abstract String getIdentifier();
+    public abstract String identifier();
 
     /**
      * The type that values of this type have to have.
      *
      * @return value type
      */
-    public abstract TypeToken<V> getValueType();
+    public abstract TypeToken<V> valueType();
 
     /**
      * If a value for a representation hint cannot be found by quering a node
@@ -94,14 +94,14 @@ public abstract class RepresentationHint<V> {
      *
      * @return default type
      */
-    public abstract @Nullable V getDefaultValue();
+    public abstract @Nullable V defaultValue();
 
     /**
      * Get whether or not this hint can draw its value from parent nodes.
      *
      * @return if inheritable
      */
-    public abstract boolean isInheritable();
+    public abstract boolean inheritable();
 
     /**
      * A builder for {@link RepresentationHint}s.
@@ -112,7 +112,7 @@ public abstract class RepresentationHint<V> {
     public abstract static class Builder<V> {
 
         Builder() {
-            this.setInheritable(true);
+            this.inheritable(true);
         }
 
         /**
@@ -121,7 +121,7 @@ public abstract class RepresentationHint<V> {
          * @param identifier hint identifier
          * @return this builder
          */
-        public abstract Builder<V> setIdentifier(String identifier);
+        public abstract Builder<V> identifier(String identifier);
 
         /**
          * Set the type used for this node's value.
@@ -131,8 +131,8 @@ public abstract class RepresentationHint<V> {
          * @param valueType the value type
          * @return this builder
          */
-        public final Builder<V> setValueType(final Class<V> valueType) {
-            return setValueType(TypeToken.get(valueType));
+        public final Builder<V> valueType(final Class<V> valueType) {
+            return valueType(TypeToken.get(valueType));
         }
 
         /**
@@ -143,7 +143,7 @@ public abstract class RepresentationHint<V> {
          * @param valueType the value type
          * @return this builder
          */
-        public abstract Builder<V> setValueType(TypeToken<V> valueType);
+        public abstract Builder<V> valueType(TypeToken<V> valueType);
 
         /**
          * Set the default value when this hint is not present in the hierarchy.
@@ -153,7 +153,7 @@ public abstract class RepresentationHint<V> {
          * @param defaultValue value to return on gets
          * @return this builder
          */
-        public abstract Builder<V> setDefaultValue(@Nullable V defaultValue);
+        public abstract Builder<V> defaultValue(@Nullable V defaultValue);
 
         /**
          * Set whether or not the hint can be inherited.
@@ -162,9 +162,9 @@ public abstract class RepresentationHint<V> {
          *
          * @param inheritable if inheritable
          * @return this builder
-         * @see #isInheritable()
+         * @see #inheritable()
          */
-        public abstract Builder<V> setInheritable(boolean inheritable);
+        public abstract Builder<V> inheritable(boolean inheritable);
 
         /**
          * Create a new hint from the provided options.

--- a/core/src/main/java/org/spongepowered/configurate/ScalarConfigValue.java
+++ b/core/src/main/java/org/spongepowered/configurate/ScalarConfigValue.java
@@ -38,13 +38,13 @@ final class ScalarConfigValue<N extends ScopedConfigurationNode<N>, T extends Ab
 
     @Nullable
     @Override
-    public Object getValue() {
+    public Object get() {
         return this.value;
     }
 
     @Override
-    public void setValue(final @Nullable Object value) {
-        if (!holder.getOptions().acceptsType(requireNonNull(value).getClass())) {
+    public void set(final @Nullable Object value) {
+        if (!holder.options().acceptsType(requireNonNull(value).getClass())) {
             throw new IllegalArgumentException("Configuration does not accept objects of type " + value.getClass());
         }
         this.value = value;
@@ -64,7 +64,7 @@ final class ScalarConfigValue<N extends ScopedConfigurationNode<N>, T extends Ab
 
     @Nullable
     @Override
-    public T getChild(final @Nullable Object key) {
+    public T child(final @Nullable Object key) {
         return null;
     }
 

--- a/core/src/main/java/org/spongepowered/configurate/ScopedConfigurationNode.java
+++ b/core/src/main/java/org/spongepowered/configurate/ScopedConfigurationNode.java
@@ -62,31 +62,31 @@ public interface ScopedConfigurationNode<N extends ScopedConfigurationNode<N>> e
      * {@inheritDoc}
      */
     @Override
-    @NonNull N getNode(@NonNull Object... path);
+    @NonNull N node(@NonNull Object... path);
 
     /**
      * {@inheritDoc}
      */
     @Override
-    @NonNull N getNode(@NonNull Iterable<?> path);
+    @NonNull N node(@NonNull Iterable<?> path);
 
     /**
      * {@inheritDoc}
      */
     @Override
-    @Nullable N getParent();
+    @Nullable N parent();
 
     /**
      * {@inheritDoc}
      */
     @Override
-    @NonNull N mergeValuesFrom(@NonNull ConfigurationNode other);
+    @NonNull N mergeFrom(@NonNull ConfigurationNode other);
 
     /**
      * {@inheritDoc}
      */
     @Override
-    @NonNull N setValue(@Nullable Object value);
+    @NonNull N set(@Nullable Object value);
 
     /**
      * {@inheritDoc}
@@ -94,16 +94,16 @@ public interface ScopedConfigurationNode<N extends ScopedConfigurationNode<N>> e
     @Override
     @NonNull
     @SuppressWarnings({"unchecked", "rawtypes"}) // for TypeSerializer.serialize
-    default N setValue(@NonNull Type type, @Nullable Object value) throws ObjectMappingException {
+    default N set(@NonNull Type type, @Nullable Object value) throws ObjectMappingException {
         if (value == null) {
-            return setValue(null);
+            return set(null);
         }
 
-        final @Nullable TypeSerializer<?> serial = getOptions().getSerializers().get(type);
+        final @Nullable TypeSerializer<?> serial = options().serializers().get(type);
         if (serial != null) {
             ((TypeSerializer) serial).serialize(type, value, self());
-        } else if (getOptions().acceptsType(value.getClass())) {
-            setValue(value); // Just write if no applicable serializer exists?
+        } else if (options().acceptsType(value.getClass())) {
+            set(value); // Just write if no applicable serializer exists?
         } else {
             throw new ObjectMappingException("No serializer available for type " + type);
         }
@@ -111,26 +111,26 @@ public interface ScopedConfigurationNode<N extends ScopedConfigurationNode<N>> e
     }
 
     @Override
-    default <V> N setValue(Class<V> type, @Nullable V value) throws ObjectMappingException {
-        return setValue((Type) type, value);
+    default <V> N set(Class<V> type, @Nullable V value) throws ObjectMappingException {
+        return set((Type) type, value);
     }
 
     @Override
-    default <V> N setValue(TypeToken<V> type, @Nullable V value) throws ObjectMappingException {
-        return setValue(type.getType(), value);
+    default <V> N set(TypeToken<V> type, @Nullable V value) throws ObjectMappingException {
+        return set(type.getType(), value);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    @NonNull List<N> getChildrenList();
+    @NonNull List<N> childrenList();
 
     /**
      * {@inheritDoc}
      */
     @Override
-    @NonNull Map<Object, N> getChildrenMap();
+    @NonNull Map<Object, N> childrenMap();
 
     /**
      * {@inheritDoc}
@@ -238,6 +238,6 @@ public interface ScopedConfigurationNode<N extends ScopedConfigurationNode<N>> e
     <S, T> T visit(ConfigurationVisitor.Safe<? super N, S, T> visitor, S state);
 
     @Override
-    <V> N setHint(RepresentationHint<V> hint, @Nullable V value);
+    <V> N hint(RepresentationHint<V> hint, @Nullable V value);
 
 }

--- a/core/src/main/java/org/spongepowered/configurate/SimpleAttributedConfigurationNode.java
+++ b/core/src/main/java/org/spongepowered/configurate/SimpleAttributedConfigurationNode.java
@@ -37,24 +37,24 @@ class SimpleAttributedConfigurationNode extends AbstractCommentedConfigurationNo
     protected SimpleAttributedConfigurationNode(final @NonNull String tagName, final @Nullable Object path,
             final @Nullable SimpleAttributedConfigurationNode parent, final @NonNull ConfigurationOptions options) {
         super(path, parent, options);
-        setTagName(tagName);
+        tagName(tagName);
     }
 
     protected SimpleAttributedConfigurationNode(final @NonNull String tagName, final @Nullable SimpleAttributedConfigurationNode parent,
             final @NonNull SimpleAttributedConfigurationNode copyOf) {
         super(parent, copyOf);
-        setTagName(tagName);
+        tagName(tagName);
     }
 
     @NonNull
     @Override
-    public String getTagName() {
+    public String tagName() {
         return this.tagName;
     }
 
     @NonNull
     @Override
-    public SimpleAttributedConfigurationNode setTagName(final @NonNull String tagName) {
+    public SimpleAttributedConfigurationNode tagName(final @NonNull String tagName) {
         if (requireNonNull(tagName, "tag name").isEmpty()) {
             throw new IllegalArgumentException("Tag name cannot be null/empty");
         }
@@ -83,7 +83,7 @@ class SimpleAttributedConfigurationNode extends AbstractCommentedConfigurationNo
 
     @NonNull
     @Override
-    public SimpleAttributedConfigurationNode setAttributes(final @NonNull Map<String, String> attributes) {
+    public SimpleAttributedConfigurationNode attributes(final @NonNull Map<String, String> attributes) {
         for (String name : attributes.keySet()) {
             if (requireNonNull(name, "name").isEmpty()) {
                 throw new IllegalArgumentException("Attribute name cannot be null/empty");
@@ -97,6 +97,12 @@ class SimpleAttributedConfigurationNode extends AbstractCommentedConfigurationNo
         return this;
     }
 
+    @NonNull
+    @Override
+    public Map<String, String> attributes() {
+        return Collections.unmodifiableMap(new LinkedHashMap<>(this.attributes));
+    }
+
     @Override
     public boolean hasAttributes() {
         return !this.attributes.isEmpty();
@@ -104,14 +110,8 @@ class SimpleAttributedConfigurationNode extends AbstractCommentedConfigurationNo
 
     @Nullable
     @Override
-    public String getAttribute(final @NonNull String name) {
+    public String attribute(final @NonNull String name) {
         return this.attributes.get(name);
-    }
-
-    @NonNull
-    @Override
-    public Map<String, String> getAttributes() {
-        return Collections.unmodifiableMap(new LinkedHashMap<>(this.attributes));
     }
 
     @Override
@@ -123,31 +123,31 @@ class SimpleAttributedConfigurationNode extends AbstractCommentedConfigurationNo
 
     @Override
     protected SimpleAttributedConfigurationNode createNode(final Object path) {
-        return new SimpleAttributedConfigurationNode("element", path, this, getOptions());
+        return new SimpleAttributedConfigurationNode("element", path, this, options());
     }
 
     @NonNull
     @Override
-    public AttributedConfigurationNode setValue(final @Nullable Object value) {
+    public AttributedConfigurationNode set(final @Nullable Object value) {
         if (value instanceof AttributedConfigurationNode) {
             final AttributedConfigurationNode node = (AttributedConfigurationNode) value;
-            setTagName(node.getTagName());
-            setAttributes(node.getAttributes());
+            tagName(node.tagName());
+            attributes(node.attributes());
         }
-        return super.setValue(value);
+        return super.set(value);
     }
 
     @NonNull
     @Override
-    public AttributedConfigurationNode mergeValuesFrom(final @NonNull ConfigurationNode other) {
+    public AttributedConfigurationNode mergeFrom(final @NonNull ConfigurationNode other) {
         if (other instanceof AttributedConfigurationNode) {
             final AttributedConfigurationNode node = (AttributedConfigurationNode) other;
-            setTagName(node.getTagName());
-            for (Map.Entry<String, String> attribute : node.getAttributes().entrySet()) {
+            tagName(node.tagName());
+            for (Map.Entry<String, String> attribute : node.attributes().entrySet()) {
                 addAttribute(attribute.getKey(), attribute.getValue());
             }
         }
-        return super.mergeValuesFrom(other);
+        return super.mergeFrom(other);
     }
 
     @NonNull

--- a/core/src/main/java/org/spongepowered/configurate/SimpleCommentedConfigurationNode.java
+++ b/core/src/main/java/org/spongepowered/configurate/SimpleCommentedConfigurationNode.java
@@ -39,7 +39,7 @@ class SimpleCommentedConfigurationNode extends AbstractCommentedConfigurationNod
 
     @Override
     protected SimpleCommentedConfigurationNode createNode(final Object path) {
-        return new SimpleCommentedConfigurationNode(path, this, getOptions());
+        return new SimpleCommentedConfigurationNode(path, this, options());
     }
 
     @NonNull

--- a/core/src/main/java/org/spongepowered/configurate/SimpleConfigurationNode.java
+++ b/core/src/main/java/org/spongepowered/configurate/SimpleConfigurationNode.java
@@ -49,7 +49,7 @@ class SimpleConfigurationNode extends AbstractConfigurationNode<BasicConfigurati
 
     @Override
     protected SimpleConfigurationNode createNode(final Object path) {
-        return new SimpleConfigurationNode(path, this, getOptions());
+        return new SimpleConfigurationNode(path, this, options());
     }
 
 }

--- a/core/src/main/java/org/spongepowered/configurate/VisitorNodeEnd.java
+++ b/core/src/main/java/org/spongepowered/configurate/VisitorNodeEnd.java
@@ -34,7 +34,7 @@ class VisitorNodeEnd {
         this.isMap = isMap;
     }
 
-    ConfigurationNode getEnd() {
+    ConfigurationNode end() {
         return this.end;
     }
 
@@ -49,19 +49,19 @@ class VisitorNodeEnd {
         }
 
         final VisitorNodeEnd that = (VisitorNodeEnd) o;
-        return getEnd().equals(that.getEnd());
+        return end().equals(that.end());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getEnd());
+        return Objects.hash(end());
     }
 
     @SuppressWarnings("unchecked")
     static <N extends ConfigurationNode, A extends AbstractConfigurationNode<?, A>, S, E extends Exception> @Nullable A
             popFromVisitor(final Object unknown, final ConfigurationVisitor<N, S, ?, E> visitor, final S state) throws E {
         if (unknown instanceof VisitorNodeEnd) {
-            final N node = (N) ((VisitorNodeEnd) unknown).getEnd();
+            final N node = (N) ((VisitorNodeEnd) unknown).end();
             if (((VisitorNodeEnd) unknown).isMap) {
                 visitor.exitMappingNode(node, state);
             } else {

--- a/core/src/main/java/org/spongepowered/configurate/loader/AtomicFiles.java
+++ b/core/src/main/java/org/spongepowered/configurate/loader/AtomicFiles.java
@@ -47,9 +47,9 @@ public final class AtomicFiles {
      * @param charset the charset to be used by the writer
      * @return a new writer factory
      */
-    public static Callable<BufferedWriter> createAtomicWriterFactory(final Path path, final Charset charset) {
+    public static Callable<BufferedWriter> atomicWriterFactory(final Path path, final Charset charset) {
         requireNonNull(path, "path");
-        return () -> createAtomicBufferedWriter(path, charset);
+        return () -> atomicBufferedWriter(path, charset);
     }
 
     /**
@@ -60,7 +60,7 @@ public final class AtomicFiles {
      * @return a new writer factory
      * @throws IOException for any underlying filesystem errors
      */
-    public static BufferedWriter createAtomicBufferedWriter(Path path, final Charset charset) throws IOException {
+    public static BufferedWriter atomicBufferedWriter(Path path, final Charset charset) throws IOException {
         // absolute
         path = path.toAbsolutePath();
 
@@ -73,7 +73,7 @@ public final class AtomicFiles {
             // ignore
         }
 
-        final Path writePath = getTemporaryPath(path.getParent(), path.getFileName().toString());
+        final Path writePath = temporaryPath(path.getParent(), path.getFileName().toString());
         if (Files.exists(path)) {
             Files.copy(path, writePath, StandardCopyOption.COPY_ATTRIBUTES, StandardCopyOption.REPLACE_EXISTING);
         }
@@ -83,7 +83,7 @@ public final class AtomicFiles {
         return new BufferedWriter(new AtomicFileWriter(writePath, path, output));
     }
 
-    private static Path getTemporaryPath(final Path parent, final String key) {
+    private static Path temporaryPath(final Path parent, final String key) {
         final String fileName = System.nanoTime() + ThreadLocalRandom.current().nextInt()
                 + requireNonNull(key, "key").replaceAll("[\\\\/:]", "-") + ".tmp";
         return parent.resolve(fileName);

--- a/core/src/main/java/org/spongepowered/configurate/objectmapping/FieldData.java
+++ b/core/src/main/java/org/spongepowered/configurate/objectmapping/FieldData.java
@@ -126,7 +126,7 @@ public abstract class FieldData<I, O> {
     }
 
     TypeSerializer<?> serializerFrom(final ConfigurationNode node) throws ObjectMappingException {
-        final @Nullable TypeSerializer<?> serial = node.getOptions().getSerializers().get(resolvedType().getType());
+        final @Nullable TypeSerializer<?> serial = node.options().serializers().get(resolvedType().getType());
         if (serial == null) {
             throw new ObjectMappingException("No TypeSerializer found for field " + name() + " of type " + resolvedType().getType());
         }

--- a/core/src/main/java/org/spongepowered/configurate/objectmapping/FieldDiscoverer.java
+++ b/core/src/main/java/org/spongepowered/configurate/objectmapping/FieldDiscoverer.java
@@ -39,7 +39,7 @@ public interface FieldDiscoverer<I> {
      *
      * @return new discoverer
      */
-    static FieldDiscoverer<?> ofRecord() {
+    static FieldDiscoverer<?> record() {
         return RecordFieldDiscoverer.INSTANCE;
     }
 
@@ -52,7 +52,7 @@ public interface FieldDiscoverer<I> {
      * @param instanceFactory a factory for instance providers
      * @return new discoverer
      */
-    static FieldDiscoverer<?> ofObject(final CheckedFunction<AnnotatedType, @Nullable Supplier<Object>, ObjectMappingException> instanceFactory) {
+    static FieldDiscoverer<?> object(final CheckedFunction<AnnotatedType, @Nullable Supplier<Object>, ObjectMappingException> instanceFactory) {
         return new ObjectFieldDiscoverer(requireNonNull(instanceFactory, "instanceFactory"));
     }
 
@@ -62,10 +62,10 @@ public interface FieldDiscoverer<I> {
      * <p>Only objects with empty constructors can be created.</p>
      *
      * @return new discoverer
-     * @see #ofObject(CheckedFunction) for more details on which fields will
+     * @see #object(CheckedFunction) for more details on which fields will
      *      be discovered.
      */
-    static FieldDiscoverer<?> ofEmptyConstructorObject() {
+    static FieldDiscoverer<?> emptyConstructorObject() {
         return ObjectFieldDiscoverer.EMPTY_CONSTRUCTOR_INSTANCE;
     }
 

--- a/core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectMapper.java
+++ b/core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectMapper.java
@@ -39,7 +39,7 @@ import java.util.function.Predicate;
  *
  * <p>The object mapper can be accessed directly, through its {@link #factory()},
  * or through a {@link ConfigurationNode}'s
- * {@link ConfigurationNode#getValue(TypeToken)} method. To use a custom factory
+ * {@link ConfigurationNode#get(TypeToken)} method. To use a custom factory
  * instance through a node, a custom TypeSerializer has to be registered to the
  * {@link org.spongepowered.configurate.serialize.TypeSerializerCollection} used
  * by the node.</p>
@@ -135,14 +135,14 @@ public interface ObjectMapper<V> {
      *
      * @return immutable list of fields
      */
-    List<? extends FieldData<?, V>> getFields();
+    List<? extends FieldData<?, V>> fields();
 
     /**
      * The generic type of object that this mapper instance handles.
      *
      * @return object type
      */
-    Type getMappedType();
+    Type mappedType();
 
     /**
      * Get whether or not this mapper is capable of creating new instances of
@@ -250,7 +250,7 @@ public interface ObjectMapper<V> {
              * @param scheme naming scheme
              * @return this builder
              */
-            Builder setDefaultNamingScheme(NamingScheme scheme);
+            Builder defaultNamingScheme(NamingScheme scheme);
 
             /**
              * Add a resolver that will locate a node for a field.

--- a/core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectMapperFactoryImpl.java
+++ b/core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectMapperFactoryImpl.java
@@ -78,7 +78,7 @@ final class ObjectMapperFactoryImpl implements ObjectMapper.Factory, TypeSeriali
         if (scheme != null) {
             this.resolverFactories.add((name, element) -> {
                 final String key = scheme.coerce(name);
-                return node -> node.getNode(key);
+                return node -> node.node(key);
             });
         }
 
@@ -198,11 +198,11 @@ final class ObjectMapperFactoryImpl implements ObjectMapper.Factory, TypeSeriali
 
     @Override
     public Object deserialize(final Type type, final ConfigurationNode node) throws ObjectMappingException {
-        final Type clazz = getInstantiableType(type, node.getNode(CLASS_KEY).getString());
+        final Type clazz = instantiableType(type, node.node(CLASS_KEY).getString());
         return get(clazz).load(node);
     }
 
-    private Type getInstantiableType(final Type type, final @Nullable String configuredName) throws ObjectMappingException {
+    private Type instantiableType(final Type type, final @Nullable String configuredName) throws ObjectMappingException {
         final Type retClass;
         final Class<?> rawType = erase(type);
         if (rawType.isInterface() || Modifier.isAbstract(rawType.getModifiers())) {
@@ -229,10 +229,10 @@ final class ObjectMapperFactoryImpl implements ObjectMapper.Factory, TypeSeriali
     @SuppressWarnings("unchecked")
     public void serialize(final Type type, final @Nullable Object obj, final ConfigurationNode node) throws ObjectMappingException {
         if (obj == null) {
-            final ConfigurationNode clazz = node.getNode(CLASS_KEY);
-            node.setValue(null);
-            if (!clazz.isVirtual()) {
-                node.getNode(CLASS_KEY).setValue(clazz);
+            final ConfigurationNode clazz = node.node(CLASS_KEY);
+            node.set(null);
+            if (!clazz.virtual()) {
+                node.node(CLASS_KEY).set(clazz);
             }
             return;
         }
@@ -240,7 +240,7 @@ final class ObjectMapperFactoryImpl implements ObjectMapper.Factory, TypeSeriali
         final ObjectMapper<?> mapper;
         if (rawType.isInterface() || Modifier.isAbstract(rawType.getModifiers())) {
             // serialize obj's concrete type rather than the interface/abstract class
-            node.getNode(CLASS_KEY).setValue(obj.getClass().getName());
+            node.node(CLASS_KEY).set(obj.getClass().getName());
             mapper = get(obj.getClass());
         } else {
             mapper = get(type);
@@ -252,7 +252,7 @@ final class ObjectMapperFactoryImpl implements ObjectMapper.Factory, TypeSeriali
     public @Nullable Object emptyValue(final Type specificType, final ConfigurationOptions options) {
         try {
             // preserve options, but don't copy defaults into temporary node
-            return get(specificType).load(BasicConfigurationNode.root(options.withShouldCopyDefaults(false)));
+            return get(specificType).load(BasicConfigurationNode.root(options.shouldCopyDefaults(false)));
         } catch (final ObjectMappingException ex) {
             return null;
         }
@@ -300,7 +300,7 @@ final class ObjectMapperFactoryImpl implements ObjectMapper.Factory, TypeSeriali
 
     static ObjectMapper.Factory.Builder defaultBuilder() {
         return new Builder()
-                .setDefaultNamingScheme(NamingSchemes.LOWER_CASE_DASHED)
+                .defaultNamingScheme(NamingSchemes.LOWER_CASE_DASHED)
                 // Resolvers //
                 .addNodeResolver(NodeResolver.nodeKey())
                 .addNodeResolver(NodeResolver.keyFromSetting())
@@ -309,8 +309,8 @@ final class ObjectMapperFactoryImpl implements ObjectMapper.Factory, TypeSeriali
                 .addConstraint(Matches.class, String.class, Constraint.pattern())
                 .addConstraint(Required.class, Constraint.required())
                 // Field discovers //
-                .addDiscoverer(FieldDiscoverer.ofEmptyConstructorObject())
-                .addDiscoverer(FieldDiscoverer.ofRecord());
+                .addDiscoverer(FieldDiscoverer.emptyConstructorObject())
+                .addDiscoverer(FieldDiscoverer.record());
     }
 
     /**
@@ -327,7 +327,7 @@ final class ObjectMapperFactoryImpl implements ObjectMapper.Factory, TypeSeriali
         private final List<Definition<?, ?, ? extends Processor.Factory<?, ?>>> processors = new ArrayList<>();
 
         @Override
-        public ObjectMapper.Factory.Builder setDefaultNamingScheme(final NamingScheme scheme) {
+        public ObjectMapper.Factory.Builder defaultNamingScheme(final NamingScheme scheme) {
             this.namingScheme = scheme;
             return this;
         }

--- a/core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectMapperImpl.java
+++ b/core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectMapperImpl.java
@@ -60,15 +60,15 @@ class ObjectMapperImpl<I, V> implements ObjectMapper<V> {
                 }
 
                 final TypeSerializer<?> serial = field.serializerFrom(node);
-                final @Nullable Object newVal = node.isVirtual() ? null : serial.deserialize(field.resolvedType().getType(), node);
+                final @Nullable Object newVal = node.virtual() ? null : serial.deserialize(field.resolvedType().getType(), node);
                 field.validate(newVal);
 
                 // set up an implicit initializer
                 // only the instance factory has knowledge of the underlying data type,
                 // so we have to pass both implicit and explicit options along to it.
                 final Supplier<@Nullable Object> implicitInitializer;
-                if (newVal == null && node.getOptions().isImplicitInitialization()) {
-                    implicitInitializer = () -> serial.emptyValue(field.resolvedType().getType(), node.getOptions());
+                if (newVal == null && node.options().implicitInitialization()) {
+                    implicitInitializer = () -> serial.emptyValue(field.resolvedType().getType(), node.options());
                 } else {
                     implicitInitializer = () -> null;
                 }
@@ -76,7 +76,7 @@ class ObjectMapperImpl<I, V> implements ObjectMapper<V> {
                 // load field into intermediate object
                 field.deserializer().accept(intermediate, newVal, implicitInitializer);
 
-                if (newVal == null && source.getOptions().getShouldCopyDefaults()) {
+                if (newVal == null && source.options().shouldCopyDefaults()) {
                     if (unseenFields == null) {
                         unseenFields = new ArrayList<>();
                     }
@@ -110,8 +110,8 @@ class ObjectMapperImpl<I, V> implements ObjectMapper<V> {
             saveSingle(field, value, target);
         }
 
-        if (target.isVirtual()) { // we didn't save anything
-            target.setValue(Collections.emptyMap());
+        if (target.virtual()) { // we didn't save anything
+            target.set(Collections.emptyMap());
         }
     }
 
@@ -132,7 +132,7 @@ class ObjectMapperImpl<I, V> implements ObjectMapper<V> {
         }
 
         if (fieldVal == null) {
-            node.setValue(null);
+            node.set(null);
         } else {
             final TypeSerializer<Object> serial = (TypeSerializer<Object>) field.serializerFrom(node);
             serial.serialize(field.resolvedType().getType(), fieldVal, node);
@@ -143,12 +143,12 @@ class ObjectMapperImpl<I, V> implements ObjectMapper<V> {
     }
 
     @Override
-    public List<FieldData<I, V>> getFields() {
+    public List<FieldData<I, V>> fields() {
         return this.fields;
     }
 
     @Override
-    public Type getMappedType() {
+    public Type mappedType() {
         return this.type;
     }
 

--- a/core/src/main/java/org/spongepowered/configurate/objectmapping/meta/NodeResolver.java
+++ b/core/src/main/java/org/spongepowered/configurate/objectmapping/meta/NodeResolver.java
@@ -66,7 +66,7 @@ public interface NodeResolver {
     static NodeResolver.Factory nodeKey() {
         return (name, element) -> {
             if (element.isAnnotationPresent(NodeKey.class)) {
-                return node -> BasicConfigurationNode.root(node.getOptions()).setValue(node.getKey());
+                return node -> BasicConfigurationNode.root(node.options()).set(node.key());
             }
             return null;
         };
@@ -82,7 +82,7 @@ public interface NodeResolver {
             if (element.isAnnotationPresent(Setting.class)) {
                 final String key = element.getAnnotation(Setting.class).value();
                 if (!key.isEmpty()) {
-                    return node -> node.getNode(key);
+                    return node -> node.node(key);
                 }
             }
             return null;

--- a/core/src/main/java/org/spongepowered/configurate/objectmapping/meta/Processor.java
+++ b/core/src/main/java/org/spongepowered/configurate/objectmapping/meta/Processor.java
@@ -68,9 +68,9 @@ public interface Processor<V> {
             if (destination instanceof CommentedConfigurationNodeIntermediary<?>) {
                 final CommentedConfigurationNodeIntermediary<?> commented = (CommentedConfigurationNodeIntermediary<?>) destination;
                 if (data.override()) {
-                    commented.setComment(data.value());
+                    commented.comment(data.value());
                 } else {
-                    commented.setCommentIfAbsent(data.value());
+                    commented.commentIfAbsent(data.value());
                 }
             }
         };
@@ -93,9 +93,9 @@ public interface Processor<V> {
                 if (destination instanceof CommentedConfigurationNodeIntermediary<?>) {
                     final CommentedConfigurationNodeIntermediary<?> commented = (CommentedConfigurationNodeIntermediary<?>) destination;
                     if (data.override()) {
-                        commented.setComment(translated);
+                        commented.comment(translated);
                     } else {
-                        commented.setCommentIfAbsent(translated);
+                        commented.commentIfAbsent(translated);
                     }
                 }
             };

--- a/core/src/main/java/org/spongepowered/configurate/reactive/AbstractProcessor.java
+++ b/core/src/main/java/org/spongepowered/configurate/reactive/AbstractProcessor.java
@@ -44,7 +44,7 @@ abstract class AbstractProcessor<V, R extends AbstractProcessor.Registration<V>>
     }
 
     @Override
-    public Executor getExecutor() {
+    public Executor executor() {
         return this.executor;
     }
 
@@ -113,7 +113,7 @@ abstract class AbstractProcessor<V, R extends AbstractProcessor.Registration<V>>
     }
 
     @Override
-    public void setFallbackHandler(final @Nullable Subscriber<V> subscriber) {
+    public void fallbackHandler(final @Nullable Subscriber<V> subscriber) {
         this.fallbackHandler = subscriber;
     }
 

--- a/core/src/main/java/org/spongepowered/configurate/reactive/CachedPublisher.java
+++ b/core/src/main/java/org/spongepowered/configurate/reactive/CachedPublisher.java
@@ -82,8 +82,8 @@ class CachedPublisher<V> implements Publisher.Cached<V>, AutoCloseable {
     }
 
     @Override
-    public Executor getExecutor() {
-        return this.parent.getExecutor();
+    public Executor executor() {
+        return this.parent.executor();
     }
 
     @Override

--- a/core/src/main/java/org/spongepowered/configurate/reactive/ExecutePublisher.java
+++ b/core/src/main/java/org/spongepowered/configurate/reactive/ExecutePublisher.java
@@ -76,7 +76,7 @@ class ExecutePublisher<V> implements Publisher<V> {
     }
 
     @Override
-    public Executor getExecutor() {
+    public Executor executor() {
         return this.executor;
     }
 

--- a/core/src/main/java/org/spongepowered/configurate/reactive/MappedProcessor.java
+++ b/core/src/main/java/org/spongepowered/configurate/reactive/MappedProcessor.java
@@ -30,7 +30,7 @@ class MappedProcessor<I, O> implements Processor.Transactional<I, O> {
     private final @Nullable Publisher<I> parent;
 
     MappedProcessor(final CheckedFunction<? super I, ? extends O, TransactionFailedException> mapper, final @Nullable Publisher<I> parent) {
-        this.processor = parent == null ? Processor.createTransactional() : Processor.createTransactional(parent.getExecutor());
+        this.processor = parent == null ? Processor.createTransactional() : Processor.createTransactional(parent.executor());
         this.mapper = mapper;
         this.parent = parent;
     }
@@ -62,8 +62,8 @@ class MappedProcessor<I, O> implements Processor.Transactional<I, O> {
     }
 
     @Override
-    public Executor getExecutor() {
-        return this.processor.getExecutor();
+    public Executor executor() {
+        return this.processor.executor();
     }
 
     @Override
@@ -101,8 +101,8 @@ class MappedProcessor<I, O> implements Processor.Transactional<I, O> {
     }
 
     @Override
-    public void setFallbackHandler(@Nullable final Subscriber<O> subscriber) {
-        this.processor.setFallbackHandler(subscriber);
+    public void fallbackHandler(@Nullable final Subscriber<O> subscriber) {
+        this.processor.fallbackHandler(subscriber);
     }
 
     @Override

--- a/core/src/main/java/org/spongepowered/configurate/reactive/Processor.java
+++ b/core/src/main/java/org/spongepowered/configurate/reactive/Processor.java
@@ -109,7 +109,7 @@ public interface Processor<I, O> extends Publisher<O>, Subscriber<I> {
      * @param subscriber the fallback subscriber to add. Provide {@code null} to
      *                   remove the handler
      */
-    void setFallbackHandler(@Nullable Subscriber<O> subscriber);
+    void fallbackHandler(@Nullable Subscriber<O> subscriber);
 
     /**
      * Close this processor if there are no remaining subscriptions. Any signals

--- a/core/src/main/java/org/spongepowered/configurate/reactive/Publisher.java
+++ b/core/src/main/java/org/spongepowered/configurate/reactive/Publisher.java
@@ -124,7 +124,7 @@ public interface Publisher<V> {
      *
      * @return the executor
      */
-    Executor getExecutor();
+    Executor executor();
 
     /**
      * A publisher that caches the last value received.

--- a/core/src/main/java/org/spongepowered/configurate/reactive/TransactionalRegistration.java
+++ b/core/src/main/java/org/spongepowered/configurate/reactive/TransactionalRegistration.java
@@ -30,12 +30,12 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 interface TransactionalRegistration<V> extends AbstractProcessor.Registration<V> {
 
-    TransactionalProcessorImpl<V> getHolder();
+    TransactionalProcessorImpl<V> holder();
 
     @Override
     default void dispose() {
-        if (getHolder().registrations.remove(this)) {
-            getHolder().subscriberCount.getAndDecrement();
+        if (holder().registrations.remove(this)) {
+            holder().subscriberCount.getAndDecrement();
         }
     }
 
@@ -74,7 +74,7 @@ interface TransactionalRegistration<V> extends AbstractProcessor.Registration<V>
         }
 
         @Override
-        public TransactionalProcessorImpl<V> getHolder() {
+        public TransactionalProcessorImpl<V> holder() {
             return this.holder;
         }
 
@@ -126,7 +126,7 @@ interface TransactionalRegistration<V> extends AbstractProcessor.Registration<V>
         }
 
         @Override
-        public TransactionalProcessorImpl<V> getHolder() {
+        public TransactionalProcessorImpl<V> holder() {
             return this.holder;
         }
 

--- a/core/src/main/java/org/spongepowered/configurate/reference/ConfigurationReference.java
+++ b/core/src/main/java/org/spongepowered/configurate/reference/ConfigurationReference.java
@@ -47,7 +47,7 @@ public interface ConfigurationReference<N extends ConfigurationNode> extends Aut
      * @return the newly created reference, with an initial load performed
      * @throws IOException if the configuration contained fails to load
      */
-    static <N extends ScopedConfigurationNode<N>> ConfigurationReference<N> createFixed(ConfigurationLoader<? extends N> loader) throws IOException {
+    static <N extends ScopedConfigurationNode<N>> ConfigurationReference<N> fixed(ConfigurationLoader<? extends N> loader) throws IOException {
         final ConfigurationReference<N> ret = new ManualConfigurationReference<>(loader, ForkJoinPool.commonPool());
         ret.load();
         return ret;
@@ -67,10 +67,10 @@ public interface ConfigurationReference<N extends ConfigurationNode> extends Aut
      * @see WatchServiceListener#listenToConfiguration(Function, Path)
      */
     static <T extends ScopedConfigurationNode<T>> ConfigurationReference<T>
-        createWatching(Function<Path, ConfigurationLoader<? extends T>> loaderCreator, Path file, WatchServiceListener listener) throws IOException {
+            watching(Function<Path, ConfigurationLoader<? extends T>> loaderCreator, Path file, WatchServiceListener listener) throws IOException {
         final WatchingConfigurationReference<T> ret = new WatchingConfigurationReference<>(loaderCreator.apply(file), listener.taskExecutor);
         ret.load();
-        ret.setDisposable(listener.listenToFile(file, ret));
+        ret.disposable(listener.listenToFile(file, ret));
 
         return ret;
     }
@@ -128,21 +128,21 @@ public interface ConfigurationReference<N extends ConfigurationNode> extends Aut
      *
      * @return the node
      */
-    N getNode();
+    N node();
 
     /**
      * Get the loader this reference uses to load and save its node.
      *
      * @return the loader
      */
-    ConfigurationLoader<? extends N> getLoader();
+    ConfigurationLoader<? extends N> loader();
 
     /**
      * Get the node at the given path, using the root node.
      *
      * @param path the path, a series of path elements
      * @return a child node
-     * @see ConfigurationNode#getNode(Object...)
+     * @see ConfigurationNode#node(Object...)
      */
     N get(Object... path);
 
@@ -154,7 +154,7 @@ public interface ConfigurationReference<N extends ConfigurationNode> extends Aut
      * @param value the value to set the child node to
      */
     default void set(Object[] path, @Nullable Object value) {
-        getNode().getNode(path).setValue(value);
+        node().node(path).set(value);
     }
 
     /**
@@ -173,7 +173,7 @@ public interface ConfigurationReference<N extends ConfigurationNode> extends Aut
      * @throws ObjectMappingException if thrown by the serialization mechanism
      */
     default <T> void set(Object[] path, Class<T> type, @Nullable T value) throws ObjectMappingException {
-        getNode().getNode(path).setValue(type, value);
+        node().node(path).set(type, value);
     }
 
     /**
@@ -191,7 +191,7 @@ public interface ConfigurationReference<N extends ConfigurationNode> extends Aut
      * @throws ObjectMappingException if thrown by the serialization mechanism
      */
     default <T> void set(Object[] path, TypeToken<T> type, @Nullable T value) throws ObjectMappingException {
-        getNode().getNode(path).setValue(type, value);
+        node().node(path).set(type, value);
     }
 
     /**
@@ -202,7 +202,7 @@ public interface ConfigurationReference<N extends ConfigurationNode> extends Aut
      * @param value the value to set the child node to
      */
     default void set(NodePath path, @Nullable Object value) {
-        getNode().getNode(path).setValue(value);
+        node().node(path).set(value);
     }
 
     /**
@@ -220,7 +220,7 @@ public interface ConfigurationReference<N extends ConfigurationNode> extends Aut
      * @throws ObjectMappingException if thrown by the serialization mechanism
      */
     default <T> void set(NodePath path, Class<T> type, @Nullable T value) throws ObjectMappingException {
-        getNode().getNode(path).setValue(type, value);
+        node().node(path).set(type, value);
     }
 
     /**
@@ -238,7 +238,7 @@ public interface ConfigurationReference<N extends ConfigurationNode> extends Aut
      * @throws ObjectMappingException if thrown by the serialization mechanism
      */
     default <T> void set(NodePath path, TypeToken<T> type, @Nullable T value) throws ObjectMappingException {
-        getNode().getNode(path).setValue(type, value);
+        node().node(path).set(type, value);
     }
 
     /**
@@ -257,7 +257,7 @@ public interface ConfigurationReference<N extends ConfigurationNode> extends Aut
      *         for the provided type
      */
     default <T> ValueReference<T, N> referenceTo(TypeToken<T> type, Object... path) throws ObjectMappingException {
-        return referenceTo(type, NodePath.create(path));
+        return referenceTo(type, NodePath.of(path));
     }
 
     /**
@@ -276,7 +276,7 @@ public interface ConfigurationReference<N extends ConfigurationNode> extends Aut
      *         for the provided type
      */
     default <T> ValueReference<T, N> referenceTo(Class<T> type, Object... path) throws ObjectMappingException {
-        return referenceTo(type, NodePath.create(path));
+        return referenceTo(type, NodePath.of(path));
     }
 
     /**

--- a/core/src/main/java/org/spongepowered/configurate/reference/DirectoryListenerRegistration.java
+++ b/core/src/main/java/org/spongepowered/configurate/reference/DirectoryListenerRegistration.java
@@ -52,7 +52,7 @@ class DirectoryListenerRegistration implements Subscriber<WatchEvent<?>> {
         this.dirListeners = Processor.create(executor);
     }
 
-    public WatchKey getKey() {
+    public WatchKey key() {
         return this.key;
     }
 
@@ -142,14 +142,14 @@ class DirectoryListenerRegistration implements Subscriber<WatchEvent<?>> {
         }
 
         final DirectoryListenerRegistration that = (DirectoryListenerRegistration) o;
-        return getKey().equals(that.getKey())
+        return key().equals(that.key())
             && this.fileListeners.equals(that.fileListeners)
             && this.dirListeners.equals(that.dirListeners);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getKey(), this.fileListeners, this.dirListeners);
+        return Objects.hash(key(), this.fileListeners, this.dirListeners);
     }
 
     public boolean closeIfEmpty() {

--- a/core/src/main/java/org/spongepowered/configurate/reference/ManualConfigurationReference.java
+++ b/core/src/main/java/org/spongepowered/configurate/reference/ManualConfigurationReference.java
@@ -47,7 +47,7 @@ class ManualConfigurationReference<N extends ScopedConfigurationNode<N>> impleme
         this.loader = loader;
         this.updateListener = Processor.createTransactional(taskExecutor);
         this.errorListener = Processor.create(taskExecutor);
-        this.errorListener.setFallbackHandler(it -> {
+        this.errorListener.fallbackHandler(it -> {
             System.err.println("Unhandled error while performing a " + it.getKey() + " for a "
                 + "configuration reference: " + it.getValue());
             it.getValue().printStackTrace();
@@ -77,32 +77,32 @@ class ManualConfigurationReference<N extends ScopedConfigurationNode<N>> impleme
     public Publisher<N> saveAsync() {
         return Publisher.execute(() -> {
             save();
-            return getNode();
-        }, this.updateListener.getExecutor());
+            return node();
+        }, this.updateListener.executor());
     }
 
     @Override
     public Publisher<N> updateAsync(final Function<N, ? extends N> updater) {
         return Publisher.execute(() -> {
-            final N newNode = updater.apply(getNode());
+            final N newNode = updater.apply(node());
             save(newNode);
             return newNode;
-        }, this.updateListener.getExecutor());
+        }, this.updateListener.executor());
     }
 
     @Override
-    public N getNode() {
+    public N node() {
         return this.node;
     }
 
     @Override
-    public ConfigurationLoader<? extends N> getLoader() {
+    public ConfigurationLoader<? extends N> loader() {
         return this.loader;
     }
 
     @Override
     public N get(final Object... path) {
-        return getNode().getNode(path);
+        return node().node(path);
     }
 
     @Override

--- a/core/src/main/java/org/spongepowered/configurate/reference/ValueReference.java
+++ b/core/src/main/java/org/spongepowered/configurate/reference/ValueReference.java
@@ -64,7 +64,7 @@ public interface ValueReference<T, N extends ConfigurationNode> extends Publishe
      * @param value the value
      * @return true if successful, false if serialization fails
      */
-    boolean setAndSave(@Nullable T value);
+    boolean setAndSave(@Nullable T value); // @cs-: NoGetSetPrefix (not a property accessor)
 
     /**
      * Set the new value of this node and save the underlying configuration
@@ -76,7 +76,7 @@ public interface ValueReference<T, N extends ConfigurationNode> extends Publishe
      * @param value the value
      * @return true if successful, false if serialization fails
      */
-    Publisher<Boolean> setAndSaveAsync(@Nullable T value);
+    Publisher<Boolean> setAndSaveAsync(@Nullable T value); // @cs-: NoGetSetPrefix (not a property accessor)
 
     /**
      * Update this value and the underlying node, without saving.
@@ -106,6 +106,6 @@ public interface ValueReference<T, N extends ConfigurationNode> extends Publishe
      *
      * @return the node
      */
-    N getNode();
+    N node();
 
 }

--- a/core/src/main/java/org/spongepowered/configurate/reference/WatchServiceListener.java
+++ b/core/src/main/java/org/spongepowered/configurate/reference/WatchServiceListener.java
@@ -153,7 +153,7 @@ public final class WatchServiceListener implements AutoCloseable {
      * @throws IOException if produced while registering the path with
      *          our WatchService
      */
-    private DirectoryListenerRegistration getRegistration(final Path directory) throws IOException {
+    private DirectoryListenerRegistration registration(final Path directory) throws IOException {
         final @Nullable DirectoryListenerRegistration reg = this.activeListeners.computeIfAbsent(directory, dir -> {
             try {
                 return new DirectoryListenerRegistration(dir.register(this.watchService, DEFAULT_WATCH_EVENTS), this.taskExecutor);
@@ -185,7 +185,7 @@ public final class WatchServiceListener implements AutoCloseable {
         }
 
         final Path fileName = file.getFileName();
-        return getRegistration(file.getParent()).subscribe(fileName, callback);
+        return registration(file.getParent()).subscribe(fileName, callback);
     }
 
     /**
@@ -205,7 +205,7 @@ public final class WatchServiceListener implements AutoCloseable {
             throw new IllegalArgumentException("Path " + directory + " must be a directory");
         }
 
-        return getRegistration(directory).subscribe(callback);
+        return registration(directory).subscribe(callback);
     }
 
     /**
@@ -220,7 +220,7 @@ public final class WatchServiceListener implements AutoCloseable {
      */
     public <N extends ScopedConfigurationNode<N>> ConfigurationReference<N>
         listenToConfiguration(final Function<Path, ConfigurationLoader<? extends N>> loaderFunc, final Path path) throws IOException {
-        return ConfigurationReference.createWatching(loaderFunc, path, this);
+        return ConfigurationReference.watching(loaderFunc, path, this);
     }
 
     @Override
@@ -256,7 +256,7 @@ public final class WatchServiceListener implements AutoCloseable {
          * @param factory the thread factory to use to create the deamon thread
          * @return this builder
          */
-        public Builder setThreadFactory(final ThreadFactory factory) {
+        public Builder threadFactory(final ThreadFactory factory) {
             this.threadFactory = requireNonNull(factory, "factory");
             return this;
         }
@@ -269,7 +269,7 @@ public final class WatchServiceListener implements AutoCloseable {
          * @param executor the executor to use
          * @return this builder
          */
-        public Builder setTaskExecutor(final Executor executor) {
+        public Builder taskExecutor(final Executor executor) {
             this.taskExecutor = requireNonNull(executor, "executor");
             return this;
         }
@@ -282,7 +282,7 @@ public final class WatchServiceListener implements AutoCloseable {
          * @param system the file system to use.
          * @return this builder
          */
-        public Builder setFileSystem(final FileSystem system) {
+        public Builder fileSystem(final FileSystem system) {
             this.fileSystem = system;
             return this;
         }

--- a/core/src/main/java/org/spongepowered/configurate/reference/WatchingConfigurationReference.java
+++ b/core/src/main/java/org/spongepowered/configurate/reference/WatchingConfigurationReference.java
@@ -43,7 +43,7 @@ class WatchingConfigurationReference<N extends ScopedConfigurationNode<N>>
 
     @Override
     public void save(final N newNode) throws IOException {
-        synchronized (getLoader()) {
+        synchronized (loader()) {
             try {
                 this.saveSuppressed = true;
                 super.save(newNode);
@@ -82,7 +82,7 @@ class WatchingConfigurationReference<N extends ScopedConfigurationNode<N>>
         close();
     }
 
-    void setDisposable(final Disposable disposable) {
+    void disposable(final Disposable disposable) {
         this.disposable = disposable;
     }
 

--- a/core/src/main/java/org/spongepowered/configurate/serialize/AbstractListChildSerializer.java
+++ b/core/src/main/java/org/spongepowered/configurate/serialize/AbstractListChildSerializer.java
@@ -36,21 +36,21 @@ abstract class AbstractListChildSerializer<T> implements TypeSerializer<T> {
 
     @Override
     public T deserialize(final Type type, final ConfigurationNode node) throws ObjectMappingException {
-        final Type entryType = getElementType(type);
-        final @Nullable TypeSerializer<?> entrySerial = node.getOptions().getSerializers().get(entryType);
+        final Type entryType = elementType(type);
+        final @Nullable TypeSerializer<?> entrySerial = node.options().serializers().get(entryType);
         if (entrySerial == null) {
             throw new ObjectMappingException("No applicable type serializer for type " + entryType);
         }
 
         if (node.isList()) {
-            final List<? extends ConfigurationNode> values = node.getChildrenList();
+            final List<? extends ConfigurationNode> values = node.childrenList();
             final T ret = createNew(values.size(), entryType);
             for (int i = 0; i < values.size(); ++i) {
                 deserializeSingle(i, ret, entrySerial.deserialize(entryType, values.get(i)));
             }
             return ret;
         } else {
-            final @Nullable Object unwrappedVal = node.getValue();
+            final @Nullable Object unwrappedVal = node.get();
             if (unwrappedVal != null) {
                 final T ret = createNew(1, entryType);
                 deserializeSingle(0, ret, entrySerial.deserialize(entryType, node));
@@ -63,13 +63,13 @@ abstract class AbstractListChildSerializer<T> implements TypeSerializer<T> {
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public void serialize(final Type type, final @Nullable T obj, final ConfigurationNode node) throws ObjectMappingException {
-        final Type entryType = getElementType(type);
-        final @Nullable TypeSerializer entrySerial = node.getOptions().getSerializers().get(entryType);
+        final Type entryType = elementType(type);
+        final @Nullable TypeSerializer entrySerial = node.options().serializers().get(entryType);
         if (entrySerial == null) {
             throw new ObjectMappingException("No applicable type serializer for type " + entryType);
         }
 
-        node.setValue(Collections.emptyList());
+        node.set(Collections.emptyList());
         if (obj != null) {
             forEachElement(obj, el -> entrySerial.serialize(entryType, el, node.appendListNode()));
         }
@@ -78,7 +78,7 @@ abstract class AbstractListChildSerializer<T> implements TypeSerializer<T> {
     @Override
     public @Nullable T emptyValue(final Type specificType, final ConfigurationOptions options) {
         try {
-            return this.createNew(0, getElementType(specificType));
+            return this.createNew(0, elementType(specificType));
         } catch (final ObjectMappingException ex) {
             return null;
         }
@@ -93,7 +93,7 @@ abstract class AbstractListChildSerializer<T> implements TypeSerializer<T> {
      * @return the element type
      * @throws ObjectMappingException if the element type could not be detected
      */
-    abstract Type getElementType(Type containerType) throws ObjectMappingException;
+    abstract Type elementType(Type containerType) throws ObjectMappingException;
 
     /**
      * Create a new instance of the collection. The returned instance must be
@@ -101,7 +101,7 @@ abstract class AbstractListChildSerializer<T> implements TypeSerializer<T> {
      *
      * @param length the necessary collection length
      * @param elementType the type of element contained within the collection,
-     *                    as provided by {@link #getElementType(Type)}
+     *                    as provided by {@link #elementType(Type)}
      * @return a newly created collection
      * @throws ObjectMappingException when an error occurs during the creation
      *                                of the collection

--- a/core/src/main/java/org/spongepowered/configurate/serialize/ArraySerializer.java
+++ b/core/src/main/java/org/spongepowered/configurate/serialize/ArraySerializer.java
@@ -37,7 +37,7 @@ import java.util.function.Predicate;
 abstract class ArraySerializer<T> extends AbstractListChildSerializer<T> {
 
     @Override
-    Type getElementType(final Type containerType) {
+    Type elementType(final Type containerType) {
         return requireNonNull(GenericTypeReflector.getArrayComponentType(containerType), "Must be array type");
     }
 

--- a/core/src/main/java/org/spongepowered/configurate/serialize/ConfigurationNodeSerializer.java
+++ b/core/src/main/java/org/spongepowered/configurate/serialize/ConfigurationNodeSerializer.java
@@ -42,7 +42,7 @@ class ConfigurationNodeSerializer implements TypeSerializer<ConfigurationNode> {
 
     @Override
     public void serialize(final @NonNull Type type, final @Nullable ConfigurationNode obj, final @NonNull ConfigurationNode node) {
-        node.setValue(obj);
+        node.set(obj);
     }
 
     @Override

--- a/core/src/main/java/org/spongepowered/configurate/serialize/FileSerializer.java
+++ b/core/src/main/java/org/spongepowered/configurate/serialize/FileSerializer.java
@@ -40,15 +40,15 @@ final class FileSerializer implements TypeSerializer<File> {
 
     @Override
     public File deserialize(final Type type, final ConfigurationNode node) throws ObjectMappingException {
-        return requireNonNull(node.getValue(Path.class), "node did not contain a valid path").toFile();
+        return requireNonNull(node.get(Path.class), "node did not contain a valid path").toFile();
     }
 
     @Override
     public void serialize(final Type type, final @Nullable File obj, final ConfigurationNode node) throws ObjectMappingException {
         if (obj == null) {
-            node.setValue(null);
+            node.set(null);
         } else {
-            node.setValue(Path.class, obj.toPath());
+            node.set(Path.class, obj.toPath());
         }
     }
 

--- a/core/src/main/java/org/spongepowered/configurate/serialize/ListSerializer.java
+++ b/core/src/main/java/org/spongepowered/configurate/serialize/ListSerializer.java
@@ -30,7 +30,7 @@ final class ListSerializer extends AbstractListChildSerializer<List<?>> {
     static final TypeToken<List<?>> TYPE = new TypeToken<List<?>>() {};
 
     @Override
-    Type getElementType(final Type containerType) throws ObjectMappingException {
+    Type elementType(final Type containerType) throws ObjectMappingException {
         if (!(containerType instanceof ParameterizedType)) {
             throw new ObjectMappingException("Raw types are not supported for collections");
         }

--- a/core/src/main/java/org/spongepowered/configurate/serialize/MapSerializer.java
+++ b/core/src/main/java/org/spongepowered/configurate/serialize/MapSerializer.java
@@ -50,8 +50,8 @@ final class MapSerializer implements TypeSerializer<Map<?, ?>> {
             }
             final Type key = param.getActualTypeArguments()[0];
             final Type value = param.getActualTypeArguments()[1];
-            final @Nullable TypeSerializer<?> keySerial = node.getOptions().getSerializers().get(key);
-            final @Nullable TypeSerializer<?> valueSerial = node.getOptions().getSerializers().get(value);
+            final @Nullable TypeSerializer<?> keySerial = node.options().serializers().get(key);
+            final @Nullable TypeSerializer<?> valueSerial = node.options().serializers().get(value);
 
             if (keySerial == null) {
                 throw new ObjectMappingException("No type serializer available for type " + key);
@@ -61,10 +61,10 @@ final class MapSerializer implements TypeSerializer<Map<?, ?>> {
                 throw new ObjectMappingException("No type serializer available for type " + value);
             }
 
-            final BasicConfigurationNode keyNode = BasicConfigurationNode.root(node.getOptions());
+            final BasicConfigurationNode keyNode = BasicConfigurationNode.root(node.options());
 
-            for (Map.Entry<Object, ? extends ConfigurationNode> ent : node.getChildrenMap().entrySet()) {
-                ret.put(requireNonNull(keySerial.deserialize(key, keyNode.setValue(ent.getKey())), "key"),
+            for (Map.Entry<Object, ? extends ConfigurationNode> ent : node.childrenMap().entrySet()) {
+                ret.put(requireNonNull(keySerial.deserialize(key, keyNode.set(ent.getKey())), "key"),
                     requireNonNull(valueSerial.deserialize(value, ent.getValue()), "value"));
             }
         }
@@ -83,8 +83,8 @@ final class MapSerializer implements TypeSerializer<Map<?, ?>> {
         }
         final Type key = param.getActualTypeArguments()[0];
         final Type value = param.getActualTypeArguments()[1];
-        final @Nullable TypeSerializer keySerial = node.getOptions().getSerializers().get(key);
-        final @Nullable TypeSerializer valueSerial = node.getOptions().getSerializers().get(value);
+        final @Nullable TypeSerializer keySerial = node.options().serializers().get(key);
+        final @Nullable TypeSerializer valueSerial = node.options().serializers().get(value);
 
         if (keySerial == null) {
             throw new ObjectMappingException("No type serializer available for type " + key);
@@ -95,14 +95,14 @@ final class MapSerializer implements TypeSerializer<Map<?, ?>> {
         }
 
         if (obj == null || obj.isEmpty()) {
-            node.setValue(Collections.emptyMap());
+            node.set(Collections.emptyMap());
         } else {
-            final Set<Object> unvisitedKeys = new HashSet<>(node.getChildrenMap().keySet());
-            final BasicConfigurationNode keyNode = BasicConfigurationNode.root(node.getOptions());
+            final Set<Object> unvisitedKeys = new HashSet<>(node.childrenMap().keySet());
+            final BasicConfigurationNode keyNode = BasicConfigurationNode.root(node.options());
             for (Map.Entry<?, ?> ent : obj.entrySet()) {
                 keySerial.serialize(key, ent.getKey(), keyNode);
-                final Object keyObj = requireNonNull(keyNode.getValue(), "Key must not be null!");
-                valueSerial.serialize(value, ent.getValue(), node.getNode(keyObj));
+                final Object keyObj = requireNonNull(keyNode.get(), "Key must not be null!");
+                valueSerial.serialize(value, ent.getValue(), node.node(keyObj));
                 unvisitedKeys.remove(keyObj);
             }
 

--- a/core/src/main/java/org/spongepowered/configurate/serialize/PathSerializer.java
+++ b/core/src/main/java/org/spongepowered/configurate/serialize/PathSerializer.java
@@ -48,7 +48,7 @@ final class PathSerializer implements TypeSerializer<Path> {
         } else if (node.isMap()) {
             throw new ObjectMappingException("Paths must be a list of strings, or a single string");
         }
-        final @Nullable Object value = node.getValue();
+        final @Nullable Object value = node.get();
         if (value == null) {
             throw new ObjectMappingException("must have value");
         }
@@ -63,19 +63,19 @@ final class PathSerializer implements TypeSerializer<Path> {
     @Override
     public void serialize(final Type type, final @Nullable Path obj, final ConfigurationNode node) throws ObjectMappingException {
         if (obj == null) {
-            node.setValue(null);
+            node.set(null);
             return;
         }
 
         if (node.isList()) {
-            node.setValue(null);
+            node.set(null);
             for (Path element : obj) {
-                node.appendListNode().setValue(element.toString());
+                node.appendListNode().set(element.toString());
             }
         } else if (!obj.getFileSystem().equals(FileSystems.getDefault())) { // try to do something for non-default filesystems
-            node.setValue(URI.class, obj.toUri());
+            node.set(URI.class, obj.toUri());
         } else {
-            node.setValue(obj.toString());
+            node.set(obj.toString());
         }
     }
 

--- a/core/src/main/java/org/spongepowered/configurate/serialize/ScalarSerializer.java
+++ b/core/src/main/java/org/spongepowered/configurate/serialize/ScalarSerializer.java
@@ -76,7 +76,7 @@ public abstract class ScalarSerializer<T> implements TypeSerializer<T> {
     public final T deserialize(Type type, final ConfigurationNode node) throws ObjectMappingException {
         ConfigurationNode deserializeFrom = node;
         if (node.isList()) {
-            final List<? extends ConfigurationNode> children = node.getChildrenList();
+            final List<? extends ConfigurationNode> children = node.childrenList();
             if (children.size() == 1) {
                 deserializeFrom = children.get(0);
             }
@@ -86,7 +86,7 @@ public abstract class ScalarSerializer<T> implements TypeSerializer<T> {
             throw new ObjectMappingException("Value must be provided as a scalar!");
         }
 
-        final @Nullable Object value = deserializeFrom.getValue();
+        final @Nullable Object value = deserializeFrom.get();
         if (value == null) {
             throw new ObjectMappingException("No value present");
         }
@@ -134,16 +134,16 @@ public abstract class ScalarSerializer<T> implements TypeSerializer<T> {
     @Override
     public final void serialize(final Type type, final @Nullable T obj, final ConfigurationNode node) {
         if (obj == null) {
-            node.setValue(null);
+            node.set(null);
             return;
         }
 
-        if (node.getOptions().acceptsType(obj.getClass())) {
-            node.setValue(obj);
+        if (node.options().acceptsType(obj.getClass())) {
+            node.set(obj);
             return;
         }
 
-        node.setValue(serialize(obj, node.getOptions()::acceptsType));
+        node.set(serialize(obj, node.options()::acceptsType));
     }
 
     /**

--- a/core/src/main/java/org/spongepowered/configurate/serialize/SetSerializer.java
+++ b/core/src/main/java/org/spongepowered/configurate/serialize/SetSerializer.java
@@ -31,7 +31,7 @@ final class SetSerializer extends AbstractListChildSerializer<Set<?>> {
     static final TypeToken<Set<?>> TYPE = new TypeToken<Set<?>>() {};
 
     @Override
-    Type getElementType(final Type containerType) throws ObjectMappingException {
+    Type elementType(final Type containerType) throws ObjectMappingException {
         if (!(containerType instanceof ParameterizedType)) {
             throw new ObjectMappingException("Raw types are not supported for collections");
         }

--- a/core/src/main/java/org/spongepowered/configurate/transformation/ConfigurationTransformation.java
+++ b/core/src/main/java/org/spongepowered/configurate/transformation/ConfigurationTransformation.java
@@ -128,7 +128,7 @@ public interface ConfigurationTransformation<T extends ConfigurationNode> {
          *
          * @return the move strategy
          */
-        public MoveStrategy getMoveStrategy() {
+        public MoveStrategy moveStrategy() {
             return this.strategy;
         }
 
@@ -138,7 +138,7 @@ public interface ConfigurationTransformation<T extends ConfigurationNode> {
          * @param strategy the strategy
          * @return this builder (for chaining)
          */
-        public Builder<T> setMoveStrategy(final MoveStrategy strategy) {
+        public Builder<T> moveStrategy(final MoveStrategy strategy) {
             this.strategy = requireNonNull(strategy, "strategy");
             return this;
         }
@@ -171,8 +171,8 @@ public interface ConfigurationTransformation<T extends ConfigurationNode> {
          * @param versionKey the path to the version key
          * @return this builder (for chaining)
          */
-        public VersionedBuilder<T> setVersionKey(final Object... versionKey) {
-            this.versionKey = NodePath.create(versionKey);
+        public VersionedBuilder<T> versionKey(final Object... versionKey) {
+            this.versionKey = NodePath.of(versionKey);
             return this;
         }
 
@@ -257,14 +257,14 @@ public interface ConfigurationTransformation<T extends ConfigurationNode> {
          *
          * @return version path
          */
-        NodePath getVersionKey();
+        NodePath versionKey();
 
         /**
          * Get the latest version that nodes can be updated to.
          *
          * @return the most recent version
          */
-        int getLatestVersion();
+        int latestVersion();
 
         /**
          * Get the version of a node hierarchy.
@@ -279,8 +279,8 @@ public interface ConfigurationTransformation<T extends ConfigurationNode> {
          * @param node node to check
          * @return version, or {@link #VERSION_UNKNOWN} if no value is present
          */
-        default int getVersion(final N node) {
-            return node.getNode(getVersionKey()).getInt(VERSION_UNKNOWN);
+        default int version(final N node) {
+            return node.node(versionKey()).getInt(VERSION_UNKNOWN);
         }
     }
 

--- a/core/src/main/java/org/spongepowered/configurate/transformation/MoveStrategy.java
+++ b/core/src/main/java/org/spongepowered/configurate/transformation/MoveStrategy.java
@@ -24,22 +24,22 @@ import org.spongepowered.configurate.ConfigurationNode;
 public enum MoveStrategy {
 
     /**
-     * Moves nodes using {@link ConfigurationNode#mergeValuesFrom(ConfigurationNode)}.
+     * Moves nodes using {@link ConfigurationNode#mergeFrom(ConfigurationNode)}.
      */
     MERGE {
         @Override
         public <T extends ConfigurationNode> void move(final T source, final T target) {
-            target.mergeValuesFrom(source);
+            target.mergeFrom(source);
         }
     },
 
     /**
-     * Moves nodes using {@link ConfigurationNode#setValue(Object)}.
+     * Moves nodes using {@link ConfigurationNode#set(Object)}.
      */
     OVERWRITE {
         @Override
         public <T extends ConfigurationNode> void move(final T source, final T target) {
-            target.setValue(source);
+            target.set(source);
         }
     };
 

--- a/core/src/main/java/org/spongepowered/configurate/transformation/NodePath.java
+++ b/core/src/main/java/org/spongepowered/configurate/transformation/NodePath.java
@@ -44,7 +44,7 @@ public interface NodePath extends Iterable<Object>, Cloneable {
      *
      * @return the copied array
      */
-    Object[] getArray();
+    Object[] array();
 
     /**
      * Create a new path with the provided element appended to the end.
@@ -79,7 +79,7 @@ public interface NodePath extends Iterable<Object>, Cloneable {
      * @param path the path to reference. The provided array will be copied.
      * @return the path instance
      */
-    static NodePath create(Object[] path) {
+    static NodePath of(Object[] path) {
         return new NodePathImpl(path, true);
     }
 
@@ -89,7 +89,7 @@ public interface NodePath extends Iterable<Object>, Cloneable {
      * @param path a collection containing elements of the path to reference
      * @return the path instance
      */
-    static NodePath create(Collection<?> path) {
+    static NodePath of(Collection<?> path) {
         return new NodePathImpl(path.toArray(), false);
     }
 
@@ -103,7 +103,7 @@ public interface NodePath extends Iterable<Object>, Cloneable {
      * @return the path instance
      */
     static NodePath path(Object... elements) {
-        return create(elements);
+        return of(elements);
     }
 
     /**

--- a/core/src/main/java/org/spongepowered/configurate/transformation/NodePathImpl.java
+++ b/core/src/main/java/org/spongepowered/configurate/transformation/NodePathImpl.java
@@ -69,7 +69,7 @@ final class NodePathImpl implements NodePath {
     }
 
     @Override
-    public Object[] getArray() {
+    public Object[] array() {
         return Arrays.copyOf(this.arr, this.arr.length);
     }
 

--- a/core/src/main/java/org/spongepowered/configurate/transformation/SingleConfigurationTransformation.java
+++ b/core/src/main/java/org/spongepowered/configurate/transformation/SingleConfigurationTransformation.java
@@ -51,7 +51,7 @@ final class SingleConfigurationTransformation<N extends ScopedConfigurationNode<
     @Override
     public void apply(final N node) {
         for (Map.Entry<NodePath, TransformAction<? super N>> ent : this.actions.entrySet()) {
-            applySingleAction(node, ent.getKey().getArray(), 0, node, ent.getValue());
+            applySingleAction(node, ent.getKey().array(), 0, node, ent.getValue());
         }
     }
 
@@ -59,14 +59,14 @@ final class SingleConfigurationTransformation<N extends ScopedConfigurationNode<
         for (int i = startIdx; i < path.length; ++i) {
             if (path[i] == WILDCARD_OBJECT) {
                 if (node.isList()) {
-                    final List<N> children = node.getChildrenList();
+                    final List<N> children = node.childrenList();
                     for (int di = 0; di < children.size(); ++di) {
                         path[i] = di;
                         applySingleAction(start, path, i + 1, children.get(di), action);
                     }
                     path[i] = WILDCARD_OBJECT;
                 } else if (node.isMap()) {
-                    for (Map.Entry<Object, N> ent : node.getChildrenMap().entrySet()) {
+                    for (Map.Entry<Object, N> ent : node.childrenMap().entrySet()) {
                         path[i] = ent.getKey();
                         applySingleAction(start, path, i + 1, ent.getValue(), action);
                     }
@@ -77,8 +77,8 @@ final class SingleConfigurationTransformation<N extends ScopedConfigurationNode<
                 }
                 return;
             } else {
-                node = node.getNode(path[i]);
-                if (node.isVirtual()) {
+                node = node.node(path[i]);
+                if (node.virtual()) {
                     return;
                 }
             }
@@ -90,8 +90,8 @@ final class SingleConfigurationTransformation<N extends ScopedConfigurationNode<
 
         final Object @Nullable [] transformedPath = action.visitPath(nodePath, node);
         if (transformedPath != null && !Arrays.equals(path, transformedPath)) {
-            this.strategy.move(node, start.getNode(transformedPath));
-            node.setValue(null);
+            this.strategy.move(node, start.node(transformedPath));
+            node.set(null);
         }
     }
 

--- a/core/src/main/java/org/spongepowered/configurate/transformation/TransformAction.java
+++ b/core/src/main/java/org/spongepowered/configurate/transformation/TransformAction.java
@@ -38,7 +38,7 @@ public interface TransformAction<T extends ScopedConfigurationNode<T>> {
      */
     static <N extends ScopedConfigurationNode<N>> TransformAction<N> remove() {
         return (path, value) -> {
-            value.setValue(null);
+            value.set(null);
             return null;
         };
     }
@@ -54,7 +54,7 @@ public interface TransformAction<T extends ScopedConfigurationNode<T>> {
      */
     static <N extends ScopedConfigurationNode<N>> TransformAction<N> rename(Object newKey) {
         return (path, value) -> {
-            final Object[] arr = path.getArray();
+            final Object[] arr = path.array();
             if (arr.length == 0) {
                 throw new IllegalArgumentException("The root node cannot be renamed!");
             }
@@ -73,8 +73,8 @@ public interface TransformAction<T extends ScopedConfigurationNode<T>> {
      * @param <N> node type
      * @return new transformation action
      */
-    static <V, N extends ScopedConfigurationNode<N>> TransformAction<N> setValue(TypeToken<V> type, @Nullable V value) {
-        return setValue(type, (Supplier<V>) () -> value);
+    static <V, N extends ScopedConfigurationNode<N>> TransformAction<N> set(TypeToken<V> type, @Nullable V value) {
+        return set(type, (Supplier<V>) () -> value);
     }
 
     /**
@@ -87,10 +87,10 @@ public interface TransformAction<T extends ScopedConfigurationNode<T>> {
      * @param <N> node type
      * @return new transformation action
      */
-    static <V, N extends ScopedConfigurationNode<N>> TransformAction<N> setValue(TypeToken<V> type, Supplier<V> valueSupplier) {
+    static <V, N extends ScopedConfigurationNode<N>> TransformAction<N> set(TypeToken<V> type, Supplier<V> valueSupplier) {
         return (path, value) -> {
             try {
-                value.setValue(type, valueSupplier.get());
+                value.set(type, valueSupplier.get());
             } catch (ObjectMappingException e) {
                 // TODO: Error handling
             }
@@ -108,10 +108,10 @@ public interface TransformAction<T extends ScopedConfigurationNode<T>> {
      * @param <N> node type
      * @return new transformation action
      */
-    static <V, N extends ScopedConfigurationNode<N>> TransformAction<N> setValue(Class<V> type, Supplier<V> valueSupplier) {
+    static <V, N extends ScopedConfigurationNode<N>> TransformAction<N> set(Class<V> type, Supplier<V> valueSupplier) {
         return (path, value) -> {
             try {
-                value.setValue(type, valueSupplier.get());
+                value.set(type, valueSupplier.get());
             } catch (ObjectMappingException e) {
                 // TODO: Error handling
             }

--- a/core/src/main/java/org/spongepowered/configurate/transformation/VersionedTransformation.java
+++ b/core/src/main/java/org/spongepowered/configurate/transformation/VersionedTransformation.java
@@ -37,7 +37,7 @@ class VersionedTransformation<T extends ConfigurationNode> implements Configurat
 
     @Override
     public void apply(final T node) {
-        final ConfigurationNode versionNode = node.getNode(this.versionPath);
+        final ConfigurationNode versionNode = node.node(this.versionPath);
         int currentVersion = versionNode.getInt(-1);
         for (Map.Entry<Integer, ConfigurationTransformation<? super T>> entry : this.versionTransformations.entrySet()) {
             if (entry.getKey() <= currentVersion) {
@@ -46,16 +46,16 @@ class VersionedTransformation<T extends ConfigurationNode> implements Configurat
             entry.getValue().apply(node);
             currentVersion = entry.getKey();
         }
-        versionNode.setValue(currentVersion);
+        versionNode.set(currentVersion);
     }
 
     @Override
-    public NodePath getVersionKey() {
+    public NodePath versionKey() {
         return this.versionPath;
     }
 
     @Override
-    public int getLatestVersion() {
+    public int latestVersion() {
         return this.versionTransformations.lastKey();
     }
 

--- a/core/src/main/java/org/spongepowered/configurate/util/CheckedFunction.java
+++ b/core/src/main/java/org/spongepowered/configurate/util/CheckedFunction.java
@@ -49,7 +49,7 @@ public interface CheckedFunction<I, O, E extends Exception> {
      * @param <O> return type
      * @return the function as a checked function
      */
-    static <I, O> CheckedFunction<I, O, RuntimeException> fromFunction(Function<I, @NonNull O> func) {
+    static <I, O> CheckedFunction<I, O, RuntimeException> from(Function<I, @NonNull O> func) {
         return requireNonNull(func, "func")::apply;
     }
 

--- a/core/src/main/java/org/spongepowered/configurate/util/CheckedSupplier.java
+++ b/core/src/main/java/org/spongepowered/configurate/util/CheckedSupplier.java
@@ -43,7 +43,7 @@ public interface CheckedSupplier<V, E extends Throwable> {
      * @param <V> the type returned by the consumer
      * @return a function that executes the provided consumer
      */
-    static <V> CheckedSupplier<V, RuntimeException> fromSupplier(Supplier<V> consumer) {
+    static <V> CheckedSupplier<V, RuntimeException> from(Supplier<V> consumer) {
         return consumer::get;
     }
 

--- a/core/src/test/java/org/spongepowered/configurate/AbstractConfigurationNodeTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/AbstractConfigurationNodeTest.java
@@ -50,67 +50,67 @@ public class AbstractConfigurationNodeTest {
     @Test
     void testUnattachedNodesTemporary() {
         final ConfigurationNode config = BasicConfigurationNode.root();
-        final ConfigurationNode node = config.getNode("some", "node");
-        assertTrue(node.isVirtual());
-        assertNull(node.getValue());
+        final ConfigurationNode node = config.node("some", "node");
+        assertTrue(node.virtual());
+        assertNull(node.get());
         assertFalse(node.isList());
         assertFalse(node.isMap());
-        final ConfigurationNode node2 = config.getNode("some", "node");
+        final ConfigurationNode node2 = config.node("some", "node");
         assertNotSame(node, node2);
 
 
-        final ConfigurationNode node3 = config.getNode("some").getNode("node");
+        final ConfigurationNode node3 = config.node("some").node("node");
         assertNotSame(node, node3);
     }
 
     @Test
     void testNodeCreation() {
         final ConfigurationNode config = BasicConfigurationNode.root();
-        final ConfigurationNode uncreatedNode = config.getNode("uncreated", "node");
-        assertTrue(uncreatedNode.isVirtual()); // Just in case
-        uncreatedNode.setValue("test string for cool people");
-        assertFalse(uncreatedNode.isVirtual());
-        assertEquals("test string for cool people", uncreatedNode.getValue());
+        final ConfigurationNode uncreatedNode = config.node("uncreated", "node");
+        assertTrue(uncreatedNode.virtual()); // Just in case
+        uncreatedNode.set("test string for cool people");
+        assertFalse(uncreatedNode.virtual());
+        assertEquals("test string for cool people", uncreatedNode.get());
 
-        final ConfigurationNode fetchedAfterCreation = config.getNode("uncreated", "node");
+        final ConfigurationNode fetchedAfterCreation = config.node("uncreated", "node");
         assertEquals(uncreatedNode, fetchedAfterCreation);
-        assertEquals(uncreatedNode, config.getNode("uncreated").getNode("node"));
+        assertEquals(uncreatedNode, config.node("uncreated").node("node"));
     }
 
     @Test
     void testTraversingNodeCreation() {
         final ConfigurationNode config = BasicConfigurationNode.root();
-        final ConfigurationNode nodeOne = config.getNode("uncreated", "step", "node").setValue("one");
-        final ConfigurationNode nodeTwo = config.getNode("uncreated", "step", "color").setValue("lilac");
-        final ConfigurationNode attachedParent = config.getNode("uncreated", "step");
-        assertEquals(attachedParent, nodeOne.getParent());
-        assertEquals(attachedParent, nodeTwo.getParent());
+        final ConfigurationNode nodeOne = config.node("uncreated", "step", "node").set("one");
+        final ConfigurationNode nodeTwo = config.node("uncreated", "step", "color").set("lilac");
+        final ConfigurationNode attachedParent = config.node("uncreated", "step");
+        assertEquals(attachedParent, nodeOne.parent());
+        assertEquals(attachedParent, nodeTwo.parent());
     }
 
     @Test
     void testGetDefaultValue() {
         final ConfigurationNode root = BasicConfigurationNode.root();
         final Object testObj = new Object();
-        assertEquals(testObj, root.getNode("nonexistent").getValue(testObj));
+        assertEquals(testObj, root.node("nonexistent").get(testObj));
     }
 
     @Test
     void testGetChildrenMap() {
         final ConfigurationNode root = BasicConfigurationNode.root();
-        final ConfigurationNode a = root.getNode("a").setValue("one");
-        final ConfigurationNode b = root.getNode("b").setValue("two");
+        final ConfigurationNode a = root.node("a").set("one");
+        final ConfigurationNode b = root.node("b").set("two");
         assertEquals(UnmodifiableCollections.<Object, ConfigurationNode>buildMap(map -> {
             map.put("a", a);
             map.put("b", b);
-        }), root.getChildrenMap());
+        }), root.childrenMap());
     }
 
     @Test
     void testGetChildrenList() {
         final ConfigurationNode root = BasicConfigurationNode.root();
-        final ConfigurationNode a = root.appendListNode().setValue("one");
-        final ConfigurationNode b = root.appendListNode().setValue("two");
-        assertEquals(Arrays.asList(a, b), root.getChildrenList());
+        final ConfigurationNode a = root.appendListNode().set("one");
+        final ConfigurationNode b = root.appendListNode().set("two");
+        assertEquals(Arrays.asList(a, b), root.childrenList());
     }
 
     private static final Map<Object, Object> TEST_MAP = new HashMap<>();
@@ -127,102 +127,102 @@ public class AbstractConfigurationNodeTest {
     @Test
     void testMapUnpacking() {
         final ConfigurationNode root = BasicConfigurationNode.root();
-        root.setValue(TEST_MAP);
-        assertEquals("value", root.getNode("key").getValue());
-        assertEquals(true, root.getNode("fabulous").getValue());
+        root.set(TEST_MAP);
+        assertEquals("value", root.node("key").get());
+        assertEquals(true, root.node("fabulous").get());
     }
 
     @Test
     void testMapPacking() {
         final ConfigurationNode root = BasicConfigurationNode.root();
-        root.getNode("key").setValue("value");
-        root.getNode("fabulous").setValue(true);
+        root.node("key").set("value");
+        root.node("fabulous").set(true);
 
-        assertEquals(TEST_MAP, root.getValue());
+        assertEquals(TEST_MAP, root.get());
     }
 
     @Test
     void testListUnpacking() {
         final ConfigurationNode root = BasicConfigurationNode.root();
-        root.setValue(TEST_LIST);
-        assertEquals("test1", root.getNode(0).getValue());
-        assertEquals("test2", root.getNode(1).getValue());
+        root.set(TEST_LIST);
+        assertEquals("test1", root.node(0).get());
+        assertEquals("test2", root.node(1).get());
     }
 
     @Test
     void testListPacking() {
         final ConfigurationNode root = BasicConfigurationNode.root();
-        root.appendListNode().setValue("test1");
-        root.appendListNode().setValue("test2");
-        assertEquals(TEST_LIST, root.getValue());
+        root.appendListNode().set("test1");
+        root.appendListNode().set("test2");
+        assertEquals(TEST_LIST, root.get());
     }
 
     @Test
     void testSingleListConversion() {
         final ConfigurationNode config = BasicConfigurationNode.root();
-        final ConfigurationNode node = config.getNode("test", "value");
-        node.setValue("test");
+        final ConfigurationNode node = config.node("test", "value");
+        node.set("test");
         final ConfigurationNode secondChild = node.appendListNode();
-        secondChild.setValue("test2");
-        assertEquals(Arrays.asList("test", "test2"), node.getValue());
+        secondChild.set("test2");
+        assertEquals(Arrays.asList("test", "test2"), node.get());
     }
 
     @Test
     void testSettingNullRemoves() {
         final ConfigurationNode root = BasicConfigurationNode.root();
-        final ConfigurationNode child = root.getNode("child").setValue("a");
-        assertFalse(child.isVirtual());
-        assertSame(child, root.getNode("child"));
-        child.setValue(null);
-        assertTrue(child.isVirtual());
-        assertNotSame(child, root.getNode("child"));
+        final ConfigurationNode child = root.node("child").set("a");
+        assertFalse(child.virtual());
+        assertSame(child, root.node("child"));
+        child.set(null);
+        assertTrue(child.virtual());
+        assertNotSame(child, root.node("child"));
     }
 
     @Test
     void testGetPath() {
         final ConfigurationNode root = BasicConfigurationNode.root();
-        assertArrayEquals(new Object[]{"a", "b", "c"}, root.getNode("a", "b", "c").getPath().getArray());
+        assertArrayEquals(new Object[]{"a", "b", "c"}, root.node("a", "b", "c").path().array());
     }
 
     @Test
     void testMergeValues() {
         final ConfigurationNode first = BasicConfigurationNode.root();
         final ConfigurationNode second = BasicConfigurationNode.root();
-        first.getNode("scalar").setValue("one");
-        first.getNode("absent").setValue("butmerged");
-        second.getNode("scalar").setValue("two");
+        first.node("scalar").set("one");
+        first.node("absent").set("butmerged");
+        second.node("scalar").set("two");
 
-        final ConfigurationNode firstAbsentMap = first.getNode("absent-map");
-        firstAbsentMap.getNode("a").setValue("one");
-        firstAbsentMap.getNode("b").setValue("two");
+        final ConfigurationNode firstAbsentMap = first.node("absent-map");
+        firstAbsentMap.node("a").set("one");
+        firstAbsentMap.node("b").set("two");
 
-        final ConfigurationNode firstMergedMap = first.getNode("merged-map");
-        final ConfigurationNode secondMergedMap = second.getNode("merged-map");
-        firstMergedMap.getNode("source").setValue("first");
-        secondMergedMap.getNode("source").setValue("second");
-        firstMergedMap.getNode("first-only").setValue("yeah");
-        secondMergedMap.getNode("second-only").setValue("yeah");
+        final ConfigurationNode firstMergedMap = first.node("merged-map");
+        final ConfigurationNode secondMergedMap = second.node("merged-map");
+        firstMergedMap.node("source").set("first");
+        secondMergedMap.node("source").set("second");
+        firstMergedMap.node("first-only").set("yeah");
+        secondMergedMap.node("second-only").set("yeah");
 
-        second.mergeValuesFrom(first);
-        assertEquals("two", second.getNode("scalar").getString());
-        assertEquals("butmerged", second.getNode("absent").getString());
-        assertEquals("one", second.getNode("absent-map", "a").getString());
-        assertEquals("two", second.getNode("absent-map", "b").getString());
-        assertEquals("second", second.getNode("merged-map", "source").getString());
-        assertEquals("yeah", second.getNode("merged-map", "first-only").getString());
-        assertEquals("yeah", second.getNode("merged-map", "second-only").getString());
+        second.mergeFrom(first);
+        assertEquals("two", second.node("scalar").getString());
+        assertEquals("butmerged", second.node("absent").getString());
+        assertEquals("one", second.node("absent-map", "a").getString());
+        assertEquals("two", second.node("absent-map", "b").getString());
+        assertEquals("second", second.node("merged-map", "source").getString());
+        assertEquals("yeah", second.node("merged-map", "first-only").getString());
+        assertEquals("yeah", second.node("merged-map", "second-only").getString());
     }
 
     @Test
     void testSettingMultipleTimesWorks() {
         final ConfigurationNode subject = BasicConfigurationNode.root();
-        subject.setValue(UnmodifiableCollections.buildMap(build -> {
+        subject.set(UnmodifiableCollections.buildMap(build -> {
             build.put("a", "b");
             build.put("b", "c");
             build.put("c", "d");
         }));
         assertTrue(subject.isMap());
-        subject.setValue(UnmodifiableCollections.buildMap(build -> {
+        subject.set(UnmodifiableCollections.buildMap(build -> {
             build.put("na", "na");
             build.put("eh", "eh");
             build.put("bleugh", "bleugh");
@@ -233,33 +233,33 @@ public class AbstractConfigurationNodeTest {
     @Test
     void testGetSetValueSerialized() throws ObjectMappingException {
         final ConfigurationNode subject = BasicConfigurationNode.root(ConfigurationOptions.defaults()
-                .withNativeTypes(UnmodifiableCollections.toSet(String.class, Integer.class)));
-        subject.setValue("48");
-        assertEquals(Integer.valueOf(48), subject.getValue(Integer.class));
+                .nativeTypes(UnmodifiableCollections.toSet(String.class, Integer.class)));
+        subject.set("48");
+        assertEquals(Integer.valueOf(48), subject.get(Integer.class));
         final UUID testId = UUID.randomUUID();
-        subject.setValue(UUID.class, testId);
-        assertEquals(testId.toString(), subject.getValue());
+        subject.set(UUID.class, testId);
+        assertEquals(testId.toString(), subject.get());
     }
 
     @Test
     void testDefaultsCopied() {
-        final ConfigurationNode subject = BasicConfigurationNode.root(ConfigurationOptions.defaults().withShouldCopyDefaults(true));
-        assertNull(subject.getValue());
-        assertEquals("default value", subject.getValue("default value"));
-        assertEquals("default value", subject.getValue());
+        final ConfigurationNode subject = BasicConfigurationNode.root(ConfigurationOptions.defaults().shouldCopyDefaults(true));
+        assertNull(subject.get());
+        assertEquals("default value", subject.get("default value"));
+        assertEquals("default value", subject.get());
     }
 
     @Test
     @SuppressWarnings("rawtypes")
     void testRawTypeFails() {
         final ConfigurationNode subject = BasicConfigurationNode.root(b -> {
-            b.getNode("test1").setValue(2);
-            b.getNode("test2").setValue(3);
+            b.node("test1").set(2);
+            b.node("test2").set(3);
         });
-        assertThrows(IllegalArgumentException.class, () -> subject.getValue(Map.class));
-        assertThrows(IllegalArgumentException.class, () -> subject.getValue((Type) Map.class));
+        assertThrows(IllegalArgumentException.class, () -> subject.get(Map.class));
+        assertThrows(IllegalArgumentException.class, () -> subject.get((Type) Map.class));
         // expected raw type
-        assertThrows(IllegalArgumentException.class, () -> subject.getValue(new TypeToken<Map>() {}));
+        assertThrows(IllegalArgumentException.class, () -> subject.get(new TypeToken<Map>() {}));
 
     }
 
@@ -267,25 +267,25 @@ public class AbstractConfigurationNodeTest {
     void testHasChildArray() {
         final ConfigurationNode node = BasicConfigurationNode.root();
         assertFalse(node.hasChild("ball"));
-        assertTrue(node.getNode("ball").isVirtual());
+        assertTrue(node.node("ball").virtual());
 
         // still shouldn't change
         assertFalse(node.hasChild("ball"));
 
-        node.getNode("ball").setValue("yarn");
+        node.node("ball").set("yarn");
         assertTrue(node.hasChild("ball"));
 
         // but still doesn't have child
         assertFalse(node.hasChild("ball", "another"));
 
-        node.getNode("ball", "another").setValue(48);
+        node.node("ball", "another").set(48);
         assertTrue(node.hasChild("ball", "another"));
     }
 
     @Test
     void testNullElementsForbiddenHasChild() {
         assertThrows(NullPointerException.class, () -> {
-            BasicConfigurationNode.root(n -> n.getNode("test").setValue("blah"))
+            BasicConfigurationNode.root(n -> n.node("test").set("blah"))
                 .hasChild("test", null);
         });
     }
@@ -294,26 +294,26 @@ public class AbstractConfigurationNodeTest {
     void testHasChildIterable() {
         final ConfigurationNode node = BasicConfigurationNode.root();
         assertFalse(node.hasChild(NodePath.path("ball")));
-        assertTrue(node.getNode("ball").isVirtual());
+        assertTrue(node.node("ball").virtual());
 
         // still shouldn't change
         assertFalse(node.hasChild(NodePath.path("ball")));
 
-        node.getNode("ball").setValue("yarn");
+        node.node("ball").set("yarn");
         assertTrue(node.hasChild(NodePath.path("ball")));
 
         // but still doesn't have child
         assertFalse(node.hasChild(NodePath.path("ball", "another")));
 
-        node.getNode("ball", "another").setValue(48);
+        node.node("ball", "another").set(48);
         assertTrue(node.hasChild(NodePath.path("ball", "another")));
     }
 
     @Test
     void testNullOutListValue() {
         BasicConfigurationNode.root(n -> {
-            n.appendListNode().setValue("blah");
-            n.appendListNode().setValue(null);
+            n.appendListNode().set("blah");
+            n.appendListNode().set(null);
         });
     }
 
@@ -330,78 +330,78 @@ public class AbstractConfigurationNodeTest {
 
     public static final RepresentationHint<String> NAME =
             RepresentationHint.<String>builder()
-                    .setIdentifier("name")
-                    .setValueType(String.class)
-                    .setInheritable(false)
+                    .identifier("name")
+                    .valueType(String.class)
+                    .inheritable(false)
                     .build();
 
     @Test
     void testHintsReadWrite() {
         final ConfigurationNode node = BasicConfigurationNode.root();
-        node.setValue("I hold hints!");
-        assertNull(node.getHint(IS_EVIL));
-        node.setHint(IS_EVIL, true);
-        assertEquals(true, node.getHint(IS_EVIL));
+        node.set("I hold hints!");
+        assertNull(node.hint(IS_EVIL));
+        node.hint(IS_EVIL, true);
+        assertEquals(true, node.hint(IS_EVIL));
 
     }
 
     @Test
     void testHintSetToNull() {
         final ConfigurationNode node = BasicConfigurationNode.root();
-        node.setHint(IS_EVIL, null);
-        assertNull(node.getHint(IS_EVIL));
+        node.hint(IS_EVIL, null);
+        assertNull(node.hint(IS_EVIL));
     }
 
     @Test
     void testGetHintInherited() {
         final ConfigurationNode root = BasicConfigurationNode.root();
-        root.setHint(IS_EVIL, false);
+        root.hint(IS_EVIL, false);
 
-        final ConfigurationNode child = root.getNode("blah");
-        assertEquals(false, child.getHint(IS_EVIL));
+        final ConfigurationNode child = root.node("blah");
+        assertEquals(false, child.hint(IS_EVIL));
 
-        child.setHint(IS_EVIL, true);
-        assertEquals(true, child.getHint(IS_EVIL));
+        child.hint(IS_EVIL, true);
+        assertEquals(true, child.hint(IS_EVIL));
 
         // check that parent was not changed
-        assertEquals(false, root.getHint(IS_EVIL));
+        assertEquals(false, root.hint(IS_EVIL));
     }
 
     @Test
     void testNonInheritableHints() {
         final ConfigurationNode root = BasicConfigurationNode.root();
-        root.setHint(NAME, "secondary");
+        root.hint(NAME, "secondary");
 
-        final ConfigurationNode child = root.getNode("other");
-        assertNull(child.getHint(NAME));
+        final ConfigurationNode child = root.node("other");
+        assertNull(child.hint(NAME));
     }
 
     @Test
     void testHintsCopied() {
         final ConfigurationNode original = BasicConfigurationNode.root();
-        original.setValue("1234").setHint(IS_EVIL, true);
+        original.set("1234").hint(IS_EVIL, true);
 
         final ConfigurationNode copy = original.copy();
-        assertEquals(true, copy.getHint(IS_EVIL));
+        assertEquals(true, copy.hint(IS_EVIL));
 
         final ConfigurationNode copiedSet = BasicConfigurationNode.root();
-        copiedSet.setValue(original);
-        assertEquals(true, copiedSet.getHint(IS_EVIL));
+        copiedSet.set(original);
+        assertEquals(true, copiedSet.hint(IS_EVIL));
     }
 
     @Test
     void testHintsMerged() {
         final ConfigurationNode hintHolder = BasicConfigurationNode.root()
-                .setValue('o')
-                .setHint(IS_EVIL, true);
+                .set('o')
+                .hint(IS_EVIL, true);
         final ConfigurationNode mergeTarget = BasicConfigurationNode.root()
-                .setValue('o')
-                .setHint(INDENT, 34);
+                .set('o')
+                .hint(INDENT, 34);
 
-        mergeTarget.mergeValuesFrom(hintHolder);
+        mergeTarget.mergeFrom(hintHolder);
 
-        assertEquals(34, mergeTarget.getHint(INDENT));
-        assertEquals(true, mergeTarget.getHint(IS_EVIL));
+        assertEquals(34, mergeTarget.hint(INDENT));
+        assertEquals(true, mergeTarget.hint(IS_EVIL));
     }
 
     @Test
@@ -412,9 +412,9 @@ public class AbstractConfigurationNodeTest {
                 .filter(ent -> ent.getKey().contains("e"))
                 .collect(BasicConfigurationNode.factory().toMapCollector(Integer.class));
 
-        assertTrue(target.getNode("two").isVirtual());
-        assertEquals(3, target.getNode("one").getValue());
-        assertEquals(14, target.getNode("test").getValue());
+        assertTrue(target.node("two").virtual());
+        assertEquals(3, target.node("one").get());
+        assertEquals(14, target.node("test").get());
     }
 
     @Test
@@ -443,12 +443,12 @@ public class AbstractConfigurationNodeTest {
 
     @Test
     void testImplicitInitialization() throws ObjectMappingException {
-        final BasicConfigurationNode node = BasicConfigurationNode.root(ConfigurationOptions.defaults().withImplicitInitialization(true));
+        final BasicConfigurationNode node = BasicConfigurationNode.root(ConfigurationOptions.defaults().implicitInitialization(true));
 
-        assertNull(node.getValue());
-        assertEquals(Collections.emptyList(), node.getValue(new TypeToken<List<String>>() {}));
-        assertEquals(Collections.emptyMap(), node.getValue(new TypeToken<Map<String, Integer>>() {}));
-        assertEquals(new Empty(), node.getValue(Empty.class));
+        assertNull(node.get());
+        assertEquals(Collections.emptyList(), node.get(new TypeToken<List<String>>() {}));
+        assertEquals(Collections.emptyMap(), node.get(new TypeToken<Map<String, Integer>>() {}));
+        assertEquals(new Empty(), node.get(Empty.class));
     }
 
 }

--- a/core/src/test/java/org/spongepowered/configurate/AttributedConfigurationNodeTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/AttributedConfigurationNodeTest.java
@@ -38,10 +38,10 @@ public class AttributedConfigurationNodeTest {
     void testSettingAttributeAttaches() {
         final AttributedConfigurationNode node = AttributedConfigurationNode.root();
 
-        final AttributedConfigurationNode child = node.getNode("yoink");
-        assertTrue(child.isVirtual());
+        final AttributedConfigurationNode child = node.node("yoink");
+        assertTrue(child.virtual());
         child.addAttribute("cheese", "cake");
-        assertFalse(child.isVirtual());
+        assertFalse(child.virtual());
     }
 
 }

--- a/core/src/test/java/org/spongepowered/configurate/ConfigurationVisitorTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/ConfigurationVisitorTest.java
@@ -30,21 +30,21 @@ public class ConfigurationVisitorTest {
     void testTree() {
         final BasicConfigurationNode base = BasicConfigurationNode.root();
 
-        base.getNode("cats").act(c -> {
-            c.getNode("large").setValue("great");
-            c.getNode("medium").setValue("wonderful");
-            c.getNode("small").setValue("stupendous");
+        base.node("cats").act(c -> {
+            c.node("large").set("great");
+            c.node("medium").set("wonderful");
+            c.node("small").set("stupendous");
         });
 
-        base.getNode("fish").act(c -> {
-            c.appendListNode().setValue("one");
+        base.node("fish").act(c -> {
+            c.appendListNode().set("one");
             c.appendListNode().act(f -> {
-                f.getNode("number").setValue("two");
-                f.getNode("type").setValue("blue");
+                f.node("number").set("two");
+                f.node("type").set("blue");
             });
         });
 
-        base.getNode("dog").setValue("woof");
+        base.node("dog").set("woof");
 
         final String result = base.visit(VISITOR);
         assertEquals("b(m(-cats-m(-large-s)(-medium-s)(-small-s))(-fish-l(-0-s)(-1-m(-number-s)(-type-s)))(-dog-s))t", result);
@@ -60,7 +60,7 @@ public class ConfigurationVisitorTest {
     @Test
     void testSingleScalar() {
         final BasicConfigurationNode base = BasicConfigurationNode.root();
-        base.setValue("test");
+        base.set("test");
         final String result = base.visit(VISITOR);
         assertEquals("b(s)t", result);
     }
@@ -71,10 +71,10 @@ public class ConfigurationVisitorTest {
             @Override
             public void enterListNode(final BasicConfigurationNode node, final StringBuilder state) {
                 super.enterListNode(node, state);
-                node.setValue(null);
+                node.set(null);
             }
         };
-        final BasicConfigurationNode base = BasicConfigurationNode.root().setValue(Collections.emptyList());
+        final BasicConfigurationNode base = BasicConfigurationNode.root().set(Collections.emptyList());
         final String result = base.visit(visitor);
 
         assertEquals("b(l)t", result);
@@ -112,8 +112,8 @@ public class ConfigurationVisitorTest {
         @Override
         public void enterNode(final N node, final StringBuilder state) {
             state.append(NODE_ENTER);
-            if (node.getKey() != null) {
-                state.append("-").append(node.getKey()).append("-");
+            if (node.key() != null) {
+                state.append("-").append(node.key()).append("-");
             }
         }
 

--- a/core/src/test/java/org/spongepowered/configurate/CopyTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/CopyTest.java
@@ -31,61 +31,61 @@ public class CopyTest {
     @Test
     void testSimpleCopy() {
         final ConfigurationNode node = BasicConfigurationNode.root();
-        node.getNode("test").setValue(5);
-        node.getNode("section", "val1").setValue(true);
-        node.getNode("section", "val2").setValue("TEST");
-        final ConfigurationNode list = node.getNode("section2", "alist");
-        list.appendListNode().setValue("value1");
-        list.appendListNode().setValue("value2");
+        node.node("test").set(5);
+        node.node("section", "val1").set(true);
+        node.node("section", "val2").set("TEST");
+        final ConfigurationNode list = node.node("section2", "alist");
+        list.appendListNode().set("value1");
+        list.appendListNode().set("value2");
 
         final ConfigurationNode copy = node.copy();
 
         assertNotSame(node, copy);
         assertEquals(node, copy);
 
-        assertFalse(node.isVirtual());
-        assertFalse(copy.isVirtual());
+        assertFalse(node.virtual());
+        assertFalse(copy.virtual());
 
-        assertEquals(5, copy.getNode("test").getValue());
-        assertEquals(true, copy.getNode("section", "val1").getValue());
-        assertEquals("TEST", copy.getNode("section", "val2").getValue());
-        assertEquals(Arrays.asList("value1", "value2"), copy.getNode("section2", "alist").getValue());
+        assertEquals(5, copy.node("test").get());
+        assertEquals(true, copy.node("section", "val1").get());
+        assertEquals("TEST", copy.node("section", "val2").get());
+        assertEquals(Arrays.asList("value1", "value2"), copy.node("section2", "alist").get());
 
         // change value on original
-        node.getNode("section", "val2").setValue("NOT TEST");
+        node.node("section", "val2").set("NOT TEST");
 
         // test it's still the same on copy
-        assertEquals("TEST", copy.getNode("section", "val2").getValue());
+        assertEquals("TEST", copy.node("section", "val2").get());
 
         // change value on copy
-        copy.getNode("section", "val2").setValue("zzz");
+        copy.node("section", "val2").set("zzz");
 
         // test it's still the same on original
-        assertEquals("NOT TEST", node.getNode("section", "val2").getValue());
+        assertEquals("NOT TEST", node.node("section", "val2").get());
     }
 
     @Test
     void testCopyPaths() {
         final ConfigurationNode node = BasicConfigurationNode.root();
-        node.getNode("test").setValue(5);
-        node.getNode("section", "val1").setValue(true);
-        node.getNode("section", "val2").setValue("TEST");
+        node.node("test").set(5);
+        node.node("section", "val1").set(true);
+        node.node("section", "val2").set("TEST");
 
-        final ConfigurationNode original = node.getNode("section");
+        final ConfigurationNode original = node.node("section");
         final ConfigurationNode copy = original.copy();
 
-        assertNotNull(original.getParent());
-        assertNull(copy.getParent());
+        assertNotNull(original.parent());
+        assertNull(copy.parent());
 
-        final ConfigurationNode originalVal = original.getNode("val1");
-        final ConfigurationNode copyVal = copy.getNode("val1");
+        final ConfigurationNode originalVal = original.node("val1");
+        final ConfigurationNode copyVal = copy.node("val1");
 
-        assertEquals(2, originalVal.getPath().size());
-        assertEquals(1, copyVal.getPath().size());
+        assertEquals(2, originalVal.path().size());
+        assertEquals(1, copyVal.path().size());
 
-        assertNotNull(originalVal.getParent());
-        assertNotNull(copyVal.getParent());
-        assertNotSame(originalVal.getParent(), copyVal.getParent());
+        assertNotNull(originalVal.parent());
+        assertNotNull(copyVal.parent());
+        assertNotSame(originalVal.parent(), copyVal.parent());
     }
 
 }

--- a/core/src/test/java/org/spongepowered/configurate/SimpleCommentedConfigurationNodeTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/SimpleCommentedConfigurationNodeTest.java
@@ -26,38 +26,38 @@ public class SimpleCommentedConfigurationNodeTest {
     @Test
     void testCommentsTransferred() {
         final CommentedConfigurationNode subject = CommentedConfigurationNode.root();
-        final CommentedConfigurationNode firstChild = subject.getNode("first");
-        firstChild.setValue("test value");
-        firstChild.setComment("Such comment. Very wow.");
+        final CommentedConfigurationNode firstChild = subject.node("first");
+        firstChild.set("test value");
+        firstChild.comment("Such comment. Very wow.");
 
 
-        final CommentedConfigurationNode secondChild = subject.getNode("second");
-        secondChild.setValue("test value's evil twin");
+        final CommentedConfigurationNode secondChild = subject.node("second");
+        secondChild.set("test value's evil twin");
 
-        assertFalse(secondChild.isVirtual());
+        assertFalse(secondChild.virtual());
 
-        secondChild.setValue(firstChild);
-        assertEquals("test value", secondChild.getValue());
-        assertEquals("Such comment. Very wow.", secondChild.getComment());
+        secondChild.set(firstChild);
+        assertEquals("test value", secondChild.get());
+        assertEquals("Such comment. Very wow.", secondChild.comment());
     }
 
     @Test
     void testNestedCommentsTransferred() {
         final CommentedConfigurationNode subject = CommentedConfigurationNode.root();
-        final CommentedConfigurationNode firstChild = subject.getNode("first");
-        final CommentedConfigurationNode firstChildChild = firstChild.getNode("child");
-        firstChildChild.setValue("test value");
-        firstChildChild.setComment("Such comment. Very wow.");
+        final CommentedConfigurationNode firstChild = subject.node("first");
+        final CommentedConfigurationNode firstChildChild = firstChild.node("child");
+        firstChildChild.set("test value");
+        firstChildChild.comment("Such comment. Very wow.");
 
 
-        final CommentedConfigurationNode secondChild = subject.getNode("second");
-        secondChild.setValue("test value's evil twin");
+        final CommentedConfigurationNode secondChild = subject.node("second");
+        secondChild.set("test value's evil twin");
 
-        assertFalse(secondChild.isVirtual());
+        assertFalse(secondChild.virtual());
 
-        secondChild.setValue(firstChild);
-        assertEquals("test value", secondChild.getNode("child").getValue());
-        assertEquals("Such comment. Very wow.", secondChild.getNode("child").getComment());
+        secondChild.set(firstChild);
+        assertEquals("test value", secondChild.node("child").get());
+        assertEquals("Such comment. Very wow.", secondChild.node("child").comment());
     }
 
     @Test
@@ -65,19 +65,19 @@ public class SimpleCommentedConfigurationNodeTest {
         final CommentedConfigurationNode source = CommentedConfigurationNode.root();
         final CommentedConfigurationNode target = CommentedConfigurationNode.root();
 
-        source.getNode("no-value").setValue("a").setComment("yeah");
-        source.getNode("existing-value-no-comment").setValue("orig").setComment("maybe");
-        source.getNode("existing-value").setValue("a").setComment("yeah");
-        source.getNode("no-parent", "child").setValue("x").setComment("always");
-        target.getNode("existing-value-no-comment").setValue("new");
-        target.getNode("existing-value").setValue("b").setComment("nope");
+        source.node("no-value").set("a").comment("yeah");
+        source.node("existing-value-no-comment").set("orig").comment("maybe");
+        source.node("existing-value").set("a").comment("yeah");
+        source.node("no-parent", "child").set("x").comment("always");
+        target.node("existing-value-no-comment").set("new");
+        target.node("existing-value").set("b").comment("nope");
 
-        target.mergeValuesFrom(source);
-        assertEquals("yeah", target.getNode("no-value").getComment());
-        assertEquals("maybe", target.getNode("existing-value-no-comment").getComment());
-        assertEquals("new", target.getNode("existing-value-no-comment").getString());
-        assertEquals("nope", target.getNode("existing-value").getComment());
-        assertEquals("always", target.getNode("no-parent", "child").getComment());
+        target.mergeFrom(source);
+        assertEquals("yeah", target.node("no-value").comment());
+        assertEquals("maybe", target.node("existing-value-no-comment").comment());
+        assertEquals("new", target.node("existing-value-no-comment").getString());
+        assertEquals("nope", target.node("existing-value").comment());
+        assertEquals("always", target.node("no-parent", "child").comment());
     }
 
 }

--- a/core/src/test/java/org/spongepowered/configurate/loader/AbstractConfigurationLoaderTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/loader/AbstractConfigurationLoaderTest.java
@@ -37,14 +37,14 @@ public class AbstractConfigurationLoaderTest {
     @Test
     void testLoadNonexistantPath(final @TempDir Path tempDir) throws IOException {
         final Path tempPath = tempDir.resolve("text5.txt").getRoot().resolve("does-not-exist-dont-edit-testdir");
-        final TestConfigurationLoader loader = TestConfigurationLoader.builder().setPath(tempPath).build();
+        final TestConfigurationLoader loader = TestConfigurationLoader.builder().path(tempPath).build();
         loader.load();
     }
 
     @Test
     void testLoadNonexistantFile(final @TempDir Path tempDir) throws IOException {
         final File tempFile = new File(tempDir.resolve("text5.txt").getRoot().toFile(), "does-not-exist-dont-edit-testdir");
-        final TestConfigurationLoader loader = TestConfigurationLoader.builder().setFile(tempFile).build();
+        final TestConfigurationLoader loader = TestConfigurationLoader.builder().file(tempFile).build();
         loader.load();
     }
 
@@ -60,7 +60,7 @@ public class AbstractConfigurationLoaderTest {
         Files.createSymbolicLink(layerOne, actualFile);
         Files.createSymbolicLink(layerTwo, layerOne);
 
-        try (BufferedWriter writer = AtomicFiles.createAtomicBufferedWriter(layerTwo, StandardCharsets.UTF_8)) {
+        try (BufferedWriter writer = AtomicFiles.atomicBufferedWriter(layerTwo, StandardCharsets.UTF_8)) {
             writer.write("I should follow symlinks!\n");
         }
 

--- a/core/src/test/java/org/spongepowered/configurate/loader/TestConfigurationLoader.java
+++ b/core/src/test/java/org/spongepowered/configurate/loader/TestConfigurationLoader.java
@@ -53,19 +53,19 @@ public class TestConfigurationLoader extends AbstractConfigurationLoader<BasicCo
 
     @Override
     protected void loadInternal(final BasicConfigurationNode node, final BufferedReader reader) throws IOException {
-        node.setValue(this.result);
+        node.set(this.result);
     }
 
     @Override
     protected void saveInternal(final ConfigurationNode node, final Writer writer) throws IOException {
-        this.result.setValue(node);
+        this.result.set(node);
     }
 
-    public ConfigurationNode getNode() {
+    public ConfigurationNode node() {
         return this.result;
     }
 
-    public void setNode(final ConfigurationNode node) {
+    public void node(final ConfigurationNode node) {
         this.result = node;
     }
 

--- a/core/src/test/java/org/spongepowered/configurate/objectmapping/ConstraintTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/objectmapping/ConstraintTest.java
@@ -52,7 +52,7 @@ public class ConstraintTest {
             () -> {
                 assertThrows(ObjectMappingException.class, () -> {
                     mapper.load(BasicConfigurationNode.root(n -> {
-                        n.getNode("optional").setValue(UUID.randomUUID().toString());
+                        n.node("optional").set(UUID.randomUUID().toString());
                     }));
                 });
             },
@@ -60,7 +60,7 @@ public class ConstraintTest {
             () -> {
                 final UUID expected = UUID.randomUUID();
                 final TestRequired result = mapper.load(BasicConfigurationNode.root(n -> {
-                    n.getNode("mandatory").setValue(expected);
+                    n.node("mandatory").set(expected);
                 }));
                 assertEquals(expected, result.mandatory);
                 assertNull(result.optional);
@@ -70,8 +70,8 @@ public class ConstraintTest {
                 final UUID optionalVal = UUID.randomUUID();
                 final UUID requiredVal = UUID.randomUUID();
                 final TestRequired result = mapper.load(BasicConfigurationNode.root(n -> {
-                    n.getNode("optional").setValue(optionalVal.toString());
-                    n.getNode("mandatory").setValue(requiredVal.toString());
+                    n.node("optional").set(optionalVal.toString());
+                    n.node("mandatory").set(requiredVal.toString());
                 }));
                 assertEquals(optionalVal, result.optional);
                 assertEquals(requiredVal, result.mandatory);
@@ -95,14 +95,14 @@ public class ConstraintTest {
                 // Valid value loads without error
                 () -> {
                     final TestPattern result = mapper.load(BasicConfigurationNode.root(n -> {
-                        n.getNode("test").setValue("lowercase");
+                        n.node("test").set("lowercase");
                     }));
                     assertEquals("lowercase", result.test);
                 },
                 // Invalid value throws ObjectMappingException
                 () -> assertThrows(ObjectMappingException.class, () -> {
                     mapper.load(BasicConfigurationNode.root(n -> {
-                        n.getNode("test").setValue("LOUD");
+                        n.node("test").set("LOUD");
                     }));
                 })
         );
@@ -131,8 +131,8 @@ public class ConstraintTest {
                 // Matches both
                 () -> {
                     final BasicConfigurationNode node = BasicConfigurationNode.root(n -> {
-                        n.getNode("pattern").setValue("Test");
-                        n.getNode("number-like").setValue("0.0.42+4");
+                        n.node("pattern").set("Test");
+                        n.node("number-like").set("0.0.42+4");
                     });
                     final TestLocalizedPattern result = mapper.load(node);
 
@@ -142,8 +142,8 @@ public class ConstraintTest {
                 // Fails one with localized key
                 () -> {
                     final BasicConfigurationNode node = BasicConfigurationNode.root(n -> {
-                        n.getNode("pattern").setValue("bad");
-                        n.getNode("number-like").setValue("0.0.42+4");
+                        n.node("pattern").set("bad");
+                        n.node("number-like").set("0.0.42+4");
                     });
 
                     assertEquals("failed for input string \"bad\" against pattern \"Test\"!", assertThrows(ObjectMappingException.class, () -> {
@@ -153,8 +153,8 @@ public class ConstraintTest {
                 // Fails second with non-localized passthrough
                 () -> {
                     final BasicConfigurationNode node = BasicConfigurationNode.root(n -> {
-                        n.getNode("pattern").setValue("Test");
-                        n.getNode("number-like").setValue("invalid");
+                        n.node("pattern").set("Test");
+                        n.node("number-like").set("invalid");
                     });
 
                     assertEquals("Value invalid is non-numeric", assertThrows(ObjectMappingException.class, () -> {

--- a/core/src/test/java/org/spongepowered/configurate/objectmapping/DefaultsTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/objectmapping/DefaultsTest.java
@@ -35,7 +35,7 @@ import java.util.List;
 public class DefaultsTest {
 
     public static final ConfigurationOptions IMPLICIT_OPTS = ConfigurationOptions.defaults()
-            .withImplicitInitialization(true);
+            .implicitInitialization(true);
 
     @ConfigSerializable
     static class ImplicitDefaultsOnly {
@@ -60,16 +60,16 @@ public class DefaultsTest {
 
     @Test
     void testImplicitDefaultsSaved() throws ObjectMappingException {
-        final BasicConfigurationNode node = BasicConfigurationNode.root(IMPLICIT_OPTS.withShouldCopyDefaults(true));
-        node.getValue(ImplicitDefaultsOnly.class);
+        final BasicConfigurationNode node = BasicConfigurationNode.root(IMPLICIT_OPTS.shouldCopyDefaults(true));
+        node.get(ImplicitDefaultsOnly.class);
 
-        assertPresentAndEmpty(node.getNode("my-strings"));
-        assertPresentAndEmpty(node.getNode("fun-times"));
-        assertPresentAndEmpty(node.getNode("items"));
+        assertPresentAndEmpty(node.node("my-strings"));
+        assertPresentAndEmpty(node.node("fun-times"));
+        assertPresentAndEmpty(node.node("items"));
     }
 
     private void assertPresentAndEmpty(final ConfigurationNode node) {
-        assertFalse(node.isVirtual());
+        assertFalse(node.virtual());
         assertTrue(node.isEmpty());
     }
 

--- a/core/src/test/java/org/spongepowered/configurate/objectmapping/NodeResolverTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/objectmapping/NodeResolverTest.java
@@ -37,8 +37,8 @@ public class NodeResolverTest {
     @Test
     void testNodeKey() throws ObjectMappingException {
         final ObjectMapper<TestNodeKey> mapper = ObjectMapper.factory().get(TestNodeKey.class);
-        final BasicConfigurationNode source = BasicConfigurationNode.root().getNode("test");
-        source.getNode("own").setValue("yeet");
+        final BasicConfigurationNode source = BasicConfigurationNode.root().node("test");
+        source.node("own").set("yeet");
 
         final TestNodeKey object = mapper.load(source);
 
@@ -57,7 +57,7 @@ public class NodeResolverTest {
         final ObjectMapper<TestSettingKey> mapper = ObjectMapper.factory().get(TestSettingKey.class);
 
         final BasicConfigurationNode source = BasicConfigurationNode.root(n -> {
-            n.getNode("something").setValue("blah");
+            n.node("something").set("blah");
         });
 
         final TestSettingKey object = mapper.load(source);
@@ -79,8 +79,8 @@ public class NodeResolverTest {
                 .build().get(TestOnlyWithAnnotation.class);
 
         final BasicConfigurationNode source = BasicConfigurationNode.root(n -> {
-            n.getNode("marked").setValue("something");
-            n.getNode("not-processed").setValue("ignored");
+            n.node("marked").set("something");
+            n.node("not-processed").set("ignored");
         });
 
         final TestOnlyWithAnnotation object = mapper.load(source);

--- a/core/src/test/java/org/spongepowered/configurate/objectmapping/ObjectMapperTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/objectmapping/ObjectMapperTest.java
@@ -49,7 +49,7 @@ public class ObjectMapperTest {
     void testCreateFromNode() throws ObjectMappingException {
         final ObjectMapper<TestObject> mapper = ObjectMapper.factory().get(TestObject.class);
         final BasicConfigurationNode source = BasicConfigurationNode.root();
-        source.getNode("test-key").setValue("some are born great, some achieve greatness, and some have greatness thrust upon them");
+        source.node("test-key").set("some are born great, some achieve greatness, and some have greatness thrust upon them");
 
         final TestObject obj = mapper.load(source);
         assertEquals("some are born great, some achieve greatness, and some have greatness thrust upon them", obj.stringVal);
@@ -68,7 +68,7 @@ public class ObjectMapperTest {
         final BasicConfigurationNode source = BasicConfigurationNode.root();
         final TestObject instance = new TestObject();
 
-        source.getNode("test-key").setValue("boom");
+        source.node("test-key").set("boom");
         assertTrue(mapper instanceof ObjectMapper.Mutable<?>);
 
         ((ObjectMapper.Mutable<TestObject>) mapper).load(instance, source);
@@ -84,19 +84,19 @@ public class ObjectMapperTest {
 
         instance.stringVal = "hi";
         ((ObjectMapper.Mutable<TestObject>) mapper).load(instance, source);
-        assertTrue(source.getNode("test-key").isVirtual());
+        assertTrue(source.node("test-key").virtual());
     }
 
     @Test
     void testDefaultsApplied() throws ObjectMappingException {
         final ObjectMapper<TestObject> mapper = ObjectMapper.factory().get(TestObject.class);
-        final BasicConfigurationNode source = BasicConfigurationNode.root(ConfigurationOptions.defaults().withShouldCopyDefaults(true));
+        final BasicConfigurationNode source = BasicConfigurationNode.root(ConfigurationOptions.defaults().shouldCopyDefaults(true));
         final TestObject instance = new TestObject();
         assertTrue(mapper instanceof ObjectMapper.Mutable<?>);
 
         instance.stringVal = "hi";
         ((ObjectMapper.Mutable<TestObject>) mapper).load(instance, source);
-        assertEquals("hi", source.getNode("test-key").getString());
+        assertEquals("hi", source.node("test-key").getString());
     }
 
     @ConfigSerializable
@@ -115,9 +115,9 @@ public class ObjectMapperTest {
         obj.color = "fuchsia";
         obj.politician = "All of them";
         mapper.save(obj, node);
-        assertEquals("You look nice today", node.getNode("commented-key").getComment());
-        assertEquals("fuchsia", node.getNode("commented-key").getString());
-        assertNull(node.getNode("no-comment").getComment());
+        assertEquals("You look nice today", node.node("commented-key").comment());
+        assertEquals("fuchsia", node.node("commented-key").getString());
+        assertNull(node.node("no-comment").comment());
     }
 
     @ConfigSerializable
@@ -148,8 +148,8 @@ public class ObjectMapperTest {
     void testSuperclassFieldsIncluded() throws ObjectMappingException {
         final ObjectMapper<TestObjectChild> mapper = ObjectMapper.factory().get(TestObjectChild.class);
         final BasicConfigurationNode node = BasicConfigurationNode.root();
-        node.getNode("child-setting").setValue(true);
-        node.getNode("test-key").setValue("Parents get populated too!");
+        node.node("child-setting").set(true);
+        node.node("test-key").set("Parents get populated too!");
 
         final TestObjectChild instance = mapper.load(node);
         assertTrue(instance.childSetting);
@@ -165,7 +165,7 @@ public class ObjectMapperTest {
     void testKeyFromFieldName() throws ObjectMappingException {
         final ObjectMapper<FieldNameObject> mapper = ObjectMapper.factory().get(FieldNameObject.class);
         final BasicConfigurationNode node = BasicConfigurationNode.root();
-        node.getNode("loads").setValue(true);
+        node.node("loads").set(true);
 
         final FieldNameObject obj = mapper.load(node);
         assertTrue(obj.loads);
@@ -182,24 +182,24 @@ public class ObjectMapperTest {
 
     @Test
     void testNestedObjectWithComments() throws ObjectMappingException {
-        final CommentedConfigurationNode node = CommentedConfigurationNode.root(ConfigurationOptions.defaults().withShouldCopyDefaults(true));
+        final CommentedConfigurationNode node = CommentedConfigurationNode.root(ConfigurationOptions.defaults().shouldCopyDefaults(true));
         final ObjectMapper<ParentObject> mapper = ObjectMapper.factory().get(ParentObject.class);
         mapper.load(node);
-        assertEquals("Comment on parent", node.getNode("inner").getComment());
-        assertTrue(node.getNode("inner").isMap());
-        assertEquals("Default value", node.getNode("inner", "test").getString());
-        assertEquals("Something", node.getNode("inner", "test").getComment());
+        assertEquals("Comment on parent", node.node("inner").comment());
+        assertTrue(node.node("inner").isMap());
+        assertEquals("Default value", node.node("inner", "test").getString());
+        assertEquals("Something", node.node("inner", "test").comment());
     }
 
     @ConfigSerializable
     private interface ParentInterface {
-        String getTest();
+        String test();
     }
 
     private static class ChildObject implements ParentInterface {
         @Comment("Something") private String test = "Default value";
 
-        @Override public String getTest() {
+        @Override public String test() {
             return this.test;
         }
     }
@@ -227,18 +227,18 @@ public class ObjectMapperTest {
         final ContainingObject newContainingObject = mapper.load(node);
 
         // serialization
-        assertEquals(1, node.getNode("list").getChildrenList().size());
-        assertEquals("Changed value", node.getNode("inner").getNode("test").getString());
-        assertEquals("Changed value", node.getNode("list").getChildrenList().get(0).getNode("test").getString());
-        assertEquals("Something", node.getNode("inner").getNode("test").getComment());
-        assertEquals("Something", node.getNode("list").getChildrenList().get(0).getNode("test").getComment());
-        assertEquals(ChildObject.class.getName(), node.getNode("inner").getNode("__class__").getString());
-        assertEquals(ChildObject.class.getName(), node.getNode("list").getChildrenList().get(0).getNode("__class__").getString());
+        assertEquals(1, node.node("list").childrenList().size());
+        assertEquals("Changed value", node.node("inner").node("test").getString());
+        assertEquals("Changed value", node.node("list").childrenList().get(0).node("test").getString());
+        assertEquals("Something", node.node("inner").node("test").comment());
+        assertEquals("Something", node.node("list").childrenList().get(0).node("test").comment());
+        assertEquals(ChildObject.class.getName(), node.node("inner").node("__class__").getString());
+        assertEquals(ChildObject.class.getName(), node.node("list").childrenList().get(0).node("__class__").getString());
 
         // deserialization
         assertEquals(1, newContainingObject.list.size());
-        assertEquals("Changed value", newContainingObject.inner.getTest());
-        assertEquals("Changed value", newContainingObject.list.get(0).getTest());
+        assertEquals("Changed value", newContainingObject.inner.test());
+        assertEquals("Changed value", newContainingObject.list.get(0).test());
     }
 
     @ConfigSerializable
@@ -261,19 +261,19 @@ public class ObjectMapperTest {
         final ObjectMapper<GenericSerializable<Integer>> intMapper = ObjectMapper.factory().get(intSerializable);
 
         final BasicConfigurationNode stringNode = BasicConfigurationNode.root(p -> {
-            p.getNode("elements").act(n -> {
-                n.appendListNode().setValue("hello");
-                n.appendListNode().setValue("world");
+            p.node("elements").act(n -> {
+                n.appendListNode().set("hello");
+                n.appendListNode().set("world");
             });
         });
         final BasicConfigurationNode intNode = BasicConfigurationNode.root(p -> {
-            p.getNode("elements").act(n -> {
-                n.appendListNode().setValue(1);
-                n.appendListNode().setValue(1);
-                n.appendListNode().setValue(2);
-                n.appendListNode().setValue(3);
-                n.appendListNode().setValue(5);
-                n.appendListNode().setValue(8);
+            p.node("elements").act(n -> {
+                n.appendListNode().set(1);
+                n.appendListNode().set(1);
+                n.appendListNode().set(2);
+                n.appendListNode().set(3);
+                n.appendListNode().set(5);
+                n.appendListNode().set(8);
             });
         });
 
@@ -289,11 +289,11 @@ public class ObjectMapperTest {
         final ObjectMapper<ParentTypesResolved> mapper = ObjectMapper.factory().get(ParentTypesResolved.class);
 
         final BasicConfigurationNode urlNode = BasicConfigurationNode.root(p -> {
-            p.getNode("elements").act(n -> {
-                n.appendListNode().setValue("https://spongepowered.org");
-                n.appendListNode().setValue("https://yaml.org");
+            p.node("elements").act(n -> {
+                n.appendListNode().set("https://spongepowered.org");
+                n.appendListNode().set("https://yaml.org");
             });
-            p.getNode("test").setValue("bye");
+            p.node("test").set("bye");
         });
 
         final ParentTypesResolved resolved = mapper.load(urlNode);

--- a/core/src/test/java/org/spongepowered/configurate/objectmapping/ProcessorTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/objectmapping/ProcessorTest.java
@@ -45,8 +45,8 @@ public class ProcessorTest {
 
         mapper.save(object, target);
 
-        assertEquals("An important option", target.getNode("first").getComment());
-        assertEquals("Another important option!", target.getNode("second").getComment());
+        assertEquals("An important option", target.node("first").comment());
+        assertEquals("Another important option!", target.node("second").comment());
     }
 
     static class TestCommentLocalized {
@@ -66,8 +66,8 @@ public class ProcessorTest {
         final CommentedConfigurationNode target = CommentedConfigurationNode.root();
         mapper.save(new TestCommentLocalized(), target);
 
-        assertEquals("First property", target.getNode("hello").getComment());
-        assertEquals("Missing comment passthrough", target.getNode("goodbye").getComment());
+        assertEquals("First property", target.node("hello").comment());
+        assertEquals("Missing comment passthrough", target.node("goodbye").comment());
     }
 
 }

--- a/core/src/test/java/org/spongepowered/configurate/reactive/ProcessorImplTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/reactive/ProcessorImplTest.java
@@ -179,7 +179,7 @@ public class ProcessorImplTest {
         final Processor.Iso<String> handler = create();
         final String[] values = new String[2];
 
-        handler.setFallbackHandler(val -> values[0] = val);
+        handler.fallbackHandler(val -> values[0] = val);
         handler.submit("Hello");
         assertEquals("Hello", values[0]);
 

--- a/core/src/test/java/org/spongepowered/configurate/reference/WatchServiceListenerTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/reference/WatchServiceListenerTest.java
@@ -44,7 +44,7 @@ public class WatchServiceListenerTest {
     private static @MonotonicNonNull WatchServiceListener listener;
 
     @BeforeAll
-    public static void setUpClass() throws IOException {
+    public static void prepareClass() throws IOException {
         listener = WatchServiceListener.create();
     }
 

--- a/core/src/test/java/org/spongepowered/configurate/serialize/NumericSerializersTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/serialize/NumericSerializersTest.java
@@ -32,14 +32,14 @@ import org.spongepowered.configurate.util.UnmodifiableCollections;
 @SuppressWarnings("UnnecessaryParentheses") // for casting negative number literals
 public class NumericSerializersTest {
 
-    private <T> TypeSerializer<T> getSerializer(final Class<T> type) {
+    private <T> TypeSerializer<T> serializer(final Class<T> type) {
         final @Nullable TypeSerializer<T> ret = TypeSerializerCollection.defaults().get(type);
         assertNotNull(ret, "Serializer for " + type + " must be present!");
         return ret;
     }
 
     private final BasicConfigurationNode node = BasicConfigurationNode.root(ConfigurationOptions.defaults()
-            .withNativeTypes(UnmodifiableCollections.toSet(Byte.class, Float.class, String.class, Integer.class, Long.class, Double.class)));
+            .nativeTypes(UnmodifiableCollections.toSet(Byte.class, Float.class, String.class, Integer.class, Long.class, Double.class)));
 
     @Test
     void testSerializeCustomNumber() {
@@ -74,197 +74,197 @@ public class NumericSerializersTest {
 
     @Test
     void testByte() throws ObjectMappingException {
-        final TypeSerializer<Byte> serializer = getSerializer(Byte.class);
+        final TypeSerializer<Byte> serializer = serializer(Byte.class);
 
         final byte b = (byte) 65;
 
         // roundtrip actual value
-        this.node.setValue(b);
+        this.node.set(b);
         assertEquals((Byte) b, serializer.deserialize(Byte.class, this.node));
 
         // test negative
-        this.node.setValue(-65);
+        this.node.set(-65);
         assertEquals(Byte.valueOf((byte) -65), serializer.deserialize(Byte.class, this.node));
 
         // test too large
-        this.node.setValue(348);
+        this.node.set(348);
         assertThrows(ObjectMappingException.class, () -> serializer.deserialize(Byte.class, this.node));
 
         // from float
-        this.node.setValue(65f);
+        this.node.set(65f);
         assertEquals((Byte) b, serializer.deserialize(Byte.class, this.node));
 
         // from string
-        this.node.setValue("65");
+        this.node.set("65");
         assertEquals((Byte) b, serializer.deserialize(Byte.class, this.node));
 
         // from hex
-        this.node.setValue("0x41");
+        this.node.set("0x41");
         assertEquals((Byte) b, serializer.deserialize(Byte.class, this.node));
 
         // from binary
-        this.node.setValue("0b1000001");
+        this.node.set("0b1000001");
         assertEquals((Byte) b, serializer.deserialize(Byte.class, this.node));
     }
 
     @Test
     void testShort() throws ObjectMappingException {
-        final TypeSerializer<Short> serializer = getSerializer(Short.class);
+        final TypeSerializer<Short> serializer = serializer(Short.class);
 
         final short b = (short) 32486;
 
         // roundtrip actual value
-        this.node.setValue((int) b);
+        this.node.set((int) b);
         assertEquals((Short) b, serializer.deserialize(Short.class, this.node));
 
         // test negative
-        this.node.setValue(-32486);
+        this.node.set(-32486);
         assertEquals(Short.valueOf((short) -32486), serializer.deserialize(Short.class, this.node));
 
         // test too large
-        this.node.setValue(348333333);
+        this.node.set(348333333);
         assertThrows(ObjectMappingException.class, () -> serializer.deserialize(Short.class, this.node));
 
         // from float
 
-        this.node.setValue(32486f);
+        this.node.set(32486f);
         assertEquals((Short) b, serializer.deserialize(Short.class, this.node));
 
         // from string
-        this.node.setValue("32486");
+        this.node.set("32486");
         assertEquals((Short) b, serializer.deserialize(Short.class, this.node));
 
         // from hex
-        this.node.setValue("0x7ee6");
+        this.node.set("0x7ee6");
         assertEquals((Short) b, serializer.deserialize(Short.class, this.node));
 
         // from binary
-        this.node.setValue("0b111111011100110");
+        this.node.set("0b111111011100110");
         assertEquals((Short) b, serializer.deserialize(Short.class, this.node));
 
     }
 
     @Test
     void testInt() throws Exception {
-        final TypeSerializer<Integer> serializer = getSerializer(Integer.class);
+        final TypeSerializer<Integer> serializer = serializer(Integer.class);
 
         final int i = 48888333;
 
         // roundtrip actual value
-        this.node.setValue(i);
+        this.node.set(i);
         assertEquals((Integer) i, serializer.deserialize(Integer.class, this.node));
 
         // test negative
-        this.node.setValue(-595959595);
+        this.node.set(-595959595);
         assertEquals((Integer) (-595959595), serializer.deserialize(Integer.class, this.node));
 
         // test too large
-        this.node.setValue(333339003003030L);
+        this.node.set(333339003003030L);
         assertThrows(ObjectMappingException.class, () -> serializer.deserialize(Integer.class, this.node));
 
         // from double
-        this.node.setValue(48888333d);
+        this.node.set(48888333d);
         assertEquals((Integer) i, serializer.deserialize(Integer.class, this.node));
 
         // with fraction
-        this.node.setValue(48888333.4d);
+        this.node.set(48888333.4d);
         assertThrows(CoercionFailedException.class, () -> serializer.deserialize(Integer.class, this.node));
 
         // from string
-        this.node.setValue("48888333");
+        this.node.set("48888333");
         assertEquals((Integer) i, serializer.deserialize(Integer.class, this.node));
 
         // from hex
-        this.node.setValue("0x2E9FA0D");
+        this.node.set("0x2E9FA0D");
         assertEquals((Integer) i, serializer.deserialize(Integer.class, this.node));
 
         // from hex but lowercase
-        this.node.setValue("0x2e9fa0d");
+        this.node.set("0x2e9fa0d");
         assertEquals((Integer) i, serializer.deserialize(Integer.class, this.node));
 
         // from binary
-        this.node.setValue("0b10111010011111101000001101");
+        this.node.set("0b10111010011111101000001101");
         assertEquals((Integer) i, serializer.deserialize(Integer.class, this.node));
     }
 
     @Test
     void testLong() throws Exception {
-        final TypeSerializer<Long> serializer = getSerializer(Long.class);
+        final TypeSerializer<Long> serializer = serializer(Long.class);
 
         final long i = 48888333494404L;
 
         // roundtrip actual value
-        this.node.setValue(i);
+        this.node.set(i);
         assertEquals((Long) i, serializer.deserialize(Long.class, this.node));
 
         // test negative
-        this.node.setValue(-595959595);
+        this.node.set(-595959595);
         assertEquals((Long) (-595959595L), serializer.deserialize(Long.class, this.node));
 
         // from float
-        this.node.setValue(48888333494404d);
+        this.node.set(48888333494404d);
         assertEquals((Long) i, serializer.deserialize(Long.class, this.node));
 
         // from string
-        this.node.setValue("48888333494404");
+        this.node.set("48888333494404");
         assertEquals((Long) i, serializer.deserialize(Long.class, this.node));
 
         // from hex
-        this.node.setValue("0x2c76b3c06884");
+        this.node.set("0x2c76b3c06884");
         assertEquals((Long) i, serializer.deserialize(Long.class, this.node));
 
         // from binary
-        this.node.setValue("0b1011000111011010110011110000000110100010000100");
+        this.node.set("0b1011000111011010110011110000000110100010000100");
         assertEquals((Long) i, serializer.deserialize(Long.class, this.node));
     }
 
     @Test
     void testFloat() throws Exception {
-        final TypeSerializer<Float> serializer = getSerializer(Float.class);
+        final TypeSerializer<Float> serializer = serializer(Float.class);
 
         final float i = 3.1415f;
 
         // roundtrip actual value
-        this.node.setValue(i);
+        this.node.set(i);
         assertEquals((Float) i, serializer.deserialize(Float.class, this.node));
 
         // test negative
-        this.node.setValue(-595.34f);
+        this.node.set(-595.34f);
         assertEquals((Float) (-595.34f), serializer.deserialize(Float.class, this.node));
 
         // test too large
-        this.node.setValue(13.4e129d);
+        this.node.set(13.4e129d);
         assertThrows(ObjectMappingException.class, () -> serializer.deserialize(Float.class, this.node));
 
         // from int
-        this.node.setValue(448);
+        this.node.set(448);
         assertEquals((Float) 448f, serializer.deserialize(Float.class, this.node));
 
         // from string
-        this.node.setValue("3.1415");
+        this.node.set("3.1415");
         assertEquals((Float) i, serializer.deserialize(Float.class, this.node));
     }
 
     @Test
     void testDouble() throws Exception {
-        final TypeSerializer<Double> serializer = getSerializer(Double.class);
+        final TypeSerializer<Double> serializer = serializer(Double.class);
 
         final double i = 3.1415e180d;
 
         // roundtrip actual value
-        this.node.setValue(i);
+        this.node.set(i);
         assertEquals((Double) i, serializer.deserialize(Double.class, this.node));
 
         // test negative
-        this.node.setValue(-595.34e180d);
+        this.node.set(-595.34e180d);
         assertEquals((Double) (-595.34e180d), serializer.deserialize(Double.class, this.node));
 
         // from int
-        this.node.setValue(448);
+        this.node.set(448);
         assertEquals((Double) 448d, serializer.deserialize(Double.class, this.node));
 
         // from string
-        this.node.setValue("3.1415e180");
+        this.node.set("3.1415e180");
         assertEquals((Double) i, serializer.deserialize(Double.class, this.node));
     }
 

--- a/core/src/test/java/org/spongepowered/configurate/serialize/PassthroughSerializer.java
+++ b/core/src/test/java/org/spongepowered/configurate/serialize/PassthroughSerializer.java
@@ -27,7 +27,7 @@ public class PassthroughSerializer implements TypeSerializer<Object> {
 
     @Override
     public Object deserialize(final Type type, final ConfigurationNode node) throws ObjectMappingException {
-        final @Nullable Object o = node.getValue();
+        final @Nullable Object o = node.get();
         if (o == null) {
             throw new ObjectMappingException("No value present for node");
         }
@@ -39,7 +39,7 @@ public class PassthroughSerializer implements TypeSerializer<Object> {
 
     @Override
     public void serialize(final Type type, final @Nullable Object obj, final ConfigurationNode node) throws ObjectMappingException {
-        node.setValue(obj);
+        node.set(obj);
     }
 
 }

--- a/core/src/test/java/org/spongepowered/configurate/serialize/TypeSerializerCollectionTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/serialize/TypeSerializerCollectionTest.java
@@ -34,12 +34,12 @@ public class TypeSerializerCollectionTest {
     @Test
     void testResolveWildcard() throws ObjectMappingException {
         final ConfigurationNode node = BasicConfigurationNode.root(ConfigurationOptions.defaults()
-            .withSerializers(b -> b.register(Object.class, new PassthroughSerializer())), n -> {
-                n.appendListNode().setValue("a string");
-                n.appendListNode().setValue(14);
+            .serializers(b -> b.register(Object.class, new PassthroughSerializer())), n -> {
+                n.appendListNode().set("a string");
+                n.appendListNode().set(14);
             });
 
-        final @Nullable List<?> value = node.getValue(new TypeToken<List<?>>() {});
+        final @Nullable List<?> value = node.get(new TypeToken<List<?>>() {});
         assertEquals(Arrays.asList("a string", 14), value);
     }
 

--- a/core/src/test/java/org/spongepowered/configurate/serialize/TypeSerializersTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/serialize/TypeSerializersTest.java
@@ -55,13 +55,13 @@ import java.util.regex.Pattern;
 
 public class TypeSerializersTest {
 
-    private <T> TypeSerializer<T> getSerializer(final TypeToken<T> type) {
+    private <T> TypeSerializer<T> serializer(final TypeToken<T> type) {
         final @Nullable TypeSerializer<T> ret = TypeSerializerCollection.defaults().get(type);
         assertNotNull(ret);
         return ret;
     }
 
-    private <T> TypeSerializer<T> getSerializer(final Class<T> type) {
+    private <T> TypeSerializer<T> serializer(final Class<T> type) {
         final @Nullable TypeSerializer<T> ret = TypeSerializerCollection.defaults().get(type);
         assertNotNull(ret);
         return ret;
@@ -70,8 +70,8 @@ public class TypeSerializersTest {
     @Test
     void testStringSerializer() throws ObjectMappingException {
         final TypeToken<String> stringType = TypeToken.get(String.class);
-        final TypeSerializer<String> stringSerializer = getSerializer(stringType);
-        final BasicConfigurationNode node = BasicConfigurationNode.root().setValue("foobar");
+        final TypeSerializer<String> stringSerializer = serializer(stringType);
+        final BasicConfigurationNode node = BasicConfigurationNode.root().set("foobar");
 
         assertEquals("foobar", stringSerializer.deserialize(stringType.getType(), node));
         stringSerializer.serialize(stringType.getType(), "foobarbaz", node);
@@ -97,13 +97,13 @@ public class TypeSerializersTest {
     void testBooleanSerializer() throws ObjectMappingException {
         final TypeToken<Boolean> booleanType = TypeToken.get(Boolean.class);
 
-        final TypeSerializer<Boolean> booleanSerializer = getSerializer(booleanType);
+        final TypeSerializer<Boolean> booleanSerializer = serializer(booleanType);
         final BasicConfigurationNode node = BasicConfigurationNode.root();
-        node.getNode("direct").setValue(true);
-        node.getNode("fromstring").setValue("true");
+        node.node("direct").set(true);
+        node.node("fromstring").set("true");
 
-        assertEquals(true, booleanSerializer.deserialize(Boolean.class, node.getNode("direct")));
-        assertEquals(true, booleanSerializer.deserialize(Boolean.class, node.getNode("fromstring")));
+        assertEquals(true, booleanSerializer.deserialize(Boolean.class, node.node("direct")));
+        assertEquals(true, booleanSerializer.deserialize(Boolean.class, node.node("fromstring")));
     }
 
     private enum TestEnum {
@@ -117,70 +117,70 @@ public class TypeSerializersTest {
     void testEnumValueSerializer() throws ObjectMappingException {
         final TypeToken<TestEnum> enumType = TypeToken.get(TestEnum.class);
 
-        final TypeSerializer<TestEnum> enumSerializer = getSerializer(enumType);
+        final TypeSerializer<TestEnum> enumSerializer = serializer(enumType);
 
         final BasicConfigurationNode node = BasicConfigurationNode.root();
-        node.getNode("present_val").setValue("first");
-        node.getNode("another_present_val").setValue("SECOND");
-        node.getNode("casematters_val").setValue("tHiRd");
-        node.getNode("casematters_val_lowercase").setValue("third");
-        node.getNode("invalid_val").setValue("3rd");
+        node.node("present_val").set("first");
+        node.node("another_present_val").set("SECOND");
+        node.node("casematters_val").set("tHiRd");
+        node.node("casematters_val_lowercase").set("third");
+        node.node("invalid_val").set("3rd");
 
-        assertEquals(TestEnum.FIRST, enumSerializer.deserialize(enumType.getType(), node.getNode("present_val")));
-        assertEquals(TestEnum.SECOND, enumSerializer.deserialize(enumType.getType(), node.getNode("another_present_val")));
-        assertEquals(TestEnum.Third, enumSerializer.deserialize(enumType.getType(), node.getNode("casematters_val")));
-        assertEquals(TestEnum.third, enumSerializer.deserialize(enumType.getType(), node.getNode("casematters_val_lowercase")));
+        assertEquals(TestEnum.FIRST, enumSerializer.deserialize(enumType.getType(), node.node("present_val")));
+        assertEquals(TestEnum.SECOND, enumSerializer.deserialize(enumType.getType(), node.node("another_present_val")));
+        assertEquals(TestEnum.Third, enumSerializer.deserialize(enumType.getType(), node.node("casematters_val")));
+        assertEquals(TestEnum.third, enumSerializer.deserialize(enumType.getType(), node.node("casematters_val_lowercase")));
         Assertions.assertThrows(ObjectMappingException.class, () -> {
-            enumSerializer.deserialize(enumType.getType(), node.getNode("invalid_val"));
+            enumSerializer.deserialize(enumType.getType(), node.node("invalid_val"));
         });
     }
 
     @Test
     void testListSerializer() throws ObjectMappingException {
         final TypeToken<List<String>> stringListType = new TypeToken<List<String>>() {};
-        final TypeSerializer<List<String>> stringListSerializer = getSerializer(stringListType);
+        final TypeSerializer<List<String>> stringListSerializer = serializer(stringListType);
         final BasicConfigurationNode value = BasicConfigurationNode.root();
-        value.appendListNode().setValue("hi");
-        value.appendListNode().setValue("there");
-        value.appendListNode().setValue("beautiful");
-        value.appendListNode().setValue("people");
+        value.appendListNode().set("hi");
+        value.appendListNode().set("there");
+        value.appendListNode().set("beautiful");
+        value.appendListNode().set("people");
 
         assertEquals(Arrays.asList("hi", "there", "beautiful", "people"), stringListSerializer.deserialize(stringListType.getType(), value));
-        value.setValue(null);
+        value.set(null);
 
         stringListSerializer.serialize(stringListType.getType(), Arrays.asList("hi", "there", "lame", "people"), value);
-        assertEquals("hi", value.getNode(0).getString());
-        assertEquals("there", value.getNode(1).getString());
-        assertEquals("lame", value.getNode(2).getString());
-        assertEquals("people", value.getNode(3).getString());
+        assertEquals("hi", value.node(0).getString());
+        assertEquals("there", value.node(1).getString());
+        assertEquals("lame", value.node(2).getString());
+        assertEquals("people", value.node(3).getString());
     }
 
     @Test
     void testSetSerializer() throws ObjectMappingException {
         final TypeToken<Set<String>> stringListType = new TypeToken<Set<String>>() {};
-        final TypeSerializer<Set<String>> stringListSerializer = getSerializer(stringListType);
+        final TypeSerializer<Set<String>> stringListSerializer = serializer(stringListType);
         final BasicConfigurationNode value = BasicConfigurationNode.root();
-        value.appendListNode().setValue("hi");
-        value.appendListNode().setValue("there");
-        value.appendListNode().setValue("beautiful");
-        value.appendListNode().setValue("people");
+        value.appendListNode().set("hi");
+        value.appendListNode().set("there");
+        value.appendListNode().set("beautiful");
+        value.appendListNode().set("people");
 
         assertEquals(UnmodifiableCollections.toSet("hi", "there", "beautiful", "people"),
             stringListSerializer.deserialize(stringListType.getType(), value));
-        value.setValue(null);
+        value.set(null);
 
         stringListSerializer.serialize(stringListType.getType(), UnmodifiableCollections.toSet("hi", "there", "lame", "people"), value);
-        assertEquals("hi", value.getNode(0).getString());
-        assertEquals("there", value.getNode(1).getString());
-        assertEquals("lame", value.getNode(2).getString());
-        assertEquals("people", value.getNode(3).getString());
+        assertEquals("hi", value.node(0).getString());
+        assertEquals("there", value.node(1).getString());
+        assertEquals("lame", value.node(2).getString());
+        assertEquals("people", value.node(3).getString());
     }
 
     @Test
     void testListSerializerPreservesEmptyList() throws ObjectMappingException {
         final TypeToken<List<String>> listStringType = new TypeToken<List<String>>() {};
         final TypeSerializer<List<String>> listStringSerializer =
-                getSerializer(listStringType);
+                serializer(listStringType);
 
         final BasicConfigurationNode value = BasicConfigurationNode.root();
 
@@ -193,13 +193,13 @@ public class TypeSerializersTest {
     @SuppressWarnings("rawtypes")
     void testListRawTypes() {
         final TypeToken<List> rawType = TypeToken.get(List.class);
-        final TypeSerializer<List> serial = getSerializer(rawType);
+        final TypeSerializer<List> serial = serializer(rawType);
 
         final BasicConfigurationNode value = BasicConfigurationNode.root();
 
-        value.appendListNode().setValue(1);
-        value.appendListNode().setValue("dog");
-        value.appendListNode().setValue(2.4);
+        value.appendListNode().set(1);
+        value.appendListNode().set("dog");
+        value.appendListNode().set(2.4);
 
         Assertions.assertTrue(Assertions.assertThrows(Exception.class, () -> {
             serial.deserialize(rawType.getType(), value);
@@ -210,67 +210,67 @@ public class TypeSerializersTest {
     void testMapSerializer() throws ObjectMappingException {
         final TypeToken<Map<String, Integer>> mapStringIntType = new TypeToken<Map<String, Integer>>() {};
         final TypeSerializer<Map<String, Integer>> mapStringIntSerializer =
-                getSerializer(mapStringIntType);
+                serializer(mapStringIntType);
 
         final BasicConfigurationNode value = BasicConfigurationNode.root();
-        value.getNode("fish").setValue(5);
-        value.getNode("bugs").setValue("124880");
-        value.getNode("time").setValue("-1");
+        value.node("fish").set(5);
+        value.node("bugs").set("124880");
+        value.node("time").set("-1");
 
         final Map<String, Integer> expectedValues = ImmutableMap.of("fish", 5, "bugs", 124880, "time", -1);
 
         assertEquals(expectedValues, mapStringIntSerializer.deserialize(mapStringIntType.getType(), value));
 
-        value.setValue(null);
+        value.set(null);
 
         mapStringIntSerializer.serialize(mapStringIntType.getType(), expectedValues, value);
-        assertEquals(5, value.getNode("fish").getInt());
-        assertEquals(124880, value.getNode("bugs").getInt());
-        assertEquals(-1, value.getNode("time").getInt());
+        assertEquals(5, value.node("fish").getInt());
+        assertEquals(124880, value.node("bugs").getInt());
+        assertEquals(-1, value.node("time").getInt());
     }
 
     @Test
     void testInvalidMapValueTypes() throws ObjectMappingException {
         final TypeToken<Map<TestEnum, Integer>> mapTestEnumIntType = new TypeToken<Map<TestEnum, Integer>>() {};
         final TypeSerializer<Map<TestEnum, Integer>> mapTestEnumIntSerializer =
-                getSerializer(mapTestEnumIntType);
+                serializer(mapTestEnumIntType);
 
         final BasicConfigurationNode value = BasicConfigurationNode.root();
-        value.getNode("FIRST").setValue(5);
-        value.getNode("SECOND").setValue(8);
+        value.node("FIRST").set(5);
+        value.node("SECOND").set(8);
 
         final @Nullable Map<TestEnum, Integer> des = mapTestEnumIntSerializer.deserialize(mapTestEnumIntType.getType(), value);
         final BasicConfigurationNode serialVal = BasicConfigurationNode.root(ConfigurationOptions.defaults()
-                .withNativeTypes(UnmodifiableCollections.toSet(String.class, Integer.class)));
+                .nativeTypes(UnmodifiableCollections.toSet(String.class, Integer.class)));
         mapTestEnumIntSerializer.serialize(mapTestEnumIntType.getType(), des, serialVal);
-        assertEquals(value.getValue(), serialVal.getValue());
+        assertEquals(value.get(), serialVal.get());
         //assertEquals(value, serialVal);
     }
 
     @Test
     void testMapSerializerRemovesDeletedKeys() throws ObjectMappingException {
         final TypeToken<Map<String, Integer>> mapStringIntType = new TypeToken<Map<String, Integer>>() {};
-        final TypeSerializer<Map<String, Integer>> mapStringIntSerializer = getSerializer(mapStringIntType);
+        final TypeSerializer<Map<String, Integer>> mapStringIntSerializer = serializer(mapStringIntType);
 
         final BasicConfigurationNode value = BasicConfigurationNode.root();
-        value.getNode("fish").setValue(5);
-        value.getNode("bugs").setValue("124880");
-        value.getNode("time").setValue("-1");
+        value.node("fish").set(5);
+        value.node("bugs").set("124880");
+        value.node("time").set("-1");
 
         @SuppressWarnings("unchecked")
         final @Nullable Map<String, Integer> deserialized = mapStringIntSerializer.deserialize(mapStringIntType.getType(), value);
         requireNonNull(deserialized).remove("fish");
 
         mapStringIntSerializer.serialize(mapStringIntType.getType(), deserialized, value);
-        assertTrue(value.getNode("fish").isVirtual());
-        assertFalse(value.getNode("bugs").isVirtual());
+        assertTrue(value.node("fish").virtual());
+        assertFalse(value.node("bugs").virtual());
     }
 
     @Test
     void testMapSerializerPreservesEmptyMap() throws ObjectMappingException {
         final TypeToken<Map<String, Integer>> mapStringIntType = new TypeToken<Map<String, Integer>>() {};
         final TypeSerializer<Map<String, Integer>> mapStringIntSerializer =
-                getSerializer(mapStringIntType);
+                serializer(mapStringIntType);
 
         final BasicConfigurationNode value = BasicConfigurationNode.root();
 
@@ -283,16 +283,16 @@ public class TypeSerializersTest {
     void testMapSerializerPreservesChildComments() throws ObjectMappingException {
         final TypeToken<Map<String, Integer>> mapStringIntType = new TypeToken<Map<String, Integer>>() {};
         final TypeSerializer<Map<String, Integer>> mapStringIntSerializer =
-                getSerializer(mapStringIntType);
+                serializer(mapStringIntType);
 
         final CommentedConfigurationNode commentNode = CommentedConfigurationNode.root();
 
-        commentNode.getNode("hi").setComment("test").setValue(3);
+        commentNode.node("hi").comment("test").set(3);
 
         mapStringIntSerializer.serialize(mapStringIntType.getType(), ImmutableMap.of("hi", 5, "no", 2), commentNode);
 
-        assertEquals(5, commentNode.getNode("hi").getValue());
-        assertEquals("test", commentNode.getNode("hi").getComment());
+        assertEquals(5, commentNode.node("hi").get());
+        assertEquals("test", commentNode.node("hi").comment());
 
     }
 
@@ -305,10 +305,10 @@ public class TypeSerializersTest {
     @Test
     void testAnnotatedObjectSerializer() throws ObjectMappingException {
         final TypeToken<TestObject> testNodeType = TypeToken.get(TestObject.class);
-        final TypeSerializer<TestObject> testObjectSerializer = getSerializer(testNodeType);
+        final TypeSerializer<TestObject> testObjectSerializer = serializer(testNodeType);
         final BasicConfigurationNode node = BasicConfigurationNode.root();
-        node.getNode("int").setValue("42");
-        node.getNode("name").setValue("Bob");
+        node.node("int").set("42");
+        node.node("name").set("Bob");
 
         final TestObject object = testObjectSerializer.deserialize(testNodeType.getType(), node);
         assertEquals(42, object.value);
@@ -318,48 +318,48 @@ public class TypeSerializersTest {
     @Test
     void testUriSerializer() throws ObjectMappingException {
         final TypeToken<URI> uriType = TypeToken.get(URI.class);
-        final TypeSerializer<URI> uriSerializer = getSerializer(uriType);
+        final TypeSerializer<URI> uriSerializer = serializer(uriType);
 
         final String uriString = "http://google.com";
         final URI testUri = URI.create(uriString);
 
         final BasicConfigurationNode node = BasicConfigurationNode.root(ConfigurationOptions.defaults()
-                .withNativeTypes(UnmodifiableCollections.toSet(String.class, Integer.class)))
-                .setValue(uriString);
+                .nativeTypes(UnmodifiableCollections.toSet(String.class, Integer.class)))
+                .set(uriString);
         assertEquals(testUri, uriSerializer.deserialize(uriType.getType(), node));
 
         uriSerializer.serialize(uriType.getType(), testUri, node);
-        assertEquals(uriString, node.getValue());
+        assertEquals(uriString, node.get());
     }
 
     @Test
     void testUrlSerializer() throws ObjectMappingException, MalformedURLException {
         final TypeToken<URL> urlType = TypeToken.get(URL.class);
-        final TypeSerializer<URL> urlSerializer = getSerializer(urlType);
+        final TypeSerializer<URL> urlSerializer = serializer(urlType);
 
         final String urlString = "http://google.com";
         final URL testUrl = new URL(urlString);
 
         final BasicConfigurationNode node = BasicConfigurationNode.root(ConfigurationOptions.defaults()
-                .withNativeTypes(UnmodifiableCollections.toSet(String.class, Integer.class)))
-                .setValue(urlString);
+                .nativeTypes(UnmodifiableCollections.toSet(String.class, Integer.class)))
+                .set(urlString);
         assertEquals(testUrl, urlSerializer.deserialize(urlType.getType(), node));
 
         urlSerializer.serialize(urlType.getType(), testUrl, node);
-        assertEquals(urlString, node.getValue());
+        assertEquals(urlString, node.get());
     }
 
     @Test
     void testUuidSerializer() throws ObjectMappingException {
         final TypeToken<UUID> uuidType = TypeToken.get(UUID.class);
-        final TypeSerializer<UUID> uuidSerializer = getSerializer(uuidType);
+        final TypeSerializer<UUID> uuidSerializer = serializer(uuidType);
 
         final UUID testUuid = UUID.randomUUID();
 
         final BasicConfigurationNode serializeTo = BasicConfigurationNode.root(ConfigurationOptions.defaults()
-                .withNativeTypes(UnmodifiableCollections.toSet(String.class, Integer.class)));
+                .nativeTypes(UnmodifiableCollections.toSet(String.class, Integer.class)));
         uuidSerializer.serialize(uuidType.getType(), testUuid, serializeTo);
-        assertEquals(testUuid.toString(), serializeTo.getValue());
+        assertEquals(testUuid.toString(), serializeTo.get());
 
         assertEquals(testUuid, uuidSerializer.deserialize(uuidType.getType(), serializeTo));
 
@@ -368,155 +368,155 @@ public class TypeSerializersTest {
     @Test
     void testPatternSerializer() throws ObjectMappingException {
         final TypeToken<Pattern> patternType = TypeToken.get(Pattern.class);
-        final TypeSerializer<Pattern> patternSerializer = getSerializer(patternType);
+        final TypeSerializer<Pattern> patternSerializer = serializer(patternType);
 
         final Pattern testPattern = Pattern.compile("(na )+batman");
         final BasicConfigurationNode serializeTo = BasicConfigurationNode.root(ConfigurationOptions.defaults()
-                .withNativeTypes(UnmodifiableCollections.toSet(String.class, Integer.class)));
+                .nativeTypes(UnmodifiableCollections.toSet(String.class, Integer.class)));
         patternSerializer.serialize(patternType.getType(), testPattern, serializeTo);
-        assertEquals("(na )+batman", serializeTo.getValue());
+        assertEquals("(na )+batman", serializeTo.get());
         assertEquals(testPattern.pattern(), patternSerializer.deserialize(patternType.getType(), serializeTo).pattern());
     }
 
     @Test
     void testCharSerializer() throws ObjectMappingException {
         final TypeToken<Character> charType = TypeToken.get(Character.class);
-        final TypeSerializer<Character> charSerializer = getSerializer(charType);
+        final TypeSerializer<Character> charSerializer = serializer(charType);
 
         final BasicConfigurationNode serializeTo = BasicConfigurationNode.root();
 
-        serializeTo.setValue("e");
+        serializeTo.set("e");
         assertEquals(Character.valueOf('e'), charSerializer.deserialize(charType.getType(), serializeTo));
 
-        serializeTo.setValue('P');
+        serializeTo.set('P');
         assertEquals(Character.valueOf('P'), charSerializer.deserialize(charType.getType(), serializeTo));
 
-        serializeTo.setValue(0x2a);
+        serializeTo.set(0x2a);
         assertEquals(Character.valueOf('*'), charSerializer.deserialize(charType.getType(), serializeTo));
 
         charSerializer.serialize(charType.getType(), 'z', serializeTo);
-        assertEquals('z', serializeTo.getValue());
+        assertEquals('z', serializeTo.get());
     }
 
     @Test
     void testArraySerializer() throws ObjectMappingException {
         final TypeToken<String[]> arrayType = TypeToken.get(String[].class);
-        final TypeSerializer<String[]> arraySerializer = getSerializer(arrayType);
+        final TypeSerializer<String[]> arraySerializer = serializer(arrayType);
 
         final String[] testArray = new String[] {"hello", "world"};
         final BasicConfigurationNode serializeTo = BasicConfigurationNode.root();
         arraySerializer.serialize(arrayType.getType(), testArray, serializeTo);
-        assertEquals(Arrays.asList("hello", "world"), serializeTo.getValue());
+        assertEquals(Arrays.asList("hello", "world"), serializeTo.get());
         assertArrayEquals(testArray, arraySerializer.deserialize(arrayType.getType(), serializeTo));
     }
 
     @Test
     void testArraySerializerBooleanPrimitive() throws ObjectMappingException {
         final TypeToken<boolean[]> booleanArrayType = TypeToken.get(boolean[].class);
-        final TypeSerializer<boolean[]> booleanArraySerializer = getSerializer(booleanArrayType);
+        final TypeSerializer<boolean[]> booleanArraySerializer = serializer(booleanArrayType);
 
         final boolean[] testArray = new boolean[] {true, false, true, true, false};
         final BasicConfigurationNode serializeTo = BasicConfigurationNode.root();
         booleanArraySerializer.serialize(booleanArrayType.getType(), testArray, serializeTo);
-        assertEquals(Arrays.asList(true, false, true, true, false), serializeTo.getValue());
+        assertEquals(Arrays.asList(true, false, true, true, false), serializeTo.get());
         assertArrayEquals(testArray, booleanArraySerializer.deserialize(booleanArrayType.getType(), serializeTo));
     }
 
     @Test
     void testArraySerializerBytePrimitive() throws ObjectMappingException {
         final TypeToken<byte[]> byteArrayType = TypeToken.get(byte[].class);
-        final TypeSerializer<byte[]> byteArraySerializer = getSerializer(byteArrayType);
+        final TypeSerializer<byte[]> byteArraySerializer = serializer(byteArrayType);
 
         final byte[] testArray = new byte[] {1, 5, 3, -7, 9, 0};
         final BasicConfigurationNode serializeTo = BasicConfigurationNode.root();
         byteArraySerializer.serialize(byteArrayType.getType(), testArray, serializeTo);
-        assertEquals(Arrays.asList((byte) 1, (byte) 5, (byte) 3, (byte) -7, (byte) 9, (byte) 0), serializeTo.getValue());
+        assertEquals(Arrays.asList((byte) 1, (byte) 5, (byte) 3, (byte) -7, (byte) 9, (byte) 0), serializeTo.get());
         assertArrayEquals(testArray, byteArraySerializer.deserialize(byteArrayType.getType(), serializeTo));
     }
 
     @Test
     void testArraySerializerCharPrimitive() throws ObjectMappingException {
         final Class<char[]> charArrayType = char[].class;
-        final TypeSerializer<char[]> charArraySerializer = getSerializer(charArrayType);
+        final TypeSerializer<char[]> charArraySerializer = serializer(charArrayType);
 
         final char[] testArray = new char[] {'s', 'l', 'e', 'e', 'p'};
         final BasicConfigurationNode serializeTo = BasicConfigurationNode.root();
         charArraySerializer.serialize(charArrayType, testArray, serializeTo);
-        assertEquals(Arrays.asList('s', 'l', 'e', 'e', 'p'), serializeTo.getValue());
+        assertEquals(Arrays.asList('s', 'l', 'e', 'e', 'p'), serializeTo.get());
         assertArrayEquals(testArray, charArraySerializer.deserialize(charArrayType, serializeTo));
     }
 
     @Test
     void testArraySerializerShortPrimitive() throws ObjectMappingException {
         final Class<short[]> shortArrayType = short[].class;
-        final TypeSerializer<short[]> shortArraySerializer = getSerializer(shortArrayType);
+        final TypeSerializer<short[]> shortArraySerializer = serializer(shortArrayType);
 
         final short[] testArray = new short[] {1, 5, 3, 7, 9};
         final BasicConfigurationNode serializeTo = BasicConfigurationNode.root();
         shortArraySerializer.serialize(shortArrayType, testArray, serializeTo);
-        assertEquals(Arrays.asList((short) 1, (short) 5, (short) 3, (short) 7, (short) 9), serializeTo.getValue());
+        assertEquals(Arrays.asList((short) 1, (short) 5, (short) 3, (short) 7, (short) 9), serializeTo.get());
         assertArrayEquals(testArray, shortArraySerializer.deserialize(shortArrayType, serializeTo));
     }
 
     @Test
     void testArraySerializerIntPrimitive() throws ObjectMappingException {
         final Class<int[]> intArrayType = int[].class;
-        final TypeSerializer<int[]> intArraySerializer = getSerializer(intArrayType);
+        final TypeSerializer<int[]> intArraySerializer = serializer(intArrayType);
 
         final int[] testArray = new int[] {1, 5, 3, 7, 9};
         final BasicConfigurationNode serializeTo = BasicConfigurationNode.root();
         intArraySerializer.serialize(intArrayType, testArray, serializeTo);
-        assertEquals(Arrays.asList(1, 5, 3, 7, 9), serializeTo.getValue());
+        assertEquals(Arrays.asList(1, 5, 3, 7, 9), serializeTo.get());
         assertArrayEquals(testArray, intArraySerializer.deserialize(intArrayType, serializeTo));
     }
 
     @Test
     void testArraySerializerLongPrimitive() throws ObjectMappingException {
         final Class<long[]> longArrayType = long[].class;
-        final TypeSerializer<long[]> longArraySerializer = getSerializer(longArrayType);
+        final TypeSerializer<long[]> longArraySerializer = serializer(longArrayType);
 
         final long[] testArray = new long[] {1, 5, 3, 7, 9};
         final BasicConfigurationNode serializeTo = BasicConfigurationNode.root();
         longArraySerializer.serialize(longArrayType, testArray, serializeTo);
-        assertEquals(Arrays.asList(1L, 5L, 3L, 7L, 9L), serializeTo.getValue());
+        assertEquals(Arrays.asList(1L, 5L, 3L, 7L, 9L), serializeTo.get());
         assertArrayEquals(testArray, longArraySerializer.deserialize(longArrayType, serializeTo));
     }
 
     @Test
     void testArraySerializerFloatPrimitive() throws ObjectMappingException {
         final Class<float[]> floatArrayType = float[].class;
-        final TypeSerializer<float[]> floatArraySerializer = getSerializer(floatArrayType);
+        final TypeSerializer<float[]> floatArraySerializer = serializer(floatArrayType);
 
         final float[] testArray = new float[] {1.02f, 5.66f, 3.2f, 7.9f, 9f};
         final BasicConfigurationNode serializeTo = BasicConfigurationNode.root();
         floatArraySerializer.serialize(floatArrayType, testArray, serializeTo);
-        assertEquals(Arrays.asList(1.02f, 5.66f, 3.2f, 7.9f, 9f), serializeTo.getValue());
+        assertEquals(Arrays.asList(1.02f, 5.66f, 3.2f, 7.9f, 9f), serializeTo.get());
         assertArrayEquals(testArray, floatArraySerializer.deserialize(floatArrayType, serializeTo));
     }
 
     @Test
     void testArraySerializerDoublePrimitive() throws ObjectMappingException {
         final Class<double[]> doubleArrayType = double[].class;
-        final TypeSerializer<double[]> doubleArraySerializer = getSerializer(doubleArrayType);
+        final TypeSerializer<double[]> doubleArraySerializer = serializer(doubleArrayType);
 
         final double[] testArray = new double[] {1.02d, 5.66d, 3.2d, 7.9d, 9d};
         final BasicConfigurationNode serializeTo = BasicConfigurationNode.root();
         doubleArraySerializer.serialize(doubleArrayType, testArray, serializeTo);
-        assertEquals(Arrays.asList(1.02d, 5.66d, 3.2d, 7.9d, 9d), serializeTo.getValue());
+        assertEquals(Arrays.asList(1.02d, 5.66d, 3.2d, 7.9d, 9d), serializeTo.get());
         assertArrayEquals(testArray, doubleArraySerializer.deserialize(doubleArrayType, serializeTo));
     }
 
     @Test
     void testConfigurationNodeSerializer() throws ObjectMappingException {
         final Class<ConfigurationNode> nodeType = ConfigurationNode.class;
-        final TypeSerializer<ConfigurationNode> nodeSerializer = getSerializer(nodeType);
+        final TypeSerializer<ConfigurationNode> nodeSerializer = serializer(nodeType);
         assertNotNull(nodeSerializer);
 
         final BasicConfigurationNode sourceNode = BasicConfigurationNode.root(n -> {
-            n.getNode("hello").setValue("world");
-            n.getNode("lorg").act(c -> {
-                c.appendListNode().setValue("doggo");
-                c.appendListNode().setValue("pupper");
+            n.node("hello").set("world");
+            n.node("lorg").act(c -> {
+                c.appendListNode().set("doggo");
+                c.appendListNode().set("pupper");
             });
         });
 
@@ -531,27 +531,27 @@ public class TypeSerializersTest {
 
     @Test
     void testPathSerializer() throws ObjectMappingException {
-        final TypeSerializer<Path> pathSerializer = getSerializer(Path.class);
+        final TypeSerializer<Path> pathSerializer = serializer(Path.class);
         assertNotNull(pathSerializer);
 
-        final BasicConfigurationNode source = BasicConfigurationNode.root().setValue("test" + FileSystems.getDefault().getSeparator() + "file.txt");
+        final BasicConfigurationNode source = BasicConfigurationNode.root().set("test" + FileSystems.getDefault().getSeparator() + "file.txt");
         final Path ret = pathSerializer.deserialize(Path.class, source);
         assertEquals(Paths.get("test", "file.txt"), ret.normalize());
 
         final BasicConfigurationNode writeTo = BasicConfigurationNode.root(ConfigurationOptions.defaults()
-                .withNativeTypes(ImmutableSet.of(String.class, Byte.class)));
+                .nativeTypes(ImmutableSet.of(String.class, Byte.class)));
         pathSerializer.serialize(Path.class, ret, writeTo);
         assertEquals(source, writeTo);
     }
 
     @Test
     void testPathSerializerFromList() throws ObjectMappingException {
-        final TypeSerializer<Path> pathSerializer = getSerializer(Path.class);
+        final TypeSerializer<Path> pathSerializer = serializer(Path.class);
         assertNotNull(pathSerializer);
 
         final BasicConfigurationNode source = BasicConfigurationNode.root(n -> {
-            n.appendListNode().setValue("test");
-            n.appendListNode().setValue("file.txt");
+            n.appendListNode().set("test");
+            n.appendListNode().set("file.txt");
         });
         final Path ret = pathSerializer.deserialize(Path.class, source);
         assertEquals(Paths.get("test", "file.txt"), ret);
@@ -559,10 +559,10 @@ public class TypeSerializersTest {
 
     @Test
     void testFileSerializer() throws ObjectMappingException {
-        final TypeSerializer<File> fileSerializer = getSerializer(File.class);
+        final TypeSerializer<File> fileSerializer = serializer(File.class);
         assertNotNull(fileSerializer);
 
-        final BasicConfigurationNode source = BasicConfigurationNode.root().setValue("hello/world.png");
+        final BasicConfigurationNode source = BasicConfigurationNode.root().set("hello/world.png");
 
         assertEquals(new File("hello/world.png"), fileSerializer.deserialize(File.class, source));
     }

--- a/core/src/test/java14/org/spongepowered/configurate/objectmapping/RecordDiscovererTest.java
+++ b/core/src/test/java14/org/spongepowered/configurate/objectmapping/RecordDiscovererTest.java
@@ -39,8 +39,8 @@ public class RecordDiscovererTest {
     @Test
     void testDeserializeToRecord() throws ObjectMappingException {
         final var node = BasicConfigurationNode.root(n -> {
-            n.getNode("name").setValue("Hello");
-            n.getNode("testable").setValue(13);
+            n.node("name").set("Hello");
+            n.node("testable").set(13);
         });
 
         final var element = ObjectMapper.factory().get(TestRecord.class).load(node);
@@ -55,8 +55,8 @@ public class RecordDiscovererTest {
 
         ObjectMapper.factory().get(TestRecord.class).save(record, target);
 
-        assertEquals("meow", target.getNode("name").getValue());
-        assertEquals(32, target.getNode("testable").getValue());
+        assertEquals("meow", target.node("name").get());
+        assertEquals(32, target.node("testable").get());
     }
 
     @ConfigSerializable
@@ -72,14 +72,14 @@ public class RecordDiscovererTest {
                 new URL("https://spongepowered.org/"));
 
         final var target = CommentedConfigurationNode.root(ConfigurationOptions.defaults()
-                .withNativeTypes(Set.of(String.class, Integer.class)));
+                .nativeTypes(Set.of(String.class, Integer.class)));
 
         ObjectMapper.factory().get(AnnotatedRecord.class).save(record, target);
 
-        assertEquals("nested", target.getNode("element", "name").getValue());
-        assertEquals(0xFACE, target.getNode("element", "testable").getValue());
-        assertEquals("https://spongepowered.org/", target.getNode("fetch-loc").getValue());
-        assertEquals("The most url", target.getNode("fetch-loc").getComment());
+        assertEquals("nested", target.node("element", "name").get());
+        assertEquals(0xFACE, target.node("element", "testable").get());
+        assertEquals("https://spongepowered.org/", target.node("fetch-loc").get());
+        assertEquals("The most url", target.node("fetch-loc").comment());
     }
 
     @ConfigSerializable
@@ -109,7 +109,7 @@ public class RecordDiscovererTest {
         final var filled =
                 ObjectMapper.factory().get(ImplicitlyFillable.class)
                         .load(BasicConfigurationNode.root(ConfigurationOptions.defaults()
-                                .withImplicitInitialization(true)));
+                                .implicitInitialization(true)));
 
         assertEquals(new Empty("<unknown>"), filled.something());
         assertEquals(Set.of(), filled.somethingElse());

--- a/examples/src/main/java/org/spongepowered/configurate/examples/FormatConversion.java
+++ b/examples/src/main/java/org/spongepowered/configurate/examples/FormatConversion.java
@@ -33,12 +33,12 @@ public final class FormatConversion {
     public static void main(final String[] args) {
         // First off: we build two loaders, one with our old format pointing to the old location
         final YamlConfigurationLoader oldFormat = YamlConfigurationLoader.builder()
-                .setPath(Paths.get("widgets.yml"))
+                .path(Paths.get("widgets.yml"))
                 .build();
 
         // and a second one for our target format, pointing to the new location
         final HoconConfigurationLoader newFormat = HoconConfigurationLoader.builder()
-                .setPath(Paths.get("widgets.conf"))
+                .path(Paths.get("widgets.conf"))
                 .build();
 
         // We try to load the file into a node using the source format

--- a/examples/src/main/java/org/spongepowered/configurate/examples/ObjectMapperExample.java
+++ b/examples/src/main/java/org/spongepowered/configurate/examples/ObjectMapperExample.java
@@ -50,15 +50,15 @@ public final class ObjectMapperExample {
     public static void main(final String[] args) throws IOException, ObjectMappingException {
         final Path file = Paths.get(args[0]);
         final HoconConfigurationLoader loader = HoconConfigurationLoader.builder()
-                .setDefaultOptions(opts -> opts.withShouldCopyDefaults(true))
-                .setPath(file) // or setUrl(), or setFile(), or setSource/Sink
+                .defaultOptions(opts -> opts.shouldCopyDefaults(true))
+                .path(file) // or setUrl(), or setFile(), or setSource/Sink
                 .build();
 
         final CommentedConfigurationNode node = loader.load(); // Load from file
         final MyConfiguration config = MyConfiguration.loadFrom(node); // Populate object
 
         // Do whatever actions with the configuration, then...
-        config.setItemName("Steve");
+        config.itemName("Steve");
 
         config.saveTo(node); // Update the backing node
         loader.save(node); // Write to the original file
@@ -92,23 +92,23 @@ public final class ObjectMapperExample {
         // This won't be written to the file because it's marked as `transient`
         private transient @MonotonicNonNull String decoratedName;
 
-        public @Nullable String getItemName() {
+        public @Nullable String itemName() {
             return this.itemName;
         }
 
-        public void setItemName(final String itemName) {
+        public void itemName(final String itemName) {
             this.itemName = requireNonNull(itemName, "itemName");
         }
 
-        public Pattern getFilter() {
+        public Pattern filter() {
             return this.filter;
         }
 
-        public List<Section> getSections() {
+        public List<Section> sections() {
             return this.sections;
         }
 
-        public String getDecoratedItemName() {
+        public String decoratedItemName() {
             if (this.decoratedName == null) {
                 this.decoratedName = "[" + this.itemName + "]";
             }
@@ -128,11 +128,11 @@ public final class ObjectMapperExample {
         private UUID id;
 
         // the ObjectMapper resolves settings based on fields -- these methods are provided as a convenience
-        public String getName() {
+        public String name() {
             return this.name;
         }
 
-        public UUID getId() {
+        public UUID id() {
             return this.id;
         }
 

--- a/examples/src/main/java/org/spongepowered/configurate/examples/Transformations.java
+++ b/examples/src/main/java/org/spongepowered/configurate/examples/Transformations.java
@@ -70,7 +70,7 @@ public final class Transformations {
                 })
                 // For every direct child of the `section` node, set the value of its child `new-value` to something
                 .addAction(path("section", ConfigurationTransformation.WILDCARD_OBJECT), (path, value) -> {
-                    value.getNode("new-value").setValue("i'm a default");
+                    value.node("new-value").set("i'm a default");
 
                     return null; // don't move the value
                 })
@@ -83,7 +83,7 @@ public final class Transformations {
                 .addAction(path("server", "version"), (path, value) -> {
                     final @Nullable String val = value.getString();
                     if (val != null) {
-                        value.setValue(val.replaceAll("-", "_"));
+                        value.set(val.replaceAll("-", "_"));
                     }
                     return null;
                 })
@@ -107,11 +107,11 @@ public final class Transformations {
      * @return provided node, after transformation
      */
     public static <N extends ScopedConfigurationNode<N>> N updateNode(final N node) {
-        if (!node.isVirtual()) { // we only want to migrate existing data
+        if (!node.virtual()) { // we only want to migrate existing data
             final ConfigurationTransformation.Versioned<N> trans = create();
-            final int startVersion = trans.getVersion(node);
+            final int startVersion = trans.version(node);
             trans.apply(node);
-            final int endVersion = trans.getVersion(node);
+            final int endVersion = trans.version(node);
             if (startVersion != endVersion) { // we might not have made any changes
                 System.out.println("Updated config schema from " + startVersion + " to " + endVersion);
             }
@@ -125,7 +125,7 @@ public final class Transformations {
             System.err.println("Apply the test transformations to a single file");
         }
         final HoconConfigurationLoader loader = HoconConfigurationLoader.builder()
-                .setPath(Paths.get(args[0]))
+                .path(Paths.get(args[0]))
                 .build();
 
         loader.save(updateNode(loader.load())); // tada

--- a/examples/src/main/java/org/spongepowered/configurate/examples/Tutorial.java
+++ b/examples/src/main/java/org/spongepowered/configurate/examples/Tutorial.java
@@ -31,7 +31,7 @@ public final class Tutorial {
 
     public static void main(final String[] args) throws ObjectMappingException {
         final HoconConfigurationLoader loader = HoconConfigurationLoader.builder()
-                .setPath(Paths.get("myproject.conf")) // Set where we will load and save to
+                .path(Paths.get("myproject.conf")) // Set where we will load and save to
                 .build();
 
         final CommentedConfigurationNode root;
@@ -46,12 +46,12 @@ public final class Tutorial {
             return;
         }
 
-        final ConfigurationNode countNode = root.getNode("messages", "count");
-        final ConfigurationNode moodNode = root.getNode("messages", "mood");
+        final ConfigurationNode countNode = root.node("messages", "count");
+        final ConfigurationNode moodNode = root.node("messages", "mood");
 
-        final @Nullable String name = root.getNode("name").getString();
+        final @Nullable String name = root.node("name").getString();
         final int count = countNode.getInt(Integer.MIN_VALUE);
-        final @Nullable Mood mood = moodNode.getValue(Mood.class);
+        final @Nullable Mood mood = moodNode.get(Mood.class);
 
         if (name == null || count == Integer.MIN_VALUE || mood == null) {
             System.err.println("Invalid configuration");
@@ -64,12 +64,12 @@ public final class Tutorial {
         System.out.println("Thanks for viewing your messages");
 
         // Update values
-        countNode.setValue(0); // native type
-        moodNode.setValue(Mood.class, Mood.NEUTRAL); // serialized type
+        countNode.set(0); // native type
+        moodNode.set(Mood.class, Mood.NEUTRAL); // serialized type
 
-        root.getNode("accesses").act(n -> {
-            n.setCommentIfAbsent("The times messages have been accessed, in milliseconds since the epoch");
-            n.appendListNode().setValue(System.currentTimeMillis());
+        root.node("accesses").act(n -> {
+            n.commentIfAbsent("The times messages have been accessed, in milliseconds since the epoch");
+            n.appendListNode().set(System.currentTimeMillis());
         });
 
         // And save the node back to the file

--- a/examples/src/main/java/org/spongepowered/configurate/examples/ValueReferences.java
+++ b/examples/src/main/java/org/spongepowered/configurate/examples/ValueReferences.java
@@ -79,7 +79,7 @@ public class ValueReferences {
     public ValueReferences(final Path configFile) throws IOException, ObjectMappingException {
         this.listener = WatchServiceListener.create();
         this.base = this.listener.listenToConfiguration(file -> HoconConfigurationLoader.builder()
-                .setDefaultOptions(o -> o.withShouldCopyDefaults(true)).setPath(file).build(), configFile);
+                .defaultOptions(o -> o.shouldCopyDefaults(true)).path(file).build(), configFile);
         this.base.updates().subscribe($ -> System.out.println("Configuration auto-reloaded"));
         this.base.errors().subscribe(err -> {
             final Throwable t = err.getValue();

--- a/extra/dfu3/src/main/java/org/spongepowered/configurate/extra/dfu/v3/CodecSerializer.java
+++ b/extra/dfu3/src/main/java/org/spongepowered/configurate/extra/dfu/v3/CodecSerializer.java
@@ -42,7 +42,7 @@ final class CodecSerializer<V> implements TypeSerializer<V> {
     private static final ConfigurateOps DEFAULT_OPS = ConfigurateOps.builder().readWriteProtection(ConfigurateOps.Protection.NONE).build();
 
     static DynamicOps<ConfigurationNode> opsFor(final ConfigurationNode node) {
-        if (node.getOptions().getSerializers().equals(TypeSerializerCollection.defaults())) {
+        if (node.options().serializers().equals(TypeSerializerCollection.defaults())) {
             return DEFAULT_OPS;
         } else {
             return ConfigurateOps.builder()
@@ -79,7 +79,7 @@ final class CodecSerializer<V> implements TypeSerializer<V> {
             throw new ObjectMappingException(error.message());
         }
 
-        value.setValue(result.result().orElseThrow(() -> new ObjectMappingException("Neither a result or error was present")));
+        value.set(result.result().orElseThrow(() -> new ObjectMappingException("Neither a result or error was present")));
     }
 
 }

--- a/extra/dfu3/src/main/java/org/spongepowered/configurate/extra/dfu/v3/ConfigurateOpsBuilder.java
+++ b/extra/dfu3/src/main/java/org/spongepowered/configurate/extra/dfu/v3/ConfigurateOpsBuilder.java
@@ -67,7 +67,7 @@ public final class ConfigurateOpsBuilder {
      */
     public ConfigurateOpsBuilder factoryFromSerializers(final TypeSerializerCollection collection) {
         requireNonNull(collection, "collection");
-        return factory(() -> CommentedConfigurationNode.root(ConfigurationOptions.defaults().withSerializers(collection)));
+        return factory(() -> CommentedConfigurationNode.root(ConfigurationOptions.defaults().serializers(collection)));
     }
 
     /**
@@ -77,7 +77,7 @@ public final class ConfigurateOpsBuilder {
      * @return this builder
      */
     public ConfigurateOpsBuilder factoryFromNode(final ConfigurationNode node) {
-        final ConfigurationOptions options = requireNonNull(node, "node").getOptions();
+        final ConfigurationOptions options = requireNonNull(node, "node").options();
         return factory(() -> CommentedConfigurationNode.root(options));
     }
 

--- a/extra/dfu3/src/main/java/org/spongepowered/configurate/extra/dfu/v3/DataFixerTransformation.java
+++ b/extra/dfu3/src/main/java/org/spongepowered/configurate/extra/dfu/v3/DataFixerTransformation.java
@@ -67,12 +67,12 @@ public final class DataFixerTransformation<N extends ConfigurationNode> implemen
 
     @Override
     public void apply(@NonNull final N node) {
-        final ConfigurationNode versionNode = node.getNode(this.versionPath);
+        final ConfigurationNode versionNode = node.node(this.versionPath);
         final int currentVersion = versionNode.getInt(-1);
         if (currentVersion < this.targetVersion) {
             this.versionHolder.set(currentVersion);
             this.wrapped.apply(node);
-            versionNode.setValue(this.targetVersion);
+            versionNode.set(this.targetVersion);
         } else if (currentVersion > this.targetVersion) {
             // TODO: Logging or throw error
         }
@@ -80,23 +80,23 @@ public final class DataFixerTransformation<N extends ConfigurationNode> implemen
 
     /**
      * Get the version from a specific configuration node, using the configured
-     * {@linkplain #getVersionKey() version key}.
+     * {@linkplain #versionKey() version key}.
      *
      * @param root base node to query
      * @return version, or -1 if this node is unversioned.
      */
     @Override
-    public int getVersion(final ConfigurationNode root) {
-        return requireNonNull(root, "root").getNode(getVersionKey()).getInt(-1);
+    public int version(final ConfigurationNode root) {
+        return requireNonNull(root, "root").node(versionKey()).getInt(-1);
     }
 
     @Override
-    public NodePath getVersionKey() {
+    public NodePath versionKey() {
         return this.versionPath;
     }
 
     @Override
-    public int getLatestVersion() {
+    public int latestVersion() {
         return this.targetVersion;
     }
 
@@ -115,7 +115,7 @@ public final class DataFixerTransformation<N extends ConfigurationNode> implemen
          * @param fixer the fixer
          * @return this builder
          */
-        public Builder<N> setDataFixer(final DataFixer fixer) {
+        public Builder<N> dataFixer(final DataFixer fixer) {
             this.fixer = requireNonNull(fixer);
             return this;
         }
@@ -128,8 +128,8 @@ public final class DataFixerTransformation<N extends ConfigurationNode> implemen
          * @return this builder
          *
          */
-        public Builder<N> setVersionPath(final Object... path) {
-            this.versionPath = NodePath.create(requireNonNull(path, "path"));
+        public Builder<N> versionPath(final Object... path) {
+            this.versionPath = NodePath.of(requireNonNull(path, "path"));
             return this;
         }
 
@@ -140,7 +140,7 @@ public final class DataFixerTransformation<N extends ConfigurationNode> implemen
          * @param path the path
          * @return this builder
          */
-        public Builder<N> setVersionPath(final NodePath path) {
+        public Builder<N> versionPath(final NodePath path) {
             this.versionPath = requireNonNull(path, "path");
             return this;
         }
@@ -152,7 +152,7 @@ public final class DataFixerTransformation<N extends ConfigurationNode> implemen
          * @param targetVersion target version
          * @return this builder
          */
-        public Builder<N> setTargetVersion(final int targetVersion) {
+        public Builder<N> targetVersion(final int targetVersion) {
             this.targetVersion = targetVersion;
             return this;
         }
@@ -164,8 +164,8 @@ public final class DataFixerTransformation<N extends ConfigurationNode> implemen
          * @param path target path
          * @return this builder
          */
-        public Builder<N> type(final DSL.TypeReference type, final Object... path) {
-            return type(type, NodePath.create(path));
+        public Builder<N> addType(final DSL.TypeReference type, final Object... path) {
+            return addType(type, NodePath.of(path));
         }
 
         /**
@@ -175,7 +175,7 @@ public final class DataFixerTransformation<N extends ConfigurationNode> implemen
          * @param path target path
          * @return this builder
          */
-        public Builder<N> type(final DSL.TypeReference type, final NodePath path) {
+        public Builder<N> addType(final DSL.TypeReference type, final NodePath path) {
             this.dataFixes.add(Pair.of(type, path));
             return this;
         }
@@ -195,7 +195,7 @@ public final class DataFixerTransformation<N extends ConfigurationNode> implemen
             final ThreadLocal<Integer> versionHolder = new ThreadLocal<>();
             for (Pair<DSL.TypeReference, NodePath> fix : this.dataFixes) {
                 wrappedBuilder.addAction(fix.getSecond(), (path, valueAtPath) -> {
-                    valueAtPath.setValue(this.fixer.update(fix.getFirst(), ConfigurateOps.wrap(valueAtPath),
+                    valueAtPath.set(this.fixer.update(fix.getFirst(), ConfigurateOps.wrap(valueAtPath),
                             versionHolder.get(), this.targetVersion).getValue());
                     return null;
                 });

--- a/extra/dfu3/src/main/java/org/spongepowered/configurate/extra/dfu/v3/DfuSerializers.java
+++ b/extra/dfu3/src/main/java/org/spongepowered/configurate/extra/dfu/v3/DfuSerializers.java
@@ -40,7 +40,7 @@ public final class DfuSerializers {
      * @param <V> value type
      * @return a new serializer
      */
-    public static <V> TypeSerializer<V> forCodec(final Codec<V> codec) {
+    public static <V> TypeSerializer<V> serializer(final Codec<V> codec) {
         return new CodecSerializer<>(requireNonNull(codec, "codec"));
     }
 
@@ -53,8 +53,8 @@ public final class DfuSerializers {
      * @return a codec for the type, or null if an appropriate
      *      {@link TypeSerializer} could not be found.
      */
-    public static <S> @Nullable Codec<S> forSerializer(final TypeToken<S> type) {
-        return forSerializer(requireNonNull(type, "type"), TypeSerializerCollection.defaults());
+    public static <S> @Nullable Codec<S> codec(final TypeToken<S> type) {
+        return codec(requireNonNull(type, "type"), TypeSerializerCollection.defaults());
     }
 
     /**
@@ -66,12 +66,12 @@ public final class DfuSerializers {
      * @return a codec, or null if an appropriate {@link TypeSerializer}
      *      could not be found for the TypeToken.
      */
-    public static <V> @Nullable Codec<V> forSerializer(final TypeToken<V> type, final TypeSerializerCollection collection) {
+    public static <V> @Nullable Codec<V> codec(final TypeToken<V> type, final TypeSerializerCollection collection) {
         final @Nullable TypeSerializer<V> serial = collection.get(requireNonNull(type, "type"));
         if (serial == null) {
             return null;
         }
-        return new TypeSerializerCodec<>(type, serial, ConfigurateOps.getForSerializers(collection)).withLifecycle(Lifecycle.stable());
+        return new TypeSerializerCodec<>(type, serial, ConfigurateOps.forSerializers(collection)).withLifecycle(Lifecycle.stable());
     }
 
 }

--- a/extra/dfu3/src/main/java/org/spongepowered/configurate/extra/dfu/v3/NodeMaplike.java
+++ b/extra/dfu3/src/main/java/org/spongepowered/configurate/extra/dfu/v3/NodeMaplike.java
@@ -56,7 +56,7 @@ final class NodeMaplike implements MapLike<ConfigurationNode> {
     @Override
     public Stream<Pair<ConfigurationNode, ConfigurationNode>> entries() {
         return this.node.entrySet().stream()
-                .map(ent -> Pair.of(BasicConfigurationNode.root(this.options).setValue(ent.getKey()), this.ops.guardOutputRead(ent.getValue())));
+                .map(ent -> Pair.of(BasicConfigurationNode.root(this.options).set(ent.getKey()), this.ops.guardOutputRead(ent.getValue())));
     }
 
 }

--- a/extra/dfu3/src/test/java/org/spongepowered/configurate/extra/dfu/v3/ConfigurateOpsTests.java
+++ b/extra/dfu3/src/test/java/org/spongepowered/configurate/extra/dfu/v3/ConfigurateOpsTests.java
@@ -63,7 +63,7 @@ public final class ConfigurateOpsTests {
     private static void compareToJson(final ConfigurationNode node, final JsonElement element) throws IOException {
         final StringWriter configurate = new StringWriter();
         final GsonConfigurationLoader loader = GsonConfigurationLoader.builder()
-                .setSink(() -> new BufferedWriter(configurate)).build();
+                .sink(() -> new BufferedWriter(configurate)).build();
         loader.save(node);
 
         final StringWriter json = new StringWriter();
@@ -90,7 +90,7 @@ public final class ConfigurateOpsTests {
     @DisplayName("Configurate (Empty) -> Gson (Null)")
     void emptyToGson() {
         final ConfigurationNode node = BasicConfigurationNode.root();
-        final Dynamic<ConfigurationNode> wrapped = new Dynamic<>(ConfigurateOps.getInstance(), node);
+        final Dynamic<ConfigurationNode> wrapped = new Dynamic<>(ConfigurateOps.instance(), node);
         final JsonElement element = wrapped.convert(JsonOps.INSTANCE).getValue();
 
         assertTrue(element.isJsonNull(), "Resulting element was not a json null");
@@ -101,7 +101,7 @@ public final class ConfigurateOpsTests {
     void emptyFromGson() {
         final JsonNull jsonNull = JsonNull.INSTANCE;
         final Dynamic<JsonElement> wrapped = new Dynamic<>(JsonOps.INSTANCE, jsonNull);
-        final ConfigurationNode result = wrapped.convert(ConfigurateOps.getInstance()).getValue();
+        final ConfigurationNode result = wrapped.convert(ConfigurateOps.instance()).getValue();
 
         assertTrue(result.isEmpty(), "Resulting configuration node was not empty");
     }
@@ -109,8 +109,8 @@ public final class ConfigurateOpsTests {
     @Test
     @DisplayName("Configurate (String) -> Gson")
     void toGsonFromString() {
-        final ConfigurationNode node = BasicConfigurationNode.root().setValue("Test String");
-        final Dynamic<ConfigurationNode> wrapped = new Dynamic<>(ConfigurateOps.getInstance(), node);
+        final ConfigurationNode node = BasicConfigurationNode.root().set("Test String");
+        final Dynamic<ConfigurationNode> wrapped = new Dynamic<>(ConfigurateOps.instance(), node);
         final JsonElement output = wrapped.convert(JsonOps.INSTANCE).getValue();
 
         assertTrue(output instanceof JsonPrimitive, "Resulting Element was not a Json Primitive");
@@ -123,9 +123,9 @@ public final class ConfigurateOpsTests {
     void fromGsonFromString() {
         final JsonPrimitive string = new JsonPrimitive("Test String");
         final Dynamic<JsonElement> wrapped = new Dynamic<>(JsonOps.INSTANCE, string);
-        final ConfigurationNode output = wrapped.convert(ConfigurateOps.getInstance()).getValue();
+        final ConfigurationNode output = wrapped.convert(ConfigurateOps.instance()).getValue();
 
-        assertTrue(output.getValue() instanceof String, "Resulting configuration node was not a String");
+        assertTrue(output.get() instanceof String, "Resulting configuration node was not a String");
         assertEquals(output.getString(), "Test String");
     }
 
@@ -142,12 +142,12 @@ public final class ConfigurateOpsTests {
         jsonArray.add(3);
         jsonArray.add(4);
         final Dynamic<JsonElement> wrapped = new Dynamic<>(JsonOps.INSTANCE, jsonArray);
-        final ConfigurationNode output = wrapped.convert(ConfigurateOps.getInstance()).getValue();
+        final ConfigurationNode output = wrapped.convert(ConfigurateOps.instance()).getValue();
 
         assertTrue(output.isList(), "Resulting configuration node was not a list.");
-        assertEquals(3, output.getChildrenList().size(),
+        assertEquals(3, output.childrenList().size(),
                 "Resulting configuration node had wrong amount of child elements in list");
-        assertTrue(output.getChildrenList().stream()
+        assertTrue(output.childrenList().stream()
                         .map(ConfigurationNode::getInt)
                         .collect(Collectors.toList()).containsAll(expectedElements),
                 "Resulting configuration node did not contain every element in original JsonArray");
@@ -162,9 +162,9 @@ public final class ConfigurateOpsTests {
         expectedElements.add(4);
 
         final ConfigurationNode node = BasicConfigurationNode.root();
-        node.setValue(expectedElements);
+        node.set(expectedElements);
         //node.appendListNode().setValue(1).setValue(3).setValue(4);
-        final Dynamic<ConfigurationNode> wrapped = new Dynamic<>(ConfigurateOps.getInstance(), node);
+        final Dynamic<ConfigurationNode> wrapped = new Dynamic<>(ConfigurateOps.instance(), node);
         final JsonElement output = wrapped.convert(JsonOps.INSTANCE).getValue();
 
         assertTrue(output.isJsonArray(), "Resulting Element was not an array");
@@ -187,11 +187,11 @@ public final class ConfigurateOpsTests {
         object.addProperty("foo", "bar");
         object.addProperty("bar", "baz");
         final Dynamic<JsonElement> wrapped = new Dynamic<>(JsonOps.INSTANCE, object);
-        final ConfigurationNode output = wrapped.convert(ConfigurateOps.getInstance()).getValue();
+        final ConfigurationNode output = wrapped.convert(ConfigurateOps.instance()).getValue();
 
         assertTrue(output.isMap(), "Resulting configuration node was not a map");
-        assertEquals(2, output.getChildrenMap().size(), "Resulting configuration node had wrong amount of child elements");
-        assertEquals(expectedValues, output.getValue(new TypeToken<Map<String, String>>() {
+        assertEquals(2, output.childrenMap().size(), "Resulting configuration node had wrong amount of child elements");
+        assertEquals(expectedValues, output.get(new TypeToken<Map<String, String>>() {
         }));
     }
 
@@ -203,8 +203,8 @@ public final class ConfigurateOpsTests {
         expectedValues.put("bar", "baz");
 
         final ConfigurationNode node = BasicConfigurationNode.root();
-        node.setValue(expectedValues);
-        final Dynamic<ConfigurationNode> wrapped = new Dynamic<>(ConfigurateOps.getInstance(), node);
+        node.set(expectedValues);
+        final Dynamic<ConfigurationNode> wrapped = new Dynamic<>(ConfigurateOps.instance(), node);
         final JsonElement element = wrapped.convert(JsonOps.INSTANCE).getValue();
 
         assertTrue(element.isJsonObject(), "Resulting element was not a json object");
@@ -225,9 +225,9 @@ public final class ConfigurateOpsTests {
         final JsonElement compressedBlocks = assertResult(listCodec.encode(positions, JsonOps.COMPRESSED, JsonOps.COMPRESSED.empty()));
         final JsonElement regularBlocks = assertResult(listCodec.encode(positions, JsonOps.INSTANCE, JsonOps.INSTANCE.empty()));
         final ConfigurationNode compressedNode = assertResult(listCodec.encode(positions,
-            ConfigurateOps.getInstance(true), BasicConfigurationNode.root()));
+            ConfigurateOps.instance(true), BasicConfigurationNode.root()));
         final ConfigurationNode uncompressedNode = assertResult(listCodec.encode(positions,
-            ConfigurateOps.getInstance(false), BasicConfigurationNode.root()));
+            ConfigurateOps.instance(false), BasicConfigurationNode.root()));
 
         compareToJson(compressedNode, compressedBlocks);
         compareToJson(uncompressedNode, regularBlocks);

--- a/extra/dfu3/src/test/java/org/spongepowered/configurate/extra/dfu/v3/DfuSerializersTest.java
+++ b/extra/dfu3/src/test/java/org/spongepowered/configurate/extra/dfu/v3/DfuSerializersTest.java
@@ -63,16 +63,16 @@ public class DfuSerializersTest {
     @Test
     void testCodecSerializer() throws ObjectMappingException {
         final TypeSerializerCollection serializers = TypeSerializerCollection.defaults().childBuilder()
-            .register(VEC3I_TYPE, DfuSerializers.forCodec(VEC3I_CODEC))
+            .register(VEC3I_TYPE, DfuSerializers.serializer(VEC3I_CODEC))
             .build();
 
-        final ConfigurationNode testElement = BasicConfigurationNode.root(ConfigurationOptions.defaults().withSerializers(serializers), n -> {
-            n.appendListNode().setValue(4);
-            n.appendListNode().setValue(5);
-            n.appendListNode().setValue(8);
+        final ConfigurationNode testElement = BasicConfigurationNode.root(ConfigurationOptions.defaults().serializers(serializers), n -> {
+            n.appendListNode().set(4);
+            n.appendListNode().set(5);
+            n.appendListNode().set(8);
         });
 
-        final Vector3i pos = testElement.getValue(VEC3I_TYPE);
+        final Vector3i pos = testElement.get(VEC3I_TYPE);
 
         assertEquals(new Vector3i(4, 5, 8), pos);
     }
@@ -90,10 +90,10 @@ public class DfuSerializersTest {
     @Test
     void testSerializerCodec() throws IOException {
         final TypeSerializerCollection serializers = TypeSerializerCollection.defaults().childBuilder()
-            .register(VEC3I_TYPE, DfuSerializers.forCodec(VEC3I_CODEC))
+            .register(VEC3I_TYPE, DfuSerializers.serializer(VEC3I_CODEC))
             .build();
 
-        final @Nullable Codec<TestSerializable> codec = DfuSerializers.forSerializer(TypeToken.get(TestSerializable.class), serializers);
+        final @Nullable Codec<TestSerializable> codec = DfuSerializers.codec(TypeToken.get(TestSerializable.class), serializers);
         assertNotNull(codec);
 
         final DataResult<JsonElement> out = codec.encode(new TestSerializable(), JsonOps.INSTANCE, JsonOps.INSTANCE.empty());

--- a/extra/dfu4/src/main/java/org/spongepowered/configurate/extra/dfu/v4/CodecSerializer.java
+++ b/extra/dfu4/src/main/java/org/spongepowered/configurate/extra/dfu/v4/CodecSerializer.java
@@ -42,7 +42,7 @@ final class CodecSerializer<V> implements TypeSerializer<V> {
     private static final ConfigurateOps DEFAULT_OPS = ConfigurateOps.builder().readWriteProtection(ConfigurateOps.Protection.NONE).build();
 
     static DynamicOps<ConfigurationNode> opsFor(final ConfigurationNode node) {
-        if (node.getOptions().getSerializers().equals(TypeSerializerCollection.defaults())) {
+        if (node.options().serializers().equals(TypeSerializerCollection.defaults())) {
             return DEFAULT_OPS;
         } else {
             return ConfigurateOps.builder()
@@ -79,7 +79,7 @@ final class CodecSerializer<V> implements TypeSerializer<V> {
             throw new ObjectMappingException(error.message());
         }
 
-        value.setValue(result.result().orElseThrow(() -> new ObjectMappingException("Neither a result or error was present")));
+        value.set(result.result().orElseThrow(() -> new ObjectMappingException("Neither a result or error was present")));
     }
 
 }

--- a/extra/dfu4/src/main/java/org/spongepowered/configurate/extra/dfu/v4/ConfigurateOpsBuilder.java
+++ b/extra/dfu4/src/main/java/org/spongepowered/configurate/extra/dfu/v4/ConfigurateOpsBuilder.java
@@ -67,7 +67,7 @@ public final class ConfigurateOpsBuilder {
      */
     public ConfigurateOpsBuilder factoryFromSerializers(final TypeSerializerCollection collection) {
         requireNonNull(collection, "collection");
-        return factory(() -> CommentedConfigurationNode.root(ConfigurationOptions.defaults().withSerializers(collection)));
+        return factory(() -> CommentedConfigurationNode.root(ConfigurationOptions.defaults().serializers(collection)));
     }
 
     /**
@@ -77,7 +77,7 @@ public final class ConfigurateOpsBuilder {
      * @return this builder
      */
     public ConfigurateOpsBuilder factoryFromNode(final ConfigurationNode node) {
-        final ConfigurationOptions options = requireNonNull(node, "node").getOptions();
+        final ConfigurationOptions options = requireNonNull(node, "node").options();
         return factory(() -> CommentedConfigurationNode.root(options));
     }
 

--- a/extra/dfu4/src/main/java/org/spongepowered/configurate/extra/dfu/v4/DataFixerTransformation.java
+++ b/extra/dfu4/src/main/java/org/spongepowered/configurate/extra/dfu/v4/DataFixerTransformation.java
@@ -67,12 +67,12 @@ public final class DataFixerTransformation<N extends ConfigurationNode> implemen
 
     @Override
     public void apply(@NonNull final N node) {
-        final ConfigurationNode versionNode = node.getNode(this.versionPath);
+        final ConfigurationNode versionNode = node.node(this.versionPath);
         final int currentVersion = versionNode.getInt(-1);
         if (currentVersion < this.targetVersion) {
             this.versionHolder.set(currentVersion);
             this.wrapped.apply(node);
-            versionNode.setValue(this.targetVersion);
+            versionNode.set(this.targetVersion);
         } else if (currentVersion > this.targetVersion) {
             // TODO: Logging or throw error
         }
@@ -80,23 +80,23 @@ public final class DataFixerTransformation<N extends ConfigurationNode> implemen
 
     /**
      * Get the version from a specific configuration node, using the configured
-     * {@linkplain #getVersionKey() version key}.
+     * {@linkplain #versionKey() version key}.
      *
      * @param root base node to query
      * @return version, or -1 if this node is unversioned.
      */
     @Override
-    public int getVersion(final ConfigurationNode root) {
-        return requireNonNull(root, "root").getNode(getVersionKey()).getInt(-1);
+    public int version(final ConfigurationNode root) {
+        return requireNonNull(root, "root").node(versionKey()).getInt(-1);
     }
 
     @Override
-    public NodePath getVersionKey() {
+    public NodePath versionKey() {
         return this.versionPath;
     }
 
     @Override
-    public int getLatestVersion() {
+    public int latestVersion() {
         return this.targetVersion;
     }
 
@@ -115,7 +115,7 @@ public final class DataFixerTransformation<N extends ConfigurationNode> implemen
          * @param fixer the fixer
          * @return this builder
          */
-        public Builder<N> setDataFixer(final DataFixer fixer) {
+        public Builder<N> dataFixer(final DataFixer fixer) {
             this.fixer = requireNonNull(fixer);
             return this;
         }
@@ -127,8 +127,8 @@ public final class DataFixerTransformation<N extends ConfigurationNode> implemen
          * @param path the path
          * @return this builder
          */
-        public Builder<N> setVersionKey(final Object... path) {
-            this.versionPath = NodePath.create(requireNonNull(path, "path"));
+        public Builder<N> versionKey(final Object... path) {
+            this.versionPath = NodePath.of(requireNonNull(path, "path"));
             return this;
         }
 
@@ -139,7 +139,7 @@ public final class DataFixerTransformation<N extends ConfigurationNode> implemen
          * @param path the path
          * @return this builder
          */
-        public Builder<N> setVersionKey(final NodePath path) {
+        public Builder<N> versionKey(final NodePath path) {
             this.versionPath = requireNonNull(path, "path");
             return this;
         }
@@ -151,7 +151,7 @@ public final class DataFixerTransformation<N extends ConfigurationNode> implemen
          * @param targetVersion target version
          * @return this builder
          */
-        public Builder<N> setTargetVersion(final int targetVersion) {
+        public Builder<N> targetVersion(final int targetVersion) {
             this.targetVersion = targetVersion;
             return this;
         }
@@ -163,8 +163,8 @@ public final class DataFixerTransformation<N extends ConfigurationNode> implemen
          * @param path target path
          * @return this builder
          */
-        public Builder<N> type(final DSL.TypeReference type, final Object... path) {
-            return type(type, NodePath.create(path));
+        public Builder<N> addType(final DSL.TypeReference type, final Object... path) {
+            return addType(type, NodePath.of(path));
         }
 
         /**
@@ -174,7 +174,7 @@ public final class DataFixerTransformation<N extends ConfigurationNode> implemen
          * @param path target path
          * @return this builder
          */
-        public Builder<N> type(final DSL.TypeReference type, final NodePath path) {
+        public Builder<N> addType(final DSL.TypeReference type, final NodePath path) {
             this.dataFixes.add(Pair.of(type, path));
             return this;
         }
@@ -194,7 +194,7 @@ public final class DataFixerTransformation<N extends ConfigurationNode> implemen
             final ThreadLocal<Integer> versionHolder = new ThreadLocal<>();
             for (Pair<DSL.TypeReference, NodePath> fix : this.dataFixes) {
                 wrappedBuilder.addAction(fix.getSecond(), (path, valueAtPath) -> {
-                    valueAtPath.setValue(this.fixer.update(fix.getFirst(), ConfigurateOps.wrap(valueAtPath),
+                    valueAtPath.set(this.fixer.update(fix.getFirst(), ConfigurateOps.wrap(valueAtPath),
                             versionHolder.get(), this.targetVersion).getValue());
                     return null;
                 });

--- a/extra/dfu4/src/main/java/org/spongepowered/configurate/extra/dfu/v4/DfuSerializers.java
+++ b/extra/dfu4/src/main/java/org/spongepowered/configurate/extra/dfu/v4/DfuSerializers.java
@@ -40,7 +40,7 @@ public final class DfuSerializers {
      * @param <V> value type
      * @return a new serializer
      */
-    public static <V> TypeSerializer<V> forCodec(final Codec<V> codec) {
+    public static <V> TypeSerializer<V> serializer(final Codec<V> codec) {
         return new CodecSerializer<>(requireNonNull(codec, "codec"));
     }
 
@@ -53,8 +53,8 @@ public final class DfuSerializers {
      * @return a codec for the type, or null if an appropriate
      *      {@link TypeSerializer} could not be found.
      */
-    public static <S> @Nullable Codec<S> forSerializer(final TypeToken<S> type) {
-        return forSerializer(requireNonNull(type, "type"), TypeSerializerCollection.defaults());
+    public static <S> @Nullable Codec<S> codec(final TypeToken<S> type) {
+        return codec(requireNonNull(type, "type"), TypeSerializerCollection.defaults());
     }
 
     /**
@@ -66,12 +66,12 @@ public final class DfuSerializers {
      * @return a codec, or null if an appropriate {@link TypeSerializer}
      *      could not be found for the TypeToken.
      */
-    public static <V> @Nullable Codec<V> forSerializer(final TypeToken<V> type, final TypeSerializerCollection collection) {
+    public static <V> @Nullable Codec<V> codec(final TypeToken<V> type, final TypeSerializerCollection collection) {
         final @Nullable TypeSerializer<V> serial = collection.get(requireNonNull(type, "type"));
         if (serial == null) {
             return null;
         }
-        return new TypeSerializerCodec<>(type, serial, ConfigurateOps.getForSerializers(collection)).withLifecycle(Lifecycle.stable());
+        return new TypeSerializerCodec<>(type, serial, ConfigurateOps.forSerializers(collection)).withLifecycle(Lifecycle.stable());
     }
 
 }

--- a/extra/dfu4/src/main/java/org/spongepowered/configurate/extra/dfu/v4/NodeMaplike.java
+++ b/extra/dfu4/src/main/java/org/spongepowered/configurate/extra/dfu/v4/NodeMaplike.java
@@ -56,7 +56,7 @@ final class NodeMaplike implements MapLike<ConfigurationNode> {
     @Override
     public Stream<Pair<ConfigurationNode, ConfigurationNode>> entries() {
         return this.node.entrySet().stream()
-                .map(ent -> Pair.of(BasicConfigurationNode.root(this.options).setValue(ent.getKey()), this.ops.guardOutputRead(ent.getValue())));
+                .map(ent -> Pair.of(BasicConfigurationNode.root(this.options).set(ent.getKey()), this.ops.guardOutputRead(ent.getValue())));
     }
 
 }

--- a/extra/dfu4/src/test/java/org/spongepowered/configurate/extra/dfu/v4/ConfigurateOpsTests.java
+++ b/extra/dfu4/src/test/java/org/spongepowered/configurate/extra/dfu/v4/ConfigurateOpsTests.java
@@ -63,7 +63,7 @@ public final class ConfigurateOpsTests {
     private static void compareToJson(final ConfigurationNode node, final JsonElement element) throws IOException {
         final StringWriter configurate = new StringWriter();
         final GsonConfigurationLoader loader = GsonConfigurationLoader.builder()
-                .setSink(() -> new BufferedWriter(configurate)).build();
+                .sink(() -> new BufferedWriter(configurate)).build();
         loader.save(node);
 
         final StringWriter json = new StringWriter();
@@ -90,7 +90,7 @@ public final class ConfigurateOpsTests {
     @DisplayName("Configurate (Empty) -> Gson (Null)")
     void emptyToGson() {
         final ConfigurationNode node = BasicConfigurationNode.root();
-        final Dynamic<ConfigurationNode> wrapped = new Dynamic<>(ConfigurateOps.getInstance(), node);
+        final Dynamic<ConfigurationNode> wrapped = new Dynamic<>(ConfigurateOps.instance(), node);
         final JsonElement element = wrapped.convert(JsonOps.INSTANCE).getValue();
 
         assertTrue(element.isJsonNull(), "Resulting element was not a json null");
@@ -101,7 +101,7 @@ public final class ConfigurateOpsTests {
     void emptyFromGson() {
         final JsonNull jsonNull = JsonNull.INSTANCE;
         final Dynamic<JsonElement> wrapped = new Dynamic<>(JsonOps.INSTANCE, jsonNull);
-        final ConfigurationNode result = wrapped.convert(ConfigurateOps.getInstance()).getValue();
+        final ConfigurationNode result = wrapped.convert(ConfigurateOps.instance()).getValue();
 
         assertTrue(result.isEmpty(), "Resulting configuration node was not empty");
     }
@@ -109,8 +109,8 @@ public final class ConfigurateOpsTests {
     @Test
     @DisplayName("Configurate (String) -> Gson")
     void toGsonFromString() {
-        final ConfigurationNode node = BasicConfigurationNode.root().setValue("Test String");
-        final Dynamic<ConfigurationNode> wrapped = new Dynamic<>(ConfigurateOps.getInstance(), node);
+        final ConfigurationNode node = BasicConfigurationNode.root().set("Test String");
+        final Dynamic<ConfigurationNode> wrapped = new Dynamic<>(ConfigurateOps.instance(), node);
         final JsonElement output = wrapped.convert(JsonOps.INSTANCE).getValue();
 
         assertTrue(output instanceof JsonPrimitive, "Resulting Element was not a Json Primitive");
@@ -123,9 +123,9 @@ public final class ConfigurateOpsTests {
     void fromGsonFromString() {
         final JsonPrimitive string = new JsonPrimitive("Test String");
         final Dynamic<JsonElement> wrapped = new Dynamic<>(JsonOps.INSTANCE, string);
-        final ConfigurationNode output = wrapped.convert(ConfigurateOps.getInstance()).getValue();
+        final ConfigurationNode output = wrapped.convert(ConfigurateOps.instance()).getValue();
 
-        assertTrue(output.getValue() instanceof String, "Resulting configuration node was not a String");
+        assertTrue(output.get() instanceof String, "Resulting configuration node was not a String");
         assertEquals(output.getString(), "Test String");
     }
 
@@ -142,12 +142,12 @@ public final class ConfigurateOpsTests {
         jsonArray.add(3);
         jsonArray.add(4);
         final Dynamic<JsonElement> wrapped = new Dynamic<>(JsonOps.INSTANCE, jsonArray);
-        final ConfigurationNode output = wrapped.convert(ConfigurateOps.getInstance()).getValue();
+        final ConfigurationNode output = wrapped.convert(ConfigurateOps.instance()).getValue();
 
         assertTrue(output.isList(), "Resulting configuration node was not a list.");
-        assertEquals(3, output.getChildrenList().size(),
+        assertEquals(3, output.childrenList().size(),
                 "Resulting configuration node had wrong amount of child elements in list");
-        assertTrue(output.getChildrenList().stream()
+        assertTrue(output.childrenList().stream()
                         .map(ConfigurationNode::getInt)
                         .collect(Collectors.toList()).containsAll(expectedElements),
                 "Resulting configuration node did not contain every element in original JsonArray");
@@ -162,9 +162,9 @@ public final class ConfigurateOpsTests {
         expectedElements.add(4);
 
         final ConfigurationNode node = BasicConfigurationNode.root();
-        node.setValue(expectedElements);
+        node.set(expectedElements);
         //node.appendListNode().setValue(1).setValue(3).setValue(4);
-        final Dynamic<ConfigurationNode> wrapped = new Dynamic<>(ConfigurateOps.getInstance(), node);
+        final Dynamic<ConfigurationNode> wrapped = new Dynamic<>(ConfigurateOps.instance(), node);
         final JsonElement output = wrapped.convert(JsonOps.INSTANCE).getValue();
 
         assertTrue(output.isJsonArray(), "Resulting Element was not an array");
@@ -187,11 +187,11 @@ public final class ConfigurateOpsTests {
         object.addProperty("foo", "bar");
         object.addProperty("bar", "baz");
         final Dynamic<JsonElement> wrapped = new Dynamic<>(JsonOps.INSTANCE, object);
-        final ConfigurationNode output = wrapped.convert(ConfigurateOps.getInstance()).getValue();
+        final ConfigurationNode output = wrapped.convert(ConfigurateOps.instance()).getValue();
 
         assertTrue(output.isMap(), "Resulting configuration node was not a map");
-        assertEquals(2, output.getChildrenMap().size(), "Resulting configuration node had wrong amount of child elements");
-        assertEquals(expectedValues, output.getValue(new TypeToken<Map<String, String>>() {
+        assertEquals(2, output.childrenMap().size(), "Resulting configuration node had wrong amount of child elements");
+        assertEquals(expectedValues, output.get(new TypeToken<Map<String, String>>() {
         }));
     }
 
@@ -203,8 +203,8 @@ public final class ConfigurateOpsTests {
         expectedValues.put("bar", "baz");
 
         final ConfigurationNode node = BasicConfigurationNode.root();
-        node.setValue(expectedValues);
-        final Dynamic<ConfigurationNode> wrapped = new Dynamic<>(ConfigurateOps.getInstance(), node);
+        node.set(expectedValues);
+        final Dynamic<ConfigurationNode> wrapped = new Dynamic<>(ConfigurateOps.instance(), node);
         final JsonElement element = wrapped.convert(JsonOps.INSTANCE).getValue();
 
         assertTrue(element.isJsonObject(), "Resulting element was not a json object");
@@ -225,9 +225,9 @@ public final class ConfigurateOpsTests {
         final JsonElement compressedBlocks = assertResult(listCodec.encode(positions, JsonOps.COMPRESSED, JsonOps.COMPRESSED.empty()));
         final JsonElement regularBlocks = assertResult(listCodec.encode(positions, JsonOps.INSTANCE, JsonOps.INSTANCE.empty()));
         final ConfigurationNode compressedNode = assertResult(listCodec.encode(positions,
-                                                                ConfigurateOps.getInstance(true), BasicConfigurationNode.root()));
+                                                                ConfigurateOps.instance(true), BasicConfigurationNode.root()));
         final ConfigurationNode uncompressedNode = assertResult(listCodec.encode(positions,
-                                                                ConfigurateOps.getInstance(false), BasicConfigurationNode.root()));
+                                                                ConfigurateOps.instance(false), BasicConfigurationNode.root()));
 
         compareToJson(compressedNode, compressedBlocks);
         compareToJson(uncompressedNode, regularBlocks);

--- a/extra/dfu4/src/test/java/org/spongepowered/configurate/extra/dfu/v4/DfuSerializersTest.java
+++ b/extra/dfu4/src/test/java/org/spongepowered/configurate/extra/dfu/v4/DfuSerializersTest.java
@@ -63,16 +63,16 @@ public class DfuSerializersTest {
     @Test
     void testCodecSerializer() throws ObjectMappingException {
         final TypeSerializerCollection serializers = TypeSerializerCollection.defaults().childBuilder()
-            .register(VEC3I_TYPE, DfuSerializers.forCodec(VEC3I_CODEC))
+            .register(VEC3I_TYPE, DfuSerializers.serializer(VEC3I_CODEC))
             .build();
 
-        final ConfigurationNode testElement = BasicConfigurationNode.root(ConfigurationOptions.defaults().withSerializers(serializers), n -> {
-            n.appendListNode().setValue(4);
-            n.appendListNode().setValue(5);
-            n.appendListNode().setValue(8);
+        final ConfigurationNode testElement = BasicConfigurationNode.root(ConfigurationOptions.defaults().serializers(serializers), n -> {
+            n.appendListNode().set(4);
+            n.appendListNode().set(5);
+            n.appendListNode().set(8);
         });
 
-        final Vector3i pos = testElement.getValue(VEC3I_TYPE);
+        final Vector3i pos = testElement.get(VEC3I_TYPE);
 
         assertEquals(new Vector3i(4, 5, 8), pos);
     }
@@ -90,10 +90,10 @@ public class DfuSerializersTest {
     @Test
     void testSerializerCodec() throws IOException {
         final TypeSerializerCollection serializers = TypeSerializerCollection.defaults().childBuilder()
-            .register(VEC3I_TYPE, DfuSerializers.forCodec(VEC3I_CODEC))
+            .register(VEC3I_TYPE, DfuSerializers.serializer(VEC3I_CODEC))
             .build();
 
-        final @Nullable Codec<TestSerializable> codec = DfuSerializers.forSerializer(TypeToken.get(TestSerializable.class), serializers);
+        final @Nullable Codec<TestSerializable> codec = DfuSerializers.codec(TypeToken.get(TestSerializable.class), serializers);
         assertNotNull(codec);
 
         final DataResult<JsonElement> out = codec.encode(new TestSerializable(), JsonOps.INSTANCE, JsonOps.INSTANCE.empty());

--- a/extra/guice/src/main/java/org/spongepowered/configurate/objectmapping/guice/GuiceObjectMapperProvider.java
+++ b/extra/guice/src/main/java/org/spongepowered/configurate/objectmapping/guice/GuiceObjectMapperProvider.java
@@ -62,7 +62,7 @@ public final class GuiceObjectMapperProvider {
      * @return new discoverer
      */
     public static FieldDiscoverer<?> injectedObjectDiscoverer(final Injector injector) {
-        return FieldDiscoverer.ofObject(type -> {
+        return FieldDiscoverer.object(type -> {
             try {
                 final Provider<?> prov = injector.getProvider(Key.get(type.getType()));
                 return prov::get;

--- a/extra/kotlin/src/main/kotlin/org/spongepowered/configurate/kotlin/Builders.kt
+++ b/extra/kotlin/src/main/kotlin/org/spongepowered/configurate/kotlin/Builders.kt
@@ -44,7 +44,7 @@ fun attributed(
     init: AttributedConfigurationNode.() -> Unit
 ): AttributedConfigurationNode {
     val node = AttributedConfigurationNode.root(nodeName, options)
-    node.attributes = mapOf(*attributes)
+    node.attributes(mapOf(*attributes))
     node.init()
     return node
 }

--- a/extra/kotlin/src/main/kotlin/org/spongepowered/configurate/kotlin/Extensions.kt
+++ b/extra/kotlin/src/main/kotlin/org/spongepowered/configurate/kotlin/Extensions.kt
@@ -19,27 +19,14 @@ package org.spongepowered.configurate.kotlin
 import org.spongepowered.configurate.ConfigurationNode
 import org.spongepowered.configurate.ConfigurationNodeFactory
 import org.spongepowered.configurate.ConfigurationOptions
-import org.spongepowered.configurate.ScopedConfigurationNode
 import org.spongepowered.configurate.objectmapping.ObjectMappingException
 import org.spongepowered.configurate.transformation.NodePath
-
-operator fun <T : ScopedConfigurationNode<T>> T.get(path: Any): T {
-    return getNode(path)
-}
-
-operator fun <T : ScopedConfigurationNode<T>> T.get(vararg path: Any): T {
-    return getNode(*path)
-}
-
-operator fun ConfigurationNode.set(vararg path: Any, value: Any?) {
-    getNode(*path).value = value
-}
 
 /**
  * Multi level contains
  */
 operator fun ConfigurationNode.contains(path: Array<Any>): Boolean {
-    return !getNode(*path).isVirtual
+    return !node(*path).virtual()
 }
 
 /**
@@ -48,22 +35,22 @@ operator fun ConfigurationNode.contains(path: Array<Any>): Boolean {
  * @param path a single path element
  */
 operator fun ConfigurationNode.contains(path: Any): Boolean {
-    return !getNode(path).isVirtual
+    return !node(path).virtual()
 }
 
 @Throws(ObjectMappingException::class)
-inline fun <reified V> ConfigurationNode.get(): V? {
-    return getValue(typeTokenOf<V>(), null as V?)
+inline fun <reified V> ConfigurationNode.typedGet(): V? {
+    return get(typeTokenOf<V>(), null as V?)
 }
 
 @Throws(ObjectMappingException::class)
-inline fun <reified V> ConfigurationNode.get(default: V): V {
-    return getValue(typeTokenOf(), default)
+inline fun <reified V> ConfigurationNode.typedGet(default: V): V {
+    return get(typeTokenOf(), default)
 }
 
 @Throws(ObjectMappingException::class)
-inline fun <reified V> ConfigurationNode.set(value: V?) {
-    setValue(typeTokenOf(), value)
+inline fun <reified V> ConfigurationNode.typedSet(value: V?) {
+    set(typeTokenOf(), value)
 }
 
 operator fun <N : ConfigurationNode> ConfigurationNodeFactory<N>.invoke(options: ConfigurationOptions = defaultOptions()): N =
@@ -73,7 +60,7 @@ operator fun <N : ConfigurationNode> ConfigurationNodeFactory<N>.invoke(options:
  * Concatenate `this` with another [NodePath].
  */
 operator fun NodePath.plus(other: NodePath): NodePath {
-    return NodePath.create(
+    return NodePath.of(
         Array(this.size() + other.size()) {
             if (it < size()) {
                 this[it]

--- a/extra/kotlin/src/main/kotlin/org/spongepowered/configurate/kotlin/ObjectMapping.kt
+++ b/extra/kotlin/src/main/kotlin/org/spongepowered/configurate/kotlin/ObjectMapping.kt
@@ -75,7 +75,7 @@ inline fun <reified T> T.toNode(target: ConfigurationNode) {
  * Create an object mapper with the given [Factory] for objects of type [T],
  * accepting parameterized types.
  */
-inline fun <reified T> Factory.get(): ObjectMapper<T> {
+inline fun <reified T> Factory.typedGet(): ObjectMapper<T> {
     return get(typeTokenOf())
 }
 
@@ -83,7 +83,7 @@ inline fun <reified T> Factory.get(): ObjectMapper<T> {
  * Get the appropriate [TypeSerializer] for the provided type [T], or null if
  * none is applicable.
  */
-inline fun <reified T> TypeSerializerCollection.get(): TypeSerializer<T>? {
+inline fun <reified T> TypeSerializerCollection.typedGet(): TypeSerializer<T>? {
     return get(typeTokenOf())
 }
 

--- a/extra/kotlin/src/main/kotlin/org/spongepowered/configurate/kotlin/Publishers.kt
+++ b/extra/kotlin/src/main/kotlin/org/spongepowered/configurate/kotlin/Publishers.kt
@@ -71,7 +71,7 @@ suspend fun <V : Any> Flow<V>.asPublisher(): Publisher<V> = coroutineScope {
 
 private class FlowPublisher<V>(val flow: Flow<V>, val scope: CoroutineScope) : Publisher<V> {
     private val executor = Executor { task -> scope.launch { task.run() } }
-    override fun getExecutor(): Executor = this.executor
+    override fun executor(): Executor = this.executor
 
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun subscribe(subscriber: Subscriber<in V>): Disposable {

--- a/extra/kotlin/src/main/kotlin/org/spongepowered/configurate/kotlin/ReferenceExtensions.kt
+++ b/extra/kotlin/src/main/kotlin/org/spongepowered/configurate/kotlin/ReferenceExtensions.kt
@@ -29,11 +29,11 @@ inline fun <reified T : Any, N : ScopedConfigurationNode<N>> ConfigurationRefere
     return this.referenceTo(typeTokenOf(), *path)
 }
 
-operator fun ConfigurationReference<*>.set(vararg path: Any, value: Any?) {
-    node.getNode(*path).value = value
+fun ConfigurationReference<*>.set(vararg path: Any, value: Any?) {
+    node().node(*path).set(value)
 }
 
 @JvmName("set\$serialized")
-inline operator fun <reified V> ConfigurationReference<*>.set(vararg path: Any, value: V?) {
-    node.getNode(*path).setValue(typeTokenOf(), value)
+inline fun <reified V> ConfigurationReference<*>.set(vararg path: Any, value: V?) {
+    node().node(*path).set(typeTokenOf(), value)
 }

--- a/extra/kotlin/src/test/kotlin/org/spongepowered/configurate/kotlin/BuildersTest.kt
+++ b/extra/kotlin/src/test/kotlin/org/spongepowered/configurate/kotlin/BuildersTest.kt
@@ -26,13 +26,13 @@ class BuildersTest {
     @Test
     fun testBuildAttributed() {
         attributed("ServerPack", "version" to "1.15.2", "url" to "https://permissionsex.stellardrift.ca") {
-            this["a"] = "Hello"
-            this["Game, over"] = 5
+            this.node("a").set("Hello")
+            this.node("Game, over").set(5)
             child("Haa") {
-                value = "nope"
+                set("nope")
             }
             child("list", "parameter" to "test") {
-                setComment("I'm a list!")
+                comment("I'm a list!")
                 this += "hello"
                 this += "world"
             }
@@ -43,9 +43,9 @@ class BuildersTest {
     fun testBuildCommented() {
         commented {
             child("a", value = "b") {
-                setComment("The most important thing")
+                comment("The most important thing")
             }
-            this["cow"] = "potato"
+            this.node("cow").set("potato")
             set(UUID.randomUUID())
         }
     }
@@ -53,8 +53,8 @@ class BuildersTest {
     @Test
     fun testBuildBasic() {
         node {
-            this["test"] = "hello"
-            this["value"].set(URL("https://spongepowered.org"))
+            this.node("test").set("hello")
+            this.node("value").set(URL::class.java, URL("https://spongepowered.org"))
         }
     }
 }
@@ -66,9 +66,9 @@ private val NO_VALUE: Any = Any()
 // Creating children
 
 fun <N : ScopedConfigurationNode<N>> N.child(vararg path: Any, value: Any? = NO_VALUE, init: N.() -> Unit = {}) {
-    val node = this.getNode(*path)
+    val node = this.node(*path)
     if (value != NO_VALUE) {
-        node.value = value
+        node.set(value)
     }
     node.init()
 }
@@ -84,18 +84,18 @@ fun AttributedConfigurationNode.child(
     vararg attributes: Pair<String, String>,
     init: AttributedConfigurationNode.() -> Unit
 ): AttributedConfigurationNode {
-    val node = this[key]
-    tagName = key
+    val node = this.node(key)
+    tagName(key)
     if (value != NO_VALUE) {
-        node.value = value
+        node.set(value)
     }
     if (!attributes.isEmpty()) {
-        node.attributes = mapOf(*attributes)
+        node.attributes(mapOf(*attributes))
     }
     node.init()
     return node
 }
 
 operator fun <N : ScopedConfigurationNode<N>> N.plusAssign(value: Any?) {
-    appendListNode().value = value
+    appendListNode().set(value)
 }

--- a/extra/kotlin/src/test/kotlin/org/spongepowered/configurate/kotlin/ObjectMappingTest.kt
+++ b/extra/kotlin/src/test/kotlin/org/spongepowered/configurate/kotlin/ObjectMappingTest.kt
@@ -34,8 +34,8 @@ class ObjectMappingTest {
     @Test
     fun `deserialize to data class`() {
         val source = node {
-            this["deny-message"] = "you're not allowed to do that!"
-            this["match"] = "[uo]w[uo]"
+            this.node("deny-message").set("you're not allowed to do that!")
+            this.node("match").set("[uo]w[uo]")
         }
         val deserialized = objectMapper<SimpleTest>().load(source)
 
@@ -51,8 +51,8 @@ class ObjectMappingTest {
 
         objectMapper<SimpleTest>().save(source, node)
 
-        assertEquals("goodbye", node["deny-message"].value)
-        assertEquals("i'm leaving", node["match"].value)
+        assertEquals("goodbye", node.node("deny-message").get())
+        assertEquals("i'm leaving", node.node("match").get())
     }
 
     data class AnnotatedTest(
@@ -68,15 +68,15 @@ class ObjectMappingTest {
         val mapper = objectMapper<AnnotatedTest>()
         mapper.save(data, node)
 
-        assertEquals("purr", node["name"].value)
-        assertEquals("sad", node["name"].comment)
-        assertEquals("SHOUTING", node["attributes"].value)
+        assertEquals("purr", node.node("name").get())
+        assertEquals("sad", node.node("name").comment())
+        assertEquals("SHOUTING", node.node("attributes").get())
 
         assertThrows<ObjectMappingException> {
             mapper.load(
                 node {
-                    this["name"] = "meow"
-                    this["attributes"] = "quiet" // does not match regex
+                    this.node("name").set("meow")
+                    this.node("attributes").set("quiet") // does not match regex
                 }
             )
         }
@@ -93,8 +93,8 @@ class ObjectMappingTest {
     fun `collections are initialized implicitly`() {
         val node = CommentedConfigurationNode.root(
             ConfigurationOptions.defaults()
-                .withImplicitInitialization(true)
-                .withSerializers { it.registerAnnotatedObjects(objectMapperFactory()) }
+                .implicitInitialization(true)
+                .serializers { it.registerAnnotatedObjects(objectMapperFactory()) }
         )
 
         val tester = objectMapper<ImplicitTest>().load(node)

--- a/format/gson/src/main/java/org/spongepowered/configurate/gson/GsonConfigurationLoader.java
+++ b/format/gson/src/main/java/org/spongepowered/configurate/gson/GsonConfigurationLoader.java
@@ -74,7 +74,7 @@ public final class GsonConfigurationLoader extends AbstractConfigurationLoader<B
          * @return this builder (for chaining)
          */
         @NonNull
-        public Builder setIndent(final int indent) {
+        public Builder indent(final int indent) {
             this.indent = indent;
             return this;
         }
@@ -84,7 +84,7 @@ public final class GsonConfigurationLoader extends AbstractConfigurationLoader<B
          *
          * @return the indent level
          */
-        public int getIndent() {
+        public int indent() {
             return this.indent;
         }
 
@@ -96,7 +96,7 @@ public final class GsonConfigurationLoader extends AbstractConfigurationLoader<B
          * @return this builder (for chaining)
          */
         @NonNull
-        public Builder setLenient(final boolean lenient) {
+        public Builder lenient(final boolean lenient) {
             this.lenient = lenient;
             return this;
         }
@@ -106,13 +106,13 @@ public final class GsonConfigurationLoader extends AbstractConfigurationLoader<B
          *
          * @return whether the parser should parse leniently
          */
-        public boolean isLenient() {
+        public boolean lenient() {
             return this.lenient;
         }
 
         @Override
         public @NonNull GsonConfigurationLoader build() {
-            this.setDefaultOptions(o -> o.withNativeTypes(NATIVE_TYPES));
+            this.defaultOptions(o -> o.nativeTypes(NATIVE_TYPES));
             return new GsonConfigurationLoader(this);
         }
     }
@@ -122,8 +122,8 @@ public final class GsonConfigurationLoader extends AbstractConfigurationLoader<B
 
     private GsonConfigurationLoader(final Builder builder) {
         super(builder, new CommentHandler[] {CommentHandlers.DOUBLE_SLASH, CommentHandlers.SLASH_BLOCK, CommentHandlers.HASH});
-        this.lenient = builder.isLenient();
-        this.indent = Strings.repeat(" ", builder.getIndent());
+        this.lenient = builder.lenient();
+        this.indent = Strings.repeat(" ", builder.indent());
     }
 
     @Override
@@ -149,17 +149,17 @@ public final class GsonConfigurationLoader extends AbstractConfigurationLoader<B
                 parseArray(parser, node);
                 break;
             case NUMBER:
-                node.setValue(readNumber(parser));
+                node.set(readNumber(parser));
                 break;
             case STRING:
-                node.setValue(parser.nextString());
+                node.set(parser.nextString());
                 break;
             case BOOLEAN:
-                node.setValue(parser.nextBoolean());
+                node.set(parser.nextBoolean());
                 break;
             case NULL: // Ignored values
                 parser.nextNull();
-                node.setValue(null);
+                node.set(null);
                 break;
             case NAME:
                 break;
@@ -192,7 +192,7 @@ public final class GsonConfigurationLoader extends AbstractConfigurationLoader<B
                     parser.endArray();
                     // ensure the type is preserved
                     if (!written) {
-                        node.setValue(Collections.emptyList());
+                        node.set(Collections.emptyList());
                     }
                     return;
                 default:
@@ -216,11 +216,11 @@ public final class GsonConfigurationLoader extends AbstractConfigurationLoader<B
                     parser.endObject();
                     // ensure the type is preserved
                     if (!written) {
-                        node.setValue(Collections.emptyMap());
+                        node.set(Collections.emptyMap());
                     }
                     return;
                 case NAME:
-                    parseValue(parser, node.getNode(parser.nextName()));
+                    parseValue(parser, node.node(parser.nextName()));
                     written = true;
                     break;
                 default:
@@ -245,7 +245,7 @@ public final class GsonConfigurationLoader extends AbstractConfigurationLoader<B
 
     @Override
     public BasicConfigurationNode createNode(ConfigurationOptions options) {
-        options = options.withNativeTypes(NATIVE_TYPES);
+        options = options.nativeTypes(NATIVE_TYPES);
         return BasicConfigurationNode.root(options);
     }
 

--- a/format/gson/src/main/java/org/spongepowered/configurate/gson/GsonVisitor.java
+++ b/format/gson/src/main/java/org/spongepowered/configurate/gson/GsonVisitor.java
@@ -48,9 +48,9 @@ class GsonVisitor implements ConfigurationVisitor<ConfigurationNode, JsonWriter,
 
     @Override
     public void enterNode(final ConfigurationNode node, final JsonWriter state) throws IOException {
-        final @Nullable ConfigurationNode parent = node.getParent();
+        final @Nullable ConfigurationNode parent = node.parent();
         if (node != this.start && parent != null && parent.isMap()) {
-            state.name(requireNonNull(node.getKey(), "Node must have key to be a value in a mapping").toString());
+            state.name(requireNonNull(node.key(), "Node must have key to be a value in a mapping").toString());
         }
     }
 
@@ -66,7 +66,7 @@ class GsonVisitor implements ConfigurationVisitor<ConfigurationNode, JsonWriter,
 
     @Override
     public void enterScalarNode(final ConfigurationNode node, final JsonWriter writer) throws IOException {
-        final @Nullable Object value = node.getValue();
+        final @Nullable Object value = node.get();
         if (value == null) {
             writer.nullValue();
         } else if (value instanceof Double) {

--- a/format/gson/src/test/java/org/spongepowered/configurate/gson/GsonConfigurationLoaderTest.java
+++ b/format/gson/src/test/java/org/spongepowered/configurate/gson/GsonConfigurationLoaderTest.java
@@ -51,14 +51,14 @@ public class GsonConfigurationLoaderTest {
         final URL url = getClass().getResource("/example.json");
         final Path tempFile = tempDir.resolve("text1.txt");
         final ConfigurationLoader<BasicConfigurationNode> loader = GsonConfigurationLoader.builder()
-                .setSource(() -> new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8)))
-                .setSink(AtomicFiles.createAtomicWriterFactory(tempFile, StandardCharsets.UTF_8)).setLenient(true).build();
-        final ConfigurationNode node = loader.load(loader.defaultOptions().withMapFactory(MapFactories.sortedNatural()));
-        assertEquals("unicorn", node.getNode("test", "op-level").getValue());
-        assertEquals("dragon", node.getNode("other", "op-level").getValue());
-        assertEquals("dog park", node.getNode("other", "location").getValue());
-        assertTrue(node.getNode("int-val").getValue() instanceof Integer);
-        assertTrue(node.getNode("double-val").getValue() instanceof Double);
+                .source(() -> new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8)))
+                .sink(AtomicFiles.atomicWriterFactory(tempFile, StandardCharsets.UTF_8)).lenient(true).build();
+        final ConfigurationNode node = loader.load(loader.defaultOptions().mapFactory(MapFactories.sortedNatural()));
+        assertEquals("unicorn", node.node("test", "op-level").get());
+        assertEquals("dragon", node.node("other", "op-level").get());
+        assertEquals("dog park", node.node("other", "location").get());
+        assertTrue(node.node("int-val").get() instanceof Integer);
+        assertTrue(node.node("double-val").get() instanceof Double);
         loader.save(node);
         assertEquals(Resources.readLines(url, StandardCharsets.UTF_8), Files.readAllLines(tempFile, StandardCharsets.UTF_8));
     }
@@ -69,7 +69,7 @@ public class GsonConfigurationLoaderTest {
         tempFile.createNewFile();
 
         final ConfigurationLoader<BasicConfigurationNode> loader = GsonConfigurationLoader.builder()
-                .setFile(tempFile)
+                .file(tempFile)
                 .build();
 
         final BasicConfigurationNode n = BasicConfigurationNode.root();
@@ -82,7 +82,7 @@ public class GsonConfigurationLoaderTest {
         tempFile.createNewFile();
 
         final ConfigurationLoader<BasicConfigurationNode> loader = GsonConfigurationLoader.builder()
-                .setFile(tempFile)
+                .file(tempFile)
                 .build();
 
         loader.load();
@@ -93,11 +93,11 @@ public class GsonConfigurationLoaderTest {
         final URL url = getClass().getResource("/emptyObject.json");
         final Path tempFile = tempDir.resolve("text4.txt");
         final ConfigurationLoader<BasicConfigurationNode> loader = GsonConfigurationLoader.builder()
-                .setSource(() -> new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8)))
-                .setSink(AtomicFiles.createAtomicWriterFactory(tempFile, StandardCharsets.UTF_8)).setLenient(true).build();
+                .source(() -> new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8)))
+                .sink(AtomicFiles.atomicWriterFactory(tempFile, StandardCharsets.UTF_8)).lenient(true).build();
 
-        final ConfigurationNode node = loader.load(loader.defaultOptions().withMapFactory(MapFactories.sortedNatural()));
-        assertEquals(ImmutableMap.of(), node.getValue());
+        final ConfigurationNode node = loader.load(loader.defaultOptions().mapFactory(MapFactories.sortedNatural()));
+        assertEquals(ImmutableMap.of(), node.get());
         assertTrue(node.isMap());
     }
 
@@ -106,19 +106,19 @@ public class GsonConfigurationLoaderTest {
     @Test
     void testRoundtrippingLong(final @TempDir Path tempDir) throws IOException {
         final Path tempFile = tempDir.resolve("text5.txt");
-        final ConfigurationLoader<BasicConfigurationNode> loader = GsonConfigurationLoader.builder().setPath(tempFile).build();
+        final ConfigurationLoader<BasicConfigurationNode> loader = GsonConfigurationLoader.builder().path(tempFile).build();
         final BasicConfigurationNode start = loader.createNode();
-        start.getNode("long-num").setValue(TEST_LONG_VAL);
+        start.node("long-num").set(TEST_LONG_VAL);
         loader.save(start);
 
         final BasicConfigurationNode ret = loader.load();
-        assertEquals(TEST_LONG_VAL, ret.getNode("long-num").getValue());
+        assertEquals(TEST_LONG_VAL, ret.node("long-num").get());
     }
 
     @Test
     void testPrimitiveTypes(final @TempDir Path tempDir) throws IOException {
         final Path tempFile = tempDir.resolve("text6.txt");
-        final GsonConfigurationLoader loader = GsonConfigurationLoader.builder().setPath(tempFile).build();
+        final GsonConfigurationLoader loader = GsonConfigurationLoader.builder().path(tempFile).build();
         final ConfigurationNode start = loader.createNode();
 
         final int ival = 452252;
@@ -128,30 +128,30 @@ public class GsonConfigurationLoaderTest {
         final boolean blval = true;
         final String stval = "Sphinx of black quartz, judge my vow";
 
-        start.getNode("int").setValue(ival);
-        start.getNode("long").setValue(lval);
-        start.getNode("float").setValue(fval);
-        start.getNode("double").setValue(dval);
-        start.getNode("boolean").setValue(blval);
-        start.getNode("string").setValue(stval);
+        start.node("int").set(ival);
+        start.node("long").set(lval);
+        start.node("float").set(fval);
+        start.node("double").set(dval);
+        start.node("boolean").set(blval);
+        start.node("string").set(stval);
 
         loader.save(start);
 
         final ConfigurationNode ret = loader.load();
-        assertEquals(ival, ret.getNode("int").getValue());
-        assertEquals(lval, ret.getNode("long").getValue());
-        assertEquals(fval, (double) ret.getNode("float").getValue(), 0.05);
-        assertEquals(dval, ret.getNode("double").getValue());
-        assertEquals(blval, ret.getNode("boolean").getValue());
-        assertEquals(stval, ret.getNode("string").getValue());
+        assertEquals(ival, ret.node("int").get());
+        assertEquals(lval, ret.node("long").get());
+        assertEquals(fval, (double) ret.node("float").get(), 0.05);
+        assertEquals(dval, ret.node("double").get());
+        assertEquals(blval, ret.node("boolean").get());
+        assertEquals(stval, ret.node("string").get());
     }
 
     @Test
     void testWriteNonRootNode() throws IOException {
         // https://github.com/SpongePowered/Configurate/issues/163
         final ConfigurationNode source = BasicConfigurationNode.root(n -> {
-            n.getNode("GriefPrevention", "claim-name", "text")
-                    .setValue("§4§9The §4T§6h§ea§2r§9o§5w §4Estate");
+            n.node("GriefPrevention", "claim-name", "text")
+                    .set("§4§9The §4T§6h§ea§2r§9o§5w §4Estate");
         });
 
         // Code from GriefDefender's ComponentConfigSerializer
@@ -159,12 +159,12 @@ public class GsonConfigurationLoaderTest {
         final StringWriter writer = new StringWriter();
 
         final GsonConfigurationLoader gsonLoader = GsonConfigurationLoader.builder()
-                .setIndent(0)
-                .setSink(() -> new BufferedWriter(writer))
-                .setHeaderMode(HeaderMode.NONE)
+                .indent(0)
+                .sink(() -> new BufferedWriter(writer))
+                .headerMode(HeaderMode.NONE)
                 .build();
 
-        gsonLoader.save(source.getNode("GriefPrevention", "claim-name"));
+        gsonLoader.save(source.node("GriefPrevention", "claim-name"));
 
         assertEquals("{\"text\":\"§4§9The §4T§6h§ea§2r§9o§5w §4Estate\"}", writer.toString().trim());
     }

--- a/format/hocon/src/test/java/org/spongepowered/configurate/hocon/HoconConfigurationLoaderTest.java
+++ b/format/hocon/src/test/java/org/spongepowered/configurate/hocon/HoconConfigurationLoaderTest.java
@@ -57,14 +57,14 @@ public class HoconConfigurationLoaderTest {
         final Path saveTest = tempDir.resolve("text1.txt");
 
         final HoconConfigurationLoader loader = HoconConfigurationLoader.builder()
-                .setSource(() -> new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8)))
-                .setSink(AtomicFiles.createAtomicWriterFactory(saveTest, StandardCharsets.UTF_8)).build();
+                .source(() -> new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8)))
+                .sink(AtomicFiles.atomicWriterFactory(saveTest, StandardCharsets.UTF_8)).build();
         final CommentedConfigurationNode node = loader.load();
-        assertEquals("unicorn", node.getNode("test", "op-level").getValue());
-        assertEquals("dragon", node.getNode("other", "op-level").getValue());
-        final CommentedConfigurationNode testNode = node.getNode("test");
-        assertEquals(" Test node", testNode.getComment());
-        assertEquals("dog park", node.getNode("other", "location").getValue());
+        assertEquals("unicorn", node.node("test", "op-level").get());
+        assertEquals("dragon", node.node("other", "op-level").get());
+        final CommentedConfigurationNode testNode = node.node("test");
+        assertEquals(" Test node", testNode.comment());
+        assertEquals("dog park", node.node("other", "location").get());
         loader.save(node);
         assertEquals(Resources.readLines(getClass().getResource("/roundtrip-test.conf"), StandardCharsets.UTF_8), Files
                 .readAllLines(saveTest, StandardCharsets.UTF_8));
@@ -74,8 +74,8 @@ public class HoconConfigurationLoaderTest {
     void testSplitLineCommentInput(final @TempDir Path tempDir) throws IOException {
         final Path saveTo = tempDir.resolve("text2.txt");
         final HoconConfigurationLoader loader = HoconConfigurationLoader.builder()
-                .setPath(saveTo)
-                .setUrl(getClass().getResource("/splitline-comment-input.conf"))
+                .path(saveTo)
+                .url(getClass().getResource("/splitline-comment-input.conf"))
                 .build();
         final CommentedConfigurationNode node = loader.load();
         loader.save(node);
@@ -88,11 +88,11 @@ public class HoconConfigurationLoaderTest {
     void testHeaderSaved(final @TempDir Path tempDir) throws IOException {
         final Path saveTo = tempDir.resolve("text3.txt");
         final HoconConfigurationLoader loader = HoconConfigurationLoader.builder()
-                .setPath(saveTo)
+                .path(saveTo)
                 .build();
-        final CommentedConfigurationNode node = loader.createNode(ConfigurationOptions.defaults().withHeader("Hi! I am a header!\n"
+        final CommentedConfigurationNode node = loader.createNode(ConfigurationOptions.defaults().header("Hi! I am a header!\n"
                         + "Look at meeeeeee!!!"));
-        node.getNode("node").setComment("I have a comment").getNode("party").setValue("now");
+        node.node("node").comment("I have a comment").node("party").set("now");
 
         loader.save(node);
         assertEquals(Resources.readLines(getClass().getResource("/header.conf"), StandardCharsets.UTF_8),
@@ -105,13 +105,13 @@ public class HoconConfigurationLoaderTest {
         final URL url = getClass().getResource("/comments-test.conf");
         final Path saveTo = tempDir.resolve("text4.txt");
         final HoconConfigurationLoader loader = HoconConfigurationLoader.builder()
-                .setPath(saveTo).setUrl(url).build();
+                .path(saveTo).url(url).build();
 
         final CommentedConfigurationNode node = loader.createNode(ConfigurationOptions.defaults());
-        node.getNode("test", "third").setValue(false).setComment("really?");
-        node.getNode("test", "apple").setComment("fruit").setValue(false);
-        node.getNode("test", "donut").setValue(true).setComment("tasty");
-        node.getNode("test", "guacamole").setValue(true).setComment("and chips?");
+        node.node("test", "third").set(false).comment("really?");
+        node.node("test", "apple").comment("fruit").set(false);
+        node.node("test", "donut").set(true).comment("tasty");
+        node.node("test", "guacamole").set(true).comment("and chips?");
 
         loader.save(node);
         assertEquals(Resources.readLines(url, StandardCharsets.UTF_8), Files.readAllLines(saveTo, StandardCharsets.UTF_8));
@@ -135,12 +135,12 @@ public class HoconConfigurationLoaderTest {
         final URL rsrc = getClass().getResource("/empty-values.conf");
         final Path output = tempDir.resolve("load-merge-empty.conf");
         final HoconConfigurationLoader loader = HoconConfigurationLoader.builder()
-                .setPath(output)
-                .setUrl(rsrc).build();
+                .path(output)
+                .url(rsrc).build();
 
         final CommentedConfigurationNode source = loader.load();
         final CommentedConfigurationNode destination = loader.createNode();
-        destination.mergeValuesFrom(source);
+        destination.mergeFrom(source);
         loader.save(source);
         assertLinesMatch(Resources.readLines(rsrc, StandardCharsets.UTF_8), Files.readAllLines(output, StandardCharsets.UTF_8));
         loader.save(destination);
@@ -165,9 +165,9 @@ public class HoconConfigurationLoaderTest {
         final URL rsrc = getClass().getResource("/empty-section.conf");
         final Path output = tempDir.resolve("empty-section.conf");
         final HoconConfigurationLoader loader = HoconConfigurationLoader.builder()
-                .setDefaultOptions(o -> o.withShouldCopyDefaults(true))
-                .setPath(output)
-                .setUrl(rsrc).build();
+                .defaultOptions(o -> o.shouldCopyDefaults(true))
+                .path(output)
+                .url(rsrc).build();
 
         final CommentedConfigurationNode source = loader.createNode();
         ObjectMapper.factory().get(OuterConfig.TYPE).load(source);

--- a/format/jackson/src/main/java/org/spongepowered/configurate/jackson/ConfiguratePrettyPrinter.java
+++ b/format/jackson/src/main/java/org/spongepowered/configurate/jackson/ConfiguratePrettyPrinter.java
@@ -42,7 +42,7 @@ class ConfiguratePrettyPrinter extends DefaultPrettyPrinter {
 
     @Override
     public void writeObjectFieldValueSeparator(final JsonGenerator jg) throws IOException {
-        jg.writeRaw(this.style.getValue());
+        jg.writeRaw(this.style.value());
     }
 
 }

--- a/format/jackson/src/main/java/org/spongepowered/configurate/jackson/FieldValueSeparatorStyle.java
+++ b/format/jackson/src/main/java/org/spongepowered/configurate/jackson/FieldValueSeparatorStyle.java
@@ -47,7 +47,7 @@ public enum FieldValueSeparatorStyle {
      *
      * @return literal separator value
      */
-    public String getValue() {
+    public String value() {
         return this.decorationType;
     }
 

--- a/format/jackson/src/main/java/org/spongepowered/configurate/jackson/JacksonConfigurationLoader.java
+++ b/format/jackson/src/main/java/org/spongepowered/configurate/jackson/JacksonConfigurationLoader.java
@@ -83,7 +83,7 @@ public final class JacksonConfigurationLoader extends AbstractConfigurationLoade
          * @return the json factory
          */
         @NonNull
-        public JsonFactoryBuilder getFactoryBuilder() {
+        public JsonFactoryBuilder factoryBuilder() {
             return this.factory;
         }
 
@@ -94,7 +94,7 @@ public final class JacksonConfigurationLoader extends AbstractConfigurationLoade
          * @return this builder (for chaining)
          */
         @NonNull
-        public Builder setIndent(final int indent) {
+        public Builder indent(final int indent) {
             this.indent = indent;
             return this;
         }
@@ -104,7 +104,7 @@ public final class JacksonConfigurationLoader extends AbstractConfigurationLoade
          *
          * @return the indent level
          */
-        public int getIndent() {
+        public int indent() {
             return this.indent;
         }
 
@@ -115,7 +115,7 @@ public final class JacksonConfigurationLoader extends AbstractConfigurationLoade
          * @return this builder (for chaining)
          */
         @NonNull
-        public Builder setFieldValueSeparatorStyle(final @NonNull FieldValueSeparatorStyle style) {
+        public Builder fieldValueSeparatorStyle(final @NonNull FieldValueSeparatorStyle style) {
             this.fieldValueSeparatorStyle = style;
             return this;
         }
@@ -126,14 +126,14 @@ public final class JacksonConfigurationLoader extends AbstractConfigurationLoade
          * @return the style
          */
         @NonNull
-        public FieldValueSeparatorStyle getFieldValueSeparatorStyle() {
+        public FieldValueSeparatorStyle fieldValueSeparatorStyle() {
             return this.fieldValueSeparatorStyle;
         }
 
         @NonNull
         @Override
         public JacksonConfigurationLoader build() {
-            setDefaultOptions(o -> o.withNativeTypes(NATIVE_TYPES));
+            defaultOptions(o -> o.nativeTypes(NATIVE_TYPES));
             return new JacksonConfigurationLoader(this);
         }
     }
@@ -144,10 +144,10 @@ public final class JacksonConfigurationLoader extends AbstractConfigurationLoade
 
     private JacksonConfigurationLoader(final Builder builder) {
         super(builder, new CommentHandler[]{CommentHandlers.DOUBLE_SLASH, CommentHandlers.SLASH_BLOCK, CommentHandlers.HASH});
-        this.factory = builder.getFactoryBuilder().build();
+        this.factory = builder.factoryBuilder().build();
         this.factory.disable(JsonParser.Feature.AUTO_CLOSE_SOURCE);
-        this.indent = builder.getIndent();
-        this.fieldValueSeparatorStyle = builder.getFieldValueSeparatorStyle();
+        this.indent = builder.indent();
+        this.fieldValueSeparatorStyle = builder.fieldValueSeparatorStyle();
     }
 
     @Override
@@ -170,25 +170,25 @@ public final class JacksonConfigurationLoader extends AbstractConfigurationLoade
             case VALUE_NUMBER_FLOAT:
                 final double doubleVal = parser.getDoubleValue();
                 if ((float) doubleVal != doubleVal) {
-                    node.setValue(parser.getDoubleValue());
+                    node.set(parser.getDoubleValue());
                 } else {
-                    node.setValue(parser.getFloatValue());
+                    node.set(parser.getFloatValue());
                 }
                 break;
             case VALUE_NUMBER_INT:
                 final long longVal = parser.getLongValue();
                 if ((int) longVal != longVal) {
-                    node.setValue(parser.getLongValue());
+                    node.set(parser.getLongValue());
                 } else {
-                    node.setValue(parser.getIntValue());
+                    node.set(parser.getIntValue());
                 }
                 break;
             case VALUE_STRING:
-                node.setValue(parser.getText());
+                node.set(parser.getText());
                 break;
             case VALUE_TRUE:
             case VALUE_FALSE:
-                node.setValue(parser.getBooleanValue());
+                node.set(parser.getBooleanValue());
                 break;
             case VALUE_NULL: // Ignored values
             case FIELD_NAME:
@@ -206,7 +206,7 @@ public final class JacksonConfigurationLoader extends AbstractConfigurationLoade
                 case END_ARRAY:
                     // ensure the type is preserved
                     if (!written) {
-                        node.setValue(Collections.emptyList());
+                        node.set(Collections.emptyList());
                     }
                     return;
                 default:
@@ -225,11 +225,11 @@ public final class JacksonConfigurationLoader extends AbstractConfigurationLoade
                 case END_OBJECT:
                     // ensure the type is preserved
                     if (!written) {
-                        node.setValue(Collections.emptyMap());
+                        node.set(Collections.emptyMap());
                     }
                     return;
                 default:
-                    parseValue(parser, node.getNode(parser.getCurrentName()));
+                    parseValue(parser, node.node(parser.getCurrentName()));
                     written = true;
             }
         }
@@ -248,7 +248,7 @@ public final class JacksonConfigurationLoader extends AbstractConfigurationLoade
     @NonNull
     @Override
     public BasicConfigurationNode createNode(@NonNull ConfigurationOptions options) {
-        options = options.withNativeTypes(NATIVE_TYPES);
+        options = options.nativeTypes(NATIVE_TYPES);
         return BasicConfigurationNode.root(options);
     }
 

--- a/format/jackson/src/main/java/org/spongepowered/configurate/jackson/JacksonVisitor.java
+++ b/format/jackson/src/main/java/org/spongepowered/configurate/jackson/JacksonVisitor.java
@@ -44,9 +44,9 @@ class JacksonVisitor implements ConfigurationVisitor<ConfigurationNode, JsonGene
     @Override
     public void enterNode(final ConfigurationNode node, final JsonGenerator generator) throws IOException {
         //generateComment(generator, ent.getValue(), false);
-        final @Nullable ConfigurationNode parent = node.getParent();
+        final @Nullable ConfigurationNode parent = node.parent();
         if (node != this.start && parent != null && parent.isMap()) {
-            generator.writeFieldName(requireNonNull(node.getKey(), "Node must have key to be a value in a mapping").toString());
+            generator.writeFieldName(requireNonNull(node.key(), "Node must have key to be a value in a mapping").toString());
         }
     }
 
@@ -87,7 +87,7 @@ class JacksonVisitor implements ConfigurationVisitor<ConfigurationNode, JsonGene
 
     @Override
     public void enterScalarNode(final ConfigurationNode node, final JsonGenerator generator) throws IOException {
-        final @Nullable Object value = node.getValue();
+        final @Nullable Object value = node.get();
         if (value instanceof Double) {
             generator.writeNumber((Double) value);
         } else if (value instanceof Float) {

--- a/format/xml/src/main/java/org/spongepowered/configurate/xml/XmlConfigurationLoader.java
+++ b/format/xml/src/main/java/org/spongepowered/configurate/xml/XmlConfigurationLoader.java
@@ -124,7 +124,7 @@ public final class XmlConfigurationLoader extends AbstractConfigurationLoader<At
          * @return this builder (for chaining)
          */
         @NonNull
-        public Builder setIndent(final int indent) {
+        public Builder indent(final int indent) {
             this.indent = indent;
             return this;
         }
@@ -134,7 +134,7 @@ public final class XmlConfigurationLoader extends AbstractConfigurationLoader<At
          *
          * @return the indent level
          */
-        public int getIndent() {
+        public int indent() {
             return this.indent;
         }
 
@@ -144,7 +144,7 @@ public final class XmlConfigurationLoader extends AbstractConfigurationLoader<At
          * @param schema the schema
          * @return this builder (for chaining)
          */
-        public Builder setSchema(final @Nullable Schema schema) {
+        public Builder schema(final @Nullable Schema schema) {
             this.schema = schema;
             return this;
         }
@@ -154,7 +154,7 @@ public final class XmlConfigurationLoader extends AbstractConfigurationLoader<At
          *
          * @return the schema
          */
-        public @Nullable Schema getSchema() {
+        public @Nullable Schema schema() {
             return this.schema;
         }
 
@@ -164,7 +164,7 @@ public final class XmlConfigurationLoader extends AbstractConfigurationLoader<At
          * @param defaultTagName the default tag name
          * @return this builder (for chaining)
          */
-        public Builder setDefaultTagName(final String defaultTagName) {
+        public Builder defaultTagName(final String defaultTagName) {
             this.defaultTagName = defaultTagName;
             return this;
         }
@@ -175,7 +175,7 @@ public final class XmlConfigurationLoader extends AbstractConfigurationLoader<At
          * @return the default tag name
          */
         @NonNull
-        public String getDefaultTagName() {
+        public String defaultTagName() {
             return this.defaultTagName;
         }
 
@@ -191,7 +191,7 @@ public final class XmlConfigurationLoader extends AbstractConfigurationLoader<At
          * @param writeExplicitType if the loader should write explicit types
          * @return this builder (for chaining)
          */
-        public Builder setWriteExplicitType(final boolean writeExplicitType) {
+        public Builder writesExplicitType(final boolean writeExplicitType) {
             this.writeExplicitType = writeExplicitType;
             return this;
         }
@@ -199,12 +199,12 @@ public final class XmlConfigurationLoader extends AbstractConfigurationLoader<At
         /**
          * Gets if explicit type attributes should be written by the loader.
          *
-         * <p>See the method doc at {@link #setWriteExplicitType(boolean)} for
+         * <p>See the method doc at {@link #writesExplicitType(boolean)} for
          * a more detailed explanation.</p>
          *
          * @return the default tag name
          */
-        public boolean shouldWriteExplicitType() {
+        public boolean writesExplicitType() {
             return this.writeExplicitType;
         }
 
@@ -216,7 +216,7 @@ public final class XmlConfigurationLoader extends AbstractConfigurationLoader<At
          *                              included
          * @return this builder (for chaining)
          */
-        public Builder setIncludeXmlDeclaration(final boolean includeXmlDeclaration) {
+        public Builder includesXmlDeclaration(final boolean includeXmlDeclaration) {
             this.includeXmlDeclaration = includeXmlDeclaration;
             return this;
         }
@@ -227,7 +227,7 @@ public final class XmlConfigurationLoader extends AbstractConfigurationLoader<At
          *
          * @return if the XML declaration should be included
          */
-        public boolean shouldIncludeXmlDeclaration() {
+        public boolean includesXmlDeclaration() {
             return this.includeXmlDeclaration;
         }
 
@@ -248,7 +248,7 @@ public final class XmlConfigurationLoader extends AbstractConfigurationLoader<At
          * @param resolvesExternalContent whether to resolve external entities
          * @return this builder
          */
-        public Builder setResolvesExternalContent(final boolean resolvesExternalContent) {
+        public Builder resolvesExternalContent(final boolean resolvesExternalContent) {
             this.resolvesExternalContent = resolvesExternalContent;
             return this;
         }
@@ -264,7 +264,7 @@ public final class XmlConfigurationLoader extends AbstractConfigurationLoader<At
 
         @Override
         public XmlConfigurationLoader build() {
-            setDefaultOptions(o -> o.withNativeTypes(NATIVE_TYPES));
+            defaultOptions(o -> o.nativeTypes(NATIVE_TYPES));
             return new XmlConfigurationLoader(this);
         }
     }
@@ -278,11 +278,11 @@ public final class XmlConfigurationLoader extends AbstractConfigurationLoader<At
 
     private XmlConfigurationLoader(final Builder builder) {
         super(builder, new CommentHandler[] {CommentHandlers.XML_STYLE});
-        this.schema = builder.getSchema();
-        this.defaultTagName = builder.getDefaultTagName();
-        this.indent = builder.getIndent();
-        this.writeExplicitType = builder.shouldWriteExplicitType();
-        this.includeXmlDeclaration = builder.shouldIncludeXmlDeclaration();
+        this.schema = builder.schema();
+        this.defaultTagName = builder.defaultTagName();
+        this.indent = builder.indent();
+        this.writeExplicitType = builder.writesExplicitType();
+        this.includeXmlDeclaration = builder.includesXmlDeclaration();
         this.resolvesExternalContent = builder.resolvesExternalContent();
     }
 
@@ -352,7 +352,7 @@ public final class XmlConfigurationLoader extends AbstractConfigurationLoader<At
             for (int i = 0; i < children.getLength(); ++i) {
                 final Node child = children.item(i);
                 if (child.getNodeType() == Node.COMMENT_NODE) {
-                    options = options.withHeader(unwrapHeader(child.getTextContent().trim()));
+                    options = options.header(unwrapHeader(child.getTextContent().trim()));
                 } else if (child.getNodeType() == Node.ELEMENT_NODE) {
                     final AttributedConfigurationNode node = createNode(options);
                     readElement(child, node);
@@ -409,11 +409,11 @@ public final class XmlConfigurationLoader extends AbstractConfigurationLoader<At
         @Nullable NodeType type = null;
 
         // copy the name of the tag
-        to.setTagName(from.getNodeName());
+        to.tagName(from.getNodeName());
 
         final String potentialComment = (String) from.getUserData(USER_DATA_COMMENT);
         if (potentialComment != null) {
-            to.setComment(potentialComment);
+            to.comment(potentialComment);
         }
 
         // copy attributes
@@ -465,7 +465,7 @@ public final class XmlConfigurationLoader extends AbstractConfigurationLoader<At
 
         // if there are no child nodes present, assume it's a scalar value
         if (children.isEmpty()) {
-            to.setValue(parseValue(from.getTextContent()));
+            to.set(parseValue(from.getTextContent()));
             return;
         }
 
@@ -483,16 +483,16 @@ public final class XmlConfigurationLoader extends AbstractConfigurationLoader<At
         }
 
         if (type == NodeType.MAP) {
-            to.setValue(Collections.emptyMap());
+            to.set(Collections.emptyMap());
         } else {
-            to.setValue(Collections.emptyList());
+            to.set(Collections.emptyList());
         }
 
         // read out the elements
         for (Map.Entry<String, Collection<Node>> entry : children.entrySet()) {
             AttributedConfigurationNode child;
             if (type == NodeType.MAP) {
-                child = to.getNode(entry.getKey());
+                child = to.node(entry.getKey());
                 readElement(entry.getValue().iterator().next(), child);
             } else {
                 for (Node element : entry.getValue()) {
@@ -541,7 +541,7 @@ public final class XmlConfigurationLoader extends AbstractConfigurationLoader<At
 
     private @Nullable Node createCommentNode(final Document doc, final ConfigurationNode node) {
         if (node instanceof CommentedConfigurationNodeIntermediary<?>) {
-            final @Nullable String comment = ((CommentedConfigurationNodeIntermediary<?>) node).getComment();
+            final @Nullable String comment = ((CommentedConfigurationNodeIntermediary<?>) node).comment();
             if (comment != null) {
                 return doc.createComment(" " + comment.trim() + " ");
             }
@@ -555,8 +555,8 @@ public final class XmlConfigurationLoader extends AbstractConfigurationLoader<At
 
         if (node instanceof AttributedConfigurationNode) {
             final AttributedConfigurationNode attributedNode = (AttributedConfigurationNode) node;
-            tag = attributedNode.getTagName();
-            attributes = attributedNode.getAttributes();
+            tag = attributedNode.tagName();
+            attributes = attributedNode.attributes();
         }
 
         final Element element = document.createElement(forcedTag == null ? tag : forcedTag);
@@ -565,7 +565,7 @@ public final class XmlConfigurationLoader extends AbstractConfigurationLoader<At
         }
 
         if (node.isMap()) {
-            for (final Map.Entry<Object, ? extends ConfigurationNode> child : node.getChildrenMap().entrySet()) {
+            for (final Map.Entry<Object, ? extends ConfigurationNode> child : node.childrenMap().entrySet()) {
                 appendCommentIfNecessary(element, child.getValue());
                 element.appendChild(writeNode(document, child.getValue(), child.getKey().toString()));
             }
@@ -573,12 +573,12 @@ public final class XmlConfigurationLoader extends AbstractConfigurationLoader<At
             if (this.writeExplicitType) {
                 element.setAttribute(ATTRIBUTE_TYPE, "list");
             }
-            for (final ConfigurationNode child : node.getChildrenList()) {
+            for (final ConfigurationNode child : node.childrenList()) {
                 appendCommentIfNecessary(element, child);
                 element.appendChild(writeNode(document, child, null));
             }
         } else {
-            element.appendChild(document.createTextNode(Objects.toString(node.getValue())));
+            element.appendChild(document.createTextNode(Objects.toString(node.get())));
         }
 
         return element;
@@ -586,7 +586,7 @@ public final class XmlConfigurationLoader extends AbstractConfigurationLoader<At
 
     @Override
     public AttributedConfigurationNode createNode(ConfigurationOptions options) {
-        options = options.withNativeTypes(NATIVE_TYPES);
+        options = options.nativeTypes(NATIVE_TYPES);
         return AttributedConfigurationNode.root("root", options);
     }
 

--- a/format/xml/src/test/java/org/spongepowered/configuate/xml/XmlConfigurationLoaderTest.java
+++ b/format/xml/src/test/java/org/spongepowered/configuate/xml/XmlConfigurationLoaderTest.java
@@ -48,40 +48,40 @@ public class XmlConfigurationLoaderTest {
         final Path saveTest = tempDir.resolve("text1.txt");
 
         final XmlConfigurationLoader loader = XmlConfigurationLoader.builder()
-                .setWriteExplicitType(false)
-                .setIndent(4)
-                .setSource(() -> new BufferedReader(new InputStreamReader(url.openStream(), UTF_8)))
-                .setSink(AtomicFiles.createAtomicWriterFactory(saveTest, UTF_8)).build();
+                .writesExplicitType(false)
+                .indent(4)
+                .source(() -> new BufferedReader(new InputStreamReader(url.openStream(), UTF_8)))
+                .sink(AtomicFiles.atomicWriterFactory(saveTest, UTF_8)).build();
 
         final AttributedConfigurationNode node = loader.load();
 
-        assertEquals("messages", node.getTagName());
-        assertEquals("false", node.getAttribute("secret"));
+        assertEquals("messages", node.tagName());
+        assertEquals("false", node.attribute("secret"));
         assertTrue(node.isList());
 
-        final List<AttributedConfigurationNode> notes = node.getChildrenList();
+        final List<AttributedConfigurationNode> notes = node.childrenList();
         assertEquals(2, notes.size());
 
         final AttributedConfigurationNode firstNote = notes.get(0);
-        assertEquals("501", firstNote.getAttribute("id"));
+        assertEquals("501", firstNote.attribute("id"));
         assertTrue(firstNote.isMap());
         assertFalse(firstNote.isList());
 
-        final Map<Object, AttributedConfigurationNode> properties = firstNote.getChildrenMap();
-        assertEquals("Tove", properties.get("to").getValue());
-        assertEquals("Jani", properties.get("from").getValue());
-        assertEquals("Don't forget me this weekend!", properties.get("body").getValue());
-        assertEquals("heading", properties.get("heading").getTagName());
+        final Map<Object, AttributedConfigurationNode> properties = firstNote.childrenMap();
+        assertEquals("Tove", properties.get("to").get());
+        assertEquals("Jani", properties.get("from").get());
+        assertEquals("Don't forget me this weekend!", properties.get("body").get());
+        assertEquals("heading", properties.get("heading").tagName());
 
         final AttributedConfigurationNode secondNode = notes.get(1);
-        assertEquals("502", secondNode.getAttribute("id"));
+        assertEquals("502", secondNode.attribute("id"));
         assertFalse(secondNode.isMap());
         assertTrue(secondNode.isList());
 
-        final List<AttributedConfigurationNode> subNodes = secondNode.getChildrenList();
+        final List<AttributedConfigurationNode> subNodes = secondNode.childrenList();
         for (AttributedConfigurationNode subNode : subNodes) {
-            if (subNode.getTagName().equals("heading")) {
-                assertEquals("true", subNode.getAttribute("bold"));
+            if (subNode.tagName().equals("heading")) {
+                assertEquals("true", subNode.attribute("bold"));
             }
         }
 
@@ -96,24 +96,24 @@ public class XmlConfigurationLoaderTest {
         final Path saveTest = tempDir.resolve("text2.txt");
 
         final XmlConfigurationLoader loader = XmlConfigurationLoader.builder()
-                .setWriteExplicitType(true)
-                .setIncludeXmlDeclaration(false)
-                .setIndent(4)
-                .setSource(() -> new BufferedReader(new InputStreamReader(url.openStream(), UTF_8)))
-                .setSink(AtomicFiles.createAtomicWriterFactory(saveTest, UTF_8)).build();
+                .writesExplicitType(true)
+                .includesXmlDeclaration(false)
+                .indent(4)
+                .source(() -> new BufferedReader(new InputStreamReader(url.openStream(), UTF_8)))
+                .sink(AtomicFiles.atomicWriterFactory(saveTest, UTF_8)).build();
 
         final AttributedConfigurationNode node = loader.load();
 
-        final AttributedConfigurationNode list1 = node.getNode("list1");
+        final AttributedConfigurationNode list1 = node.node("list1");
         assertTrue(list1.isList());
 
-        final AttributedConfigurationNode list2 = node.getNode("list2");
+        final AttributedConfigurationNode list2 = node.node("list2");
         assertTrue(list2.isList());
 
-        final AttributedConfigurationNode map1 = node.getNode("map1");
+        final AttributedConfigurationNode map1 = node.node("map1");
         assertTrue(map1.isMap());
 
-        final AttributedConfigurationNode map2 = node.getNode("map2");
+        final AttributedConfigurationNode map2 = node.node("map2");
         assertTrue(map2.isMap());
 
         // roundtrip!
@@ -127,18 +127,18 @@ public class XmlConfigurationLoaderTest {
         final Path saveTest = tempDir.resolve("text3.txt");
 
         final XmlConfigurationLoader loader = XmlConfigurationLoader.builder()
-                .setWriteExplicitType(true)
-                .setIncludeXmlDeclaration(true)
-                .setIndent(4)
-                .setSource(() -> new BufferedReader(new InputStreamReader(url.openStream(), UTF_8)))
-                .setSink(AtomicFiles.createAtomicWriterFactory(saveTest, UTF_8)).build();
+                .writesExplicitType(true)
+                .includesXmlDeclaration(true)
+                .indent(4)
+                .source(() -> new BufferedReader(new InputStreamReader(url.openStream(), UTF_8)))
+                .sink(AtomicFiles.atomicWriterFactory(saveTest, UTF_8)).build();
 
         final AttributedConfigurationNode node = loader.createNode(
-                loader.defaultOptions().withHeader("test header\ndo multiple lines work\nyes they do!!")
-        ).setTagName("test");
+                loader.defaultOptions().header("test header\ndo multiple lines work\nyes they do!!")
+        ).tagName("test");
 
-        node.getNode("test1").setValue("something");
-        node.getNode("test2").setValue("I have a comment!").setComment("Hi!");
+        node.node("test1").set("something");
+        node.node("test2").set("I have a comment!").comment("Hi!");
 
         loader.save(node);
         assertEquals(Resources.readLines(url, UTF_8), Files.readAllLines(saveTest));
@@ -150,9 +150,9 @@ public class XmlConfigurationLoaderTest {
         final Path destination = tempDir.resolve("test3-roundtrip.xml");
 
         final XmlConfigurationLoader loader = XmlConfigurationLoader.builder()
-                .setIndent(4)
-                .setSource(() -> new BufferedReader(new InputStreamReader(original.openStream(), UTF_8)))
-                .setSink(AtomicFiles.createAtomicWriterFactory(destination, UTF_8))
+                .indent(4)
+                .source(() -> new BufferedReader(new InputStreamReader(original.openStream(), UTF_8)))
+                .sink(AtomicFiles.atomicWriterFactory(destination, UTF_8))
                 .build();
 
         final AttributedConfigurationNode node = loader.load();

--- a/format/yaml/src/main/java/org/spongepowered/configurate/yaml/YamlConfigurationLoader.java
+++ b/format/yaml/src/main/java/org/spongepowered/configurate/yaml/YamlConfigurationLoader.java
@@ -70,8 +70,8 @@ public final class YamlConfigurationLoader extends AbstractConfigurationLoader<B
         private @Nullable NodeStyle style;
 
         Builder() {
-            setIndent(4);
-            setDefaultOptions(o -> o.withNativeTypes(NATIVE_TYPES));
+            indent(4);
+            defaultOptions(o -> o.nativeTypes(NATIVE_TYPES));
         }
 
         /**
@@ -80,7 +80,7 @@ public final class YamlConfigurationLoader extends AbstractConfigurationLoader<B
          * @param indent the indent level
          * @return this builder (for chaining)
          */
-        public Builder setIndent(final int indent) {
+        public Builder indent(final int indent) {
             this.options.setIndent(indent);
             return this;
         }
@@ -90,7 +90,7 @@ public final class YamlConfigurationLoader extends AbstractConfigurationLoader<B
          *
          * @return the indent level
          */
-        public int getIndent() {
+        public int indent() {
             return this.options.getIndent();
         }
 
@@ -120,7 +120,7 @@ public final class YamlConfigurationLoader extends AbstractConfigurationLoader<B
          * @param style the node style to use
          * @return this builder (for chaining)
          */
-        public Builder setNodeStyle(final @Nullable NodeStyle style) {
+        public Builder nodeStyle(final @Nullable NodeStyle style) {
             this.style = style;
             return this;
         }
@@ -130,7 +130,7 @@ public final class YamlConfigurationLoader extends AbstractConfigurationLoader<B
          *
          * @return the node style
          */
-        public @Nullable NodeStyle getNodeStyle() {
+        public @Nullable NodeStyle nodeStyle() {
             return this.style;
         }
 
@@ -151,12 +151,12 @@ public final class YamlConfigurationLoader extends AbstractConfigurationLoader<B
 
     @Override
     protected void loadInternal(final BasicConfigurationNode node, final BufferedReader reader) {
-        node.setValue(this.yaml.get().load(reader));
+        node.set(this.yaml.get().load(reader));
     }
 
     @Override
     protected void saveInternal(final ConfigurationNode node, final Writer writer) {
-        this.yaml.get().dump(node.getValue(), writer);
+        this.yaml.get().dump(node.get(), writer);
     }
 
     @Override

--- a/format/yaml/src/test/java/org/spongepowered/configurate/yaml/YamlConfigurationLoaderTest.java
+++ b/format/yaml/src/test/java/org/spongepowered/configurate/yaml/YamlConfigurationLoaderTest.java
@@ -40,14 +40,14 @@ public class YamlConfigurationLoaderTest {
     void testSimpleLoading() throws IOException, ObjectMappingException {
         final URL url = getClass().getResource("/example.yml");
         final ConfigurationLoader<BasicConfigurationNode> loader = YamlConfigurationLoader.builder()
-                .setUrl(url).build();
+                .url(url).build();
         final ConfigurationNode node = loader.load();
-        assertEquals("unicorn", node.getNode("test", "op-level").getValue());
-        assertEquals("dragon", node.getNode("other", "op-level").getValue());
-        assertEquals("dog park", node.getNode("other", "location").getValue());
+        assertEquals("unicorn", node.node("test", "op-level").get());
+        assertEquals("dragon", node.node("other", "op-level").get());
+        assertEquals("dog park", node.node("other", "location").get());
 
 
-        final List<Map<String, List<String>>> fooList = new ArrayList<>(node.getNode("foo")
+        final List<Map<String, List<String>>> fooList = new ArrayList<>(node.node("foo")
             .getList(new TypeToken<Map<String, List<String>>>() {}));
         assertEquals(0, fooList.get(0).get("bar").size());
     }
@@ -55,19 +55,19 @@ public class YamlConfigurationLoaderTest {
     @Test
     void testReadWithTabs() throws IOException {
         final ConfigurationNode expected = BasicConfigurationNode.root(n -> {
-            n.getNode("document").act(d -> {
-                d.getNode("we").setValue("support tabs");
-                d.getNode("and").setValue("literal tabs\tin strings");
-                d.getNode("with").act(w -> {
-                    w.appendListNode().setValue("more levels");
-                    w.appendListNode().setValue("of indentation");
+            n.node("document").act(d -> {
+                d.node("we").set("support tabs");
+                d.node("and").set("literal tabs\tin strings");
+                d.node("with").act(w -> {
+                    w.appendListNode().set("more levels");
+                    w.appendListNode().set("of indentation");
                 });
             });
         });
 
         final URL url = getClass().getResource("/tab-example.yml");
         final ConfigurationLoader<BasicConfigurationNode> loader = YamlConfigurationLoader.builder()
-                .setUrl(url).build();
+                .url(url).build();
         final ConfigurationNode node = loader.load();
         assertEquals(expected, node);
     }


### PR DESCRIPTION
This continues some of the earlier steps to make Configurate operations more concise -- like allowing Class usage instead of just TypeTokens, and making the `@Setting` annotation optional in the object mapper.