### PR TITLE
Use no-default overload to avoid NPE

### DIFF
--- a/extra/kotlin/src/main/kotlin/org/spongepowered/configurate/kotlin/extensions/ConfigurationNodeExtensions.kt
+++ b/extra/kotlin/src/main/kotlin/org/spongepowered/configurate/kotlin/extensions/ConfigurationNodeExtensions.kt
@@ -58,7 +58,7 @@ operator fun ConfigurationNode.contains(path: Any): Boolean {
  */
 @Throws(SerializationException::class)
 inline fun <reified V> ConfigurationNode.get(): V? {
-    return get(typeTokenOf<V>(), null as V?)
+    return get(typeTokenOf<V>())
 }
 
 /**


### PR DESCRIPTION
When `null` is passed as the default, it causes a `NullPointerException` here:

https://github.com/SpongePowered/Configurate/blob/05515b6ff97305d6b6d4ad34a81d1accfe5200ed/core/src/main/java/org/spongepowered/configurate/AbstractConfigurationNode.java#L116