### PR TITLE
Prepend temporary file file names with a dot

### DIFF
--- a/core/src/main/java/org/spongepowered/configurate/loader/AtomicFiles.java
+++ b/core/src/main/java/org/spongepowered/configurate/loader/AtomicFiles.java
@@ -91,7 +91,7 @@ public final class AtomicFiles {
     }
 
     private static Path temporaryPath(final Path parent, final String key) {
-        final String fileName = System.nanoTime() + ThreadLocalRandom.current().nextInt()
+        final String fileName = "." + System.nanoTime() + ThreadLocalRandom.current().nextInt()
                 + requireNonNull(key, "key").replaceAll("[\\\\/:]", "-") + ".tmp";
         return parent.resolve(fileName);
     }


### PR DESCRIPTION
Prepend temporary file file names with a dot so they will be hidden by default in most file managers
![image](https://media.discordapp.net/attachments/720374890472931328/795232055373201438/unknown.png?width=948&height=394)