### PR TITLE
core: Add support for object mapper post-processing

### DIFF
--- a/core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectMapper.java
+++ b/core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectMapper.java
@@ -20,6 +20,7 @@ import io.leangen.geantyref.TypeToken;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.objectmapping.meta.Constraint;
 import org.spongepowered.configurate.objectmapping.meta.NodeResolver;
+import org.spongepowered.configurate.objectmapping.meta.PostProcessor;
 import org.spongepowered.configurate.objectmapping.meta.Processor;
 import org.spongepowered.configurate.serialize.SerializationException;
 import org.spongepowered.configurate.serialize.TypeSerializer;
@@ -193,7 +194,7 @@ public interface ObjectMapper<V> {
          * @since 4.0.0
          */
         @SuppressWarnings("unchecked")
-        default <V> ObjectMapper<V> get(TypeToken<V> type) throws SerializationException {
+        default <V> ObjectMapper<V> get(final TypeToken<V> type) throws SerializationException {
             return (ObjectMapper<V>) get(type.getType());
         }
 
@@ -210,7 +211,7 @@ public interface ObjectMapper<V> {
          * @since 4.0.0
          */
         @SuppressWarnings("unchecked")
-        default <V> ObjectMapper<V> get(Class<V> clazz) throws SerializationException {
+        default <V> ObjectMapper<V> get(final Class<V> clazz) throws SerializationException {
             return (ObjectMapper<V>) get((Type) clazz);
         }
 
@@ -295,7 +296,7 @@ public interface ObjectMapper<V> {
              * @return this builder
              * @since 4.0.0
              */
-            default <A extends Annotation> Builder addProcessor(Class<A> definition, Processor.Factory<A, Object> factory) {
+            default <A extends Annotation> Builder addProcessor(final Class<A> definition, final Processor.Factory<A, Object> factory) {
                 return addProcessor(definition, Object.class, factory);
             }
 
@@ -327,7 +328,7 @@ public interface ObjectMapper<V> {
              * @return this builder
              * @since 4.0.0
              */
-            default <A extends Annotation> Builder addConstraint(Class<A> definition, Constraint.Factory<A, Object> factory) {
+            default <A extends Annotation> Builder addConstraint(final Class<A> definition, final Constraint.Factory<A, Object> factory) {
                 return addConstraint(definition, Object.class, factory);
             }
 
@@ -346,6 +347,19 @@ public interface ObjectMapper<V> {
              * @since 4.0.0
              */
             <A extends Annotation, T> Builder addConstraint(Class<A> definition, Class<T> valueType, Constraint.Factory<A, T> factory);
+
+            /**
+             * Register an object post-processor with this object mapper.
+             *
+             * <p>All post-processors will be called, even if one
+             * throws an exception.</p>
+             *
+             * @param factory the factory optionally producing a
+             *     post processor function
+             * @return this builder
+             * @since 4.2.0
+             */
+            Builder addPostProcessor(PostProcessor.Factory factory);
 
             /**
              * Create a new factory using the current configuration.

--- a/core/src/main/java/org/spongepowered/configurate/objectmapping/meta/PostProcess.java
+++ b/core/src/main/java/org/spongepowered/configurate/objectmapping/meta/PostProcess.java
@@ -1,0 +1,42 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spongepowered.configurate.objectmapping.meta;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import org.spongepowered.configurate.serialize.SerializationException;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Indicate that a method in an object-mappable object is intended for
+ * post-processing.
+ *
+ * <p>The annotated method will be invoked after all fields in the object have
+ * been populated by the object mapper.</p>
+ *
+ * <p>The annotated method must be non-static and may only declare a thrown type
+ * of {@link SerializationException}.</p>
+ *
+ * @since 4.2.0
+ */
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface PostProcess {
+}

--- a/core/src/main/java/org/spongepowered/configurate/objectmapping/meta/PostProcessor.java
+++ b/core/src/main/java/org/spongepowered/configurate/objectmapping/meta/PostProcessor.java
@@ -1,0 +1,193 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spongepowered.configurate.objectmapping.meta;
+
+import io.leangen.geantyref.GenericTypeReflector;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.configurate.serialize.SerializationException;
+import org.spongepowered.configurate.util.Types;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A callback executed after all field serialization has been performed.
+ *
+ * @since 4.2.0
+ */
+public interface PostProcessor {
+
+    /**
+     * Perform post-processing on the fully deserialized instance.
+     *
+     * @param instance the instance to post-process
+     * @throws SerializationException if the underlying operation
+     *     detects an error
+     * @since 4.2.0
+     */
+    void postProcess(Object instance) throws SerializationException;
+
+    /**
+     * A factory to produce object post-processors.
+     *
+     * @since 4.2.0
+     */
+    interface Factory {
+
+        /**
+         * Return a post-processor if any is applicable to the provided type.
+         *
+         * @param type the type to post-process
+         * @return a potential post-processor
+         * @throws SerializationException if there is a declared post-processor
+         *     handled by this factory with an invalid type
+         * @since 4.2.0
+         */
+        @Nullable
+        PostProcessor createProcessor(Type type) throws SerializationException;
+
+    }
+
+    /**
+     * Discover methods annotated with the designated post-processor annotation
+     * in object-mapped types and their supertypes.
+     *
+     * <p>Annotated methods must be non-static, take no parameters, and can have
+     * no declared thrown exceptions
+     * except for {@link SerializationException}.</p>
+     *
+     * @param annotation the annotation that will mark post-processor methods
+     * @return a factory for annotated methods
+     * @since 4.2.0
+     */
+    static Factory methodsAnnotated(final Class<? extends Annotation> annotation) {
+        return type -> {
+            List<Method> methods = null;
+            for (final Method method : Types.allDeclaredMethods(GenericTypeReflector.erase(type))) {
+                if (method.isAnnotationPresent(annotation)) {
+                    // Validate method
+                    final int modifiers = method.getModifiers();
+                    if (Modifier.isAbstract(modifiers)) {
+                        continue;
+                    }
+
+                    if (Modifier.isStatic(modifiers)) {
+                        throw new SerializationException(
+                            type,
+                            "Post-processor method " + method.getName() + "() annotated @" + annotation.getSimpleName()
+                                + " must not be static."
+                        );
+                    }
+                    if (method.getParameterCount() != 0) {
+                        throw new SerializationException(
+                            type,
+                            "Post-processor method " + method.getName() + "() annotated @" + annotation.getSimpleName()
+                                + " must not take any parameters."
+                        );
+                    }
+
+                    for (final Class<?> exception : method.getExceptionTypes()) {
+                        if (!SerializationException.class.isAssignableFrom(exception)) {
+                            throw new SerializationException(
+                                type,
+                                "Post-processor method " + method.getName() + "() annotated @" + annotation.getSimpleName()
+                                    + " must only throw SerializationException or its subtypes, but is declared to throw "
+                                    + exception.getSimpleName() + "."
+                            );
+                        }
+                    }
+                    method.setAccessible(true);
+
+                    // Then add it
+                    if (methods == null) {
+                        methods = new ArrayList<>();
+                    }
+                    methods.add(method);
+                }
+            }
+
+            if (methods != null) {
+                final List<Method> finalMethods = methods;
+                return instance -> {
+                    SerializationException aggregateException = null;
+                    for (final Method postProcessorMethod : finalMethods) {
+                        SerializationException exc = null;
+                        try {
+                            postProcessorMethod.invoke(instance);
+                        } catch (final InvocationTargetException ex) {
+                            if (ex.getCause() instanceof SerializationException) {
+                                exc = (SerializationException) ex.getCause();
+                                exc.initType(type);
+                            } else if (ex.getCause() != null) {
+                                exc = new SerializationException(
+                                    type,
+                                    "Failure occurred in post-processor method " + postProcessorMethod.getName() + "()", ex.getCause()
+                                );
+                            } else {
+                                exc = new SerializationException(
+                                    type,
+                                    "Unknown error occurred attempting to invoke post-processor method " + postProcessorMethod.getName() + "()",
+                                    ex
+                                );
+                            }
+                        } catch (final IllegalAccessException | IllegalArgumentException ex) {
+                            exc = new SerializationException(
+                                type, "Failed to invoke post-processor method " + postProcessorMethod.getName() + "()", ex
+                            );
+                        }
+
+                        // Capture all relevant exceptions
+                        if (exc != null) {
+                            if (aggregateException == null) {
+                                aggregateException = exc;
+                            } else {
+                                aggregateException.addSuppressed(exc);
+                            }
+                        }
+                    }
+
+                    // If anybody threw an exception, rethrow
+                    if (aggregateException != null) {
+                        throw aggregateException;
+                    }
+                };
+            }
+
+            return null;
+        };
+    }
+
+    /**
+     * Discover methods annotated with the {@link PostProcess} annotation.
+     *
+     * <p>All restrictions from {@link #methodsAnnotated(Class)} apply to these
+     * annotated methods.</p>
+     *
+     * @return a new factory for discovering annotated methods
+     * @see #methodsAnnotated(Class)
+     * @since 4.2.0
+     */
+    static Factory methodsAnnotatedPostProcess() {
+        return methodsAnnotated(PostProcess.class);
+    }
+
+}

--- a/core/src/test/java/org/spongepowered/configurate/objectmapping/PostProcessorTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/objectmapping/PostProcessorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spongepowered.configurate.objectmapping;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.spongepowered.configurate.BasicConfigurationNode;
+import org.spongepowered.configurate.ConfigurationNode;
+import org.spongepowered.configurate.objectmapping.meta.PostProcess;
+import org.spongepowered.configurate.serialize.SerializationException;
+
+class PostProcessorTest {
+
+    @Test
+    void testAnnotatedPostProcessor() throws SerializationException {
+        final ConfigurationNode node = BasicConfigurationNode.root();
+        final MethodTest result = node.require(MethodTest.class);
+
+        assertTrue(result.postProcessCalled);
+    }
+
+    @ConfigSerializable
+    static class MethodTest {
+
+        private transient boolean postProcessCalled;
+
+        @PostProcess
+        void afterEvaluate() {
+            this.postProcessCalled = true;
+        }
+
+    }
+
+}


### PR DESCRIPTION
This supports both annotated methods and pluggable implementations

Closes #253