### PR TITLE
Fix typo in the Javadocs

### DIFF
--- a/core/src/main/java/org/spongepowered/configurate/ConfigurateException.java
+++ b/core/src/main/java/org/spongepowered/configurate/ConfigurateException.java
@@ -25,7 +25,7 @@ import java.util.function.Supplier;
  * Any sort of error thrown within Configurate.
  *
  * <p>Configurate's errors are designed to provide a view of as
- * many errors as possible within one configuration tree, though the
+ * many errors as possible within one configuration tree, through the
  * {@link Throwable#getSuppressed() suppressed exceptions}</p>
  *
  * @since 4.0.0


### PR DESCRIPTION
I'm pretty sure that the Javadocs meant "through the suppressed exceptions" as in "achieved with the suppressed exceptions", so I think that "though" was a typo.