### PR TITLE
core: Allow type serializers to work with annotated types

### DIFF
--- a/core/src/main/java/org/spongepowered/configurate/AbstractConfigurationNode.java
+++ b/core/src/main/java/org/spongepowered/configurate/AbstractConfigurationNode.java
@@ -211,7 +211,7 @@ abstract class AbstractConfigurationNode<N extends ScopedConfigurationNode<N>, A
     final @Nullable Object get0(final AnnotatedType type, final boolean doImplicitInit) throws SerializationException {
         requireNonNull(type, "type");
         if (isMissingTypeParameters(type.getType())) {
-            throw new SerializationException(this, type.getType(), "Raw types are not supported");
+            throw new SerializationException(this, type, "Raw types are not supported");
         }
 
         final @Nullable TypeSerializer<?> serial = this.options().serializers().get(type);

--- a/core/src/main/java/org/spongepowered/configurate/AbstractConfigurationNode.java
+++ b/core/src/main/java/org/spongepowered/configurate/AbstractConfigurationNode.java
@@ -200,7 +200,7 @@ abstract class AbstractConfigurationNode<N extends ScopedConfigurationNode<N>, A
             }
         }
         try {
-            return serial.deserialize(type, self());
+            return serial.deserialize(type, this.self());
         } catch (final SerializationException ex) {
             ex.initPath(this::path);
             ex.initType(type);
@@ -217,12 +217,7 @@ abstract class AbstractConfigurationNode<N extends ScopedConfigurationNode<N>, A
         final @Nullable TypeSerializer<?> serial = this.options().serializers().get(type);
         if (this.value instanceof NullConfigValue) {
             if (serial != null && doImplicitInit && this.options().implicitInitialization()) {
-                final @Nullable Object emptyValue;
-                if (serial instanceof TypeSerializer.Annotated<?>) {
-                    emptyValue = ((TypeSerializer.Annotated<?>) serial).emptyValue(type, this.options);
-                } else {
-                    emptyValue = serial.emptyValue(type.getType(), this.options);
-                }
+                final @Nullable Object emptyValue = serial.emptyValue(type, this.options);
                 if (emptyValue != null) {
                     return storeDefault(this, type, emptyValue);
                 }
@@ -240,11 +235,7 @@ abstract class AbstractConfigurationNode<N extends ScopedConfigurationNode<N>, A
             }
         }
         try {
-            if (serial instanceof TypeSerializer.Annotated<?>) {
-                return ((TypeSerializer.Annotated<?>) serial).deserialize(type, this);
-            } else {
-                return serial.deserialize(type.getType(), this);
-            }
+            return serial.deserialize(type, this);
         } catch (final SerializationException ex) {
             ex.initPath(this::path);
             ex.initType(type.getType());
@@ -257,7 +248,7 @@ abstract class AbstractConfigurationNode<N extends ScopedConfigurationNode<N>, A
         // if the value to be set is a configuration node already, unwrap and store the raw data
         if (newValue instanceof ConfigurationNode) {
             this.from((ConfigurationNode) newValue);
-            return self();
+            return this.self();
         }
 
         // if the new value is null, handle detaching from this nodes parent
@@ -268,10 +259,10 @@ abstract class AbstractConfigurationNode<N extends ScopedConfigurationNode<N>, A
             } else {
                 this.parent.removeChild(key);
             }
-            return self();
+            return this.self();
         } else if (newValue instanceof Collection || newValue instanceof Map) {
             this.insertNewValue(newValue, false);
-            return self();
+            return this.self();
         } else {
             return this.set(newValue.getClass(), newValue);
         }
@@ -280,7 +271,7 @@ abstract class AbstractConfigurationNode<N extends ScopedConfigurationNode<N>, A
     @Override
     public N from(final ConfigurationNode that) {
         if (that == this) { // this would be a no-op whoop
-            return self();
+            return this.self();
         }
 
         this.hints.clear();
@@ -317,7 +308,7 @@ abstract class AbstractConfigurationNode<N extends ScopedConfigurationNode<N>, A
             this.raw(that.raw());
         }
 
-        return self();
+        return this.self();
     }
 
     /**
@@ -381,7 +372,7 @@ abstract class AbstractConfigurationNode<N extends ScopedConfigurationNode<N>, A
                     if (oldValue instanceof NullConfigValue) {
                         newValue = new MapConfigValue<>(this.implSelf());
                     } else {
-                        return self();
+                        return this.self();
                     }
                 }
 
@@ -414,7 +405,7 @@ abstract class AbstractConfigurationNode<N extends ScopedConfigurationNode<N>, A
             // otherwise, replace the value of this node, only if currently null
             this.insertNewValue(other.rawScalar(), true);
         }
-        return self();
+        return this.self();
     }
 
     @Override
@@ -436,7 +427,7 @@ abstract class AbstractConfigurationNode<N extends ScopedConfigurationNode<N>, A
             this.insertNewValue(newValue, false);
         }
 
-        return self();
+        return this.self();
     }
 
     @Override
@@ -589,7 +580,7 @@ abstract class AbstractConfigurationNode<N extends ScopedConfigurationNode<N>, A
 
     @Override
     public final NodePath path() {
-        N pointer = self();
+        N pointer = this.self();
         if (pointer.parent() == null) {
             return NodePath.path();
         }
@@ -745,7 +736,7 @@ abstract class AbstractConfigurationNode<N extends ScopedConfigurationNode<N>, A
 
     @SuppressWarnings({"JdkObsolete", "unchecked"})
     private <S, T, E extends Exception> T visitInternal(final ConfigurationVisitor<S, T, E> visitor, final S state) throws E {
-        visitor.beginVisit(self(), state);
+        visitor.beginVisit(this.self(), state);
         if (!(this.value instanceof NullConfigValue)) { // only visit if we have an actual value
             final LinkedList<Object> toVisit = new LinkedList<>();
             toVisit.add(this);
@@ -794,7 +785,7 @@ abstract class AbstractConfigurationNode<N extends ScopedConfigurationNode<N>, A
             this.hints.put(hint, value);
         }
 
-        return self();
+        return this.self();
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/org/spongepowered/configurate/AbstractConfigurationNode.java
+++ b/core/src/main/java/org/spongepowered/configurate/AbstractConfigurationNode.java
@@ -238,7 +238,7 @@ abstract class AbstractConfigurationNode<N extends ScopedConfigurationNode<N>, A
             return serial.deserialize(type, this);
         } catch (final SerializationException ex) {
             ex.initPath(this::path);
-            ex.initType(type.getType());
+            ex.initType(type);
             throw ex;
         }
     }

--- a/core/src/main/java/org/spongepowered/configurate/ConfigurationNode.java
+++ b/core/src/main/java/org/spongepowered/configurate/ConfigurationNode.java
@@ -28,6 +28,7 @@ import org.spongepowered.configurate.serialize.Scalars;
 import org.spongepowered.configurate.serialize.SerializationException;
 import org.spongepowered.configurate.serialize.TypeSerializer;
 
+import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.List;
@@ -455,7 +456,7 @@ public interface ConfigurationNode {
      */
     @SuppressWarnings("unchecked") // type token
     default <V> @Nullable V get(final TypeToken<V> type) throws SerializationException {
-        return (V) this.get(type.getType());
+        return (V) this.get(type.getAnnotatedType());
     }
 
     /**
@@ -476,7 +477,7 @@ public interface ConfigurationNode {
      */
     @SuppressWarnings("unchecked") // type is verified by the token
     default <V> V get(final TypeToken<V> type, final V def) throws SerializationException {
-        return (V) this.get(type.getType(), def);
+        return (V) this.get(type.getAnnotatedType(), def);
     }
 
     /**
@@ -498,7 +499,7 @@ public interface ConfigurationNode {
      */
     @SuppressWarnings("unchecked") // type is verified by the token
     default <V> V get(final TypeToken<V> type, final Supplier<V> defSupplier) throws SerializationException {
-        return (V) this.get(type.getType(), defSupplier);
+        return (V) this.get(type.getAnnotatedType(), defSupplier);
     }
 
     /**
@@ -562,6 +563,59 @@ public interface ConfigurationNode {
     default <V> V get(final Class<V> type, final Supplier<V> defSupplier) throws SerializationException {
         return (V) this.get((Type) type, defSupplier);
     }
+
+    /**
+     * Get the current value associated with this node.
+     *
+     * <p>This method will attempt to deserialize the node's value to the
+     * provided {@link AnnotatedType} using a configured
+     * {@link TypeSerializer} for the given type, or casting if no type
+     * serializer is found.</p>
+     *
+     * @param type the type to deserialize to
+     * @return the value if present and of the proper type, else null
+     * @throws SerializationException if the value fails to be converted to the
+     *                                requested type
+     * @since 4.2.0
+     */
+    @Nullable Object get(AnnotatedType type) throws SerializationException;
+
+    /**
+     * Get the current value associated with this node.
+     *
+     * <p>This method will attempt to deserialize the node's value to the
+     * provided {@link AnnotatedType} using a configured
+     * {@link TypeSerializer} for the given type, or casting if no type
+     * serializer is found.</p>
+     *
+     * @param type the type to deserialize as
+     * @param def value to return if {@link #virtual()} or value is not of
+     *            appropriate type
+     * @return the value if of the proper type, else {@code def}
+     * @throws SerializationException if the value fails to be converted to the
+     *                                requested type
+     * @since 4.2.0
+     */
+    Object get(AnnotatedType type, Object def) throws SerializationException;
+
+    /**
+     * Get the current value associated with this node.
+     *
+     * <p>This method will attempt to deserialize the node's value to the
+     * provided {@link AnnotatedType} using a configured
+     * {@link TypeSerializer} for the given type, or casting if no type
+     * serializer is found.</p>
+     *
+     * @param type the type to deserialize to
+     * @param defSupplier the function that will be called to calculate a
+     *                    default value only if there is no existing value of
+     *                    the correct type
+     * @return the value if of the proper type, else {@code def}
+     * @throws SerializationException if the value fails to be converted to the
+     *                                requested type
+     * @since 4.2.0
+     */
+    Object get(AnnotatedType type, Supplier<?> defSupplier) throws SerializationException;
 
     /**
      * Get the current value associated with this node.
@@ -763,7 +817,7 @@ public interface ConfigurationNode {
      * @since 4.0.0
      */
     default @Nullable String getString() { // @cs-: NoGetSetPrefix (not a bean method)
-        return Scalars.STRING.tryDeserialize(this.rawScalar());
+        return Scalars.STRING.tryDeserialize(rawScalar());
     }
 
     /**
@@ -780,7 +834,7 @@ public interface ConfigurationNode {
         if (value != null) {
             return value;
         }
-        if (this.options().shouldCopyDefaults()) {
+        if (options().shouldCopyDefaults()) {
             Scalars.STRING.serialize(String.class, def, this);
         }
         return def;
@@ -806,11 +860,11 @@ public interface ConfigurationNode {
      * @since 4.0.0
      */
     default float getFloat(final float def) { // @cs-: NoGetSetPrefix (not a bean method)
-        final @Nullable Float val = Scalars.FLOAT.tryDeserialize(this.rawScalar());
+        final @Nullable Float val = Scalars.FLOAT.tryDeserialize(rawScalar());
         if (val != null) {
             return val;
         }
-        if (this.options().shouldCopyDefaults() && def != NUMBER_DEF) {
+        if (options().shouldCopyDefaults() && def != NUMBER_DEF) {
             Scalars.FLOAT.serialize(float.class, def, this);
         }
         return def;
@@ -837,11 +891,11 @@ public interface ConfigurationNode {
      * @since 4.0.0
      */
     default double getDouble(final double def) { // @cs-: NoGetSetPrefix (not a bean method)
-        final @Nullable Double val = Scalars.DOUBLE.tryDeserialize(this.rawScalar());
+        final @Nullable Double val = Scalars.DOUBLE.tryDeserialize(rawScalar());
         if (val != null) {
             return val;
         }
-        if (this.options().shouldCopyDefaults() && def != NUMBER_DEF) {
+        if (options().shouldCopyDefaults() && def != NUMBER_DEF) {
             Scalars.DOUBLE.serialize(double.class, def, this);
         }
         return def;
@@ -867,11 +921,11 @@ public interface ConfigurationNode {
      * @since 4.0.0
      */
     default int getInt(final int def) { // @cs-: NoGetSetPrefix (not a bean method)
-        final @Nullable Integer val = Scalars.INTEGER.tryDeserialize(this.rawScalar());
+        final @Nullable Integer val = Scalars.INTEGER.tryDeserialize(rawScalar());
         if (val != null) {
             return val;
         }
-        if (this.options().shouldCopyDefaults() && def != NUMBER_DEF) {
+        if (options().shouldCopyDefaults() && def != NUMBER_DEF) {
             Scalars.INTEGER.serialize(int.class, def, this);
         }
         return def;
@@ -897,11 +951,11 @@ public interface ConfigurationNode {
      * @since 4.0.0
      */
     default long getLong(final long def) { // @cs-: NoGetSetPrefix (not a bean method)
-        final @Nullable Long val = Scalars.LONG.tryDeserialize(this.rawScalar());
+        final @Nullable Long val = Scalars.LONG.tryDeserialize(rawScalar());
         if (val != null) {
             return val;
         }
-        if (this.options().shouldCopyDefaults() && def != NUMBER_DEF) {
+        if (options().shouldCopyDefaults() && def != NUMBER_DEF) {
             Scalars.LONG.serialize(long.class, def, this);
         }
         return def;
@@ -927,11 +981,11 @@ public interface ConfigurationNode {
      * @since 4.0.0
      */
     default boolean getBoolean(final boolean def) { // @cs-: NoGetSetPrefix (not a bean method)
-        final @Nullable Boolean val = Scalars.BOOLEAN.tryDeserialize(this.rawScalar());
+        final @Nullable Boolean val = Scalars.BOOLEAN.tryDeserialize(rawScalar());
         if (val != null) {
             return val;
         }
-        if (this.options().shouldCopyDefaults()) {
+        if (options().shouldCopyDefaults()) {
             Scalars.BOOLEAN.serialize(boolean.class, def, this);
         }
         return def;
@@ -1026,6 +1080,37 @@ public interface ConfigurationNode {
      * @since 4.0.0
      */
     ConfigurationNode set(Type type, @Nullable Object value) throws SerializationException;
+
+    /**
+     * Set this node's value to the given value.
+     *
+     * <p>If the provided value is a {@link Collection} or a {@link Map}, it will be unwrapped into
+     * the appropriate configuration node structure.</p>
+     *
+     * <p>This method will also perform serialization using the appropriate
+     * {@link TypeSerializer} for the given type, or casting if no type
+     * serializer is found.</p>
+     *
+     * <p>This method will fail if a raw type
+     * (i.e. a parameterized type without its type parameters) is passed.</p>
+     *
+     * <p>Because this method accepts a non-parameterized {@link Type} parameter,
+     * it has no compile-time type checking. The variants that take
+     * {@link #set(TypeToken, Object) TypeToken} and
+     * {@link #set(Class, Object)} should be preferred where possible.</p>
+     *
+     * @param type the annotated type to use for serialization type information
+     * @param value the value to set
+     * @return this node
+     * @throws IllegalArgumentException if a raw type is passed
+     * @throws IllegalArgumentException if {@code value} is not either
+     *                                  {@code null} or of type {@code type}
+     * @throws SerializationException if the value fails to be converted to the
+     *                                requested type. No change will be made to
+     *                                the node.
+     * @since 4.2.0
+     */
+    ConfigurationNode set(AnnotatedType type, @Nullable Object value) throws SerializationException;
 
     /**
      * Set the node's value to the provided list.

--- a/core/src/main/java/org/spongepowered/configurate/ScopedConfigurationNode.java
+++ b/core/src/main/java/org/spongepowered/configurate/ScopedConfigurationNode.java
@@ -112,10 +112,10 @@ public interface ScopedConfigurationNode<N extends ScopedConfigurationNode<N>> e
                 + value.getClass().getName() + ", when the value should be an instance of " + erasedType.getSimpleName());
         }
 
-        final @Nullable TypeSerializer<?> serial = options().serializers().get(type);
+        final @Nullable TypeSerializer<?> serial = this.options().serializers().get(type);
         if (serial != null) {
             ((TypeSerializer) serial).serialize(type, value, this.self());
-        } else if (options().acceptsType(value.getClass())) {
+        } else if (this.options().acceptsType(value.getClass())) {
             this.raw(value); // Just write if no applicable serializer exists?
         } else {
             throw new SerializationException(this, type, "No serializer available for type " + type);
@@ -138,14 +138,10 @@ public interface ScopedConfigurationNode<N extends ScopedConfigurationNode<N>> e
                 + value.getClass().getName() + ", when the value should be an instance of " + erasedType.getSimpleName());
         }
 
-        final @Nullable TypeSerializer<?> serial = options().serializers().get(type);
+        final @Nullable TypeSerializer<?> serial = this.options().serializers().get(type);
         if (serial != null) {
-            if (serial instanceof TypeSerializer.Annotated<?>) {
-                ((TypeSerializer.Annotated) serial).serialize(type, value, this);
-            } else {
-                ((TypeSerializer) serial).serialize(type.getType(), value, this);
-            }
-        } else if (options().acceptsType(value.getClass())) {
+            ((TypeSerializer) serial).serialize(type, value, this);
+        } else if (this.options().acceptsType(value.getClass())) {
             this.raw(value); // Just write if no applicable serializer exists?
         } else {
             throw new SerializationException(this, type.getType(), "No serializer available for type " + type);

--- a/core/src/main/java/org/spongepowered/configurate/ScopedConfigurationNode.java
+++ b/core/src/main/java/org/spongepowered/configurate/ScopedConfigurationNode.java
@@ -114,7 +114,12 @@ public interface ScopedConfigurationNode<N extends ScopedConfigurationNode<N>> e
 
         final @Nullable TypeSerializer<?> serial = this.options().serializers().get(type);
         if (serial != null) {
-            ((TypeSerializer) serial).serialize(type, value, this.self());
+            try {
+                ((TypeSerializer) serial).serialize(type, value, this.self());
+            } catch (final SerializationException ex) {
+                ex.initPath(this::path);
+                ex.initType(type);
+            }
         } else if (this.options().acceptsType(value.getClass())) {
             this.raw(value); // Just write if no applicable serializer exists?
         } else {
@@ -134,17 +139,22 @@ public interface ScopedConfigurationNode<N extends ScopedConfigurationNode<N>> e
         }
         final Class<?> erasedType = GenericTypeReflector.erase(type.getType());
         if (!erasedType.isInstance(value)) {
-            throw new SerializationException(this, type.getType(), "Got a value of unexpected type "
+            throw new SerializationException(this, type, "Got a value of unexpected type "
                 + value.getClass().getName() + ", when the value should be an instance of " + erasedType.getSimpleName());
         }
 
         final @Nullable TypeSerializer<?> serial = this.options().serializers().get(type);
         if (serial != null) {
-            ((TypeSerializer) serial).serialize(type, value, this);
+            try {
+                ((TypeSerializer) serial).serialize(type, value, this);
+            } catch (final SerializationException ex) {
+                ex.initPath(this::path);
+                ex.initType(type);
+            }
         } else if (this.options().acceptsType(value.getClass())) {
             this.raw(value); // Just write if no applicable serializer exists?
         } else {
-            throw new SerializationException(this, type.getType(), "No serializer available for type " + type);
+            throw new SerializationException(this, type, "No serializer available for type " + type);
         }
         return this.self();
     }

--- a/core/src/main/java/org/spongepowered/configurate/objectmapping/FieldData.java
+++ b/core/src/main/java/org/spongepowered/configurate/objectmapping/FieldData.java
@@ -127,13 +127,13 @@ public abstract class FieldData<I, O> {
             throw new SerializationException("Object " + instance + " is not of expected type " + resolvedType().getType());
         }
 
-        for (Constraint<?> constraint : constraints()) {
+        for (final Constraint<?> constraint : constraints()) {
             ((Constraint<Object>) constraint).validate(instance);
         }
     }
 
     TypeSerializer<?> serializerFrom(final ConfigurationNode node) throws SerializationException {
-        final @Nullable TypeSerializer<?> serial = node.options().serializers().get(resolvedType().getType());
+        final @Nullable TypeSerializer<?> serial = node.options().serializers().get(resolvedType());
         if (serial == null) {
             throw new SerializationException("No TypeSerializer found for field " + name() + " of type " + resolvedType().getType());
         }

--- a/core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectMapperImpl.java
+++ b/core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectMapperImpl.java
@@ -98,7 +98,7 @@ class ObjectMapperImpl<I, V> implements ObjectMapper<V> {
                 }
             } catch (final SerializationException ex) {
                 ex.initPath(node::path);
-                ex.initType(field.resolvedType().getType());
+                ex.initType(field.resolvedType());
 
                 if (failure == null) {
                     failure = ex;
@@ -163,7 +163,7 @@ class ObjectMapperImpl<I, V> implements ObjectMapper<V> {
             } catch (final SerializationException ex) {
                 throw ex;
             } catch (final Exception ex) {
-                throw new SerializationException(node, field.resolvedType().getType(), ex);
+                throw new SerializationException(node, field.resolvedType(), ex);
             }
 
             if (fieldVal == null) {
@@ -177,7 +177,7 @@ class ObjectMapperImpl<I, V> implements ObjectMapper<V> {
             }
         } catch (final SerializationException ex) {
             ex.initPath(node::path);
-            ex.initType(field.resolvedType().getType());
+            ex.initType(field.resolvedType());
             throw ex;
         }
     }

--- a/core/src/main/java/org/spongepowered/configurate/serialize/ArraySerializer.java
+++ b/core/src/main/java/org/spongepowered/configurate/serialize/ArraySerializer.java
@@ -21,6 +21,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.configurate.util.CheckedConsumer;
 import org.spongepowered.configurate.util.Types;
 
+import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Array;
 import java.lang.reflect.Type;
 
@@ -36,8 +37,8 @@ abstract class ArraySerializer<T> extends AbstractListChildSerializer<T> {
     }
 
     @Override
-    protected Type elementType(final Type containerType) throws SerializationException {
-        final Type componentType = GenericTypeReflector.getArrayComponentType(containerType);
+    protected AnnotatedType elementType(final AnnotatedType containerType) throws SerializationException {
+        final AnnotatedType componentType = GenericTypeReflector.getArrayComponentType(containerType);
         if (componentType == null) {
             throw new SerializationException(containerType, "Must be array type");
         }
@@ -58,14 +59,14 @@ abstract class ArraySerializer<T> extends AbstractListChildSerializer<T> {
         }
 
         @Override
-        protected Object[] createNew(final int length, final Type elementType) {
-            return (Object[]) Array.newInstance(GenericTypeReflector.erase(elementType), length);
+        protected Object[] createNew(final int length, final AnnotatedType elementType) {
+            return (Object[]) Array.newInstance(GenericTypeReflector.erase(elementType.getType()), length);
         }
 
         @Override
         protected void forEachElement(final Object[] collection,
                 final CheckedConsumer<Object, SerializationException> action) throws SerializationException {
-            for (Object o : collection) {
+            for (final Object o : collection) {
                 action.accept(o);
             }
         }
@@ -82,14 +83,14 @@ abstract class ArraySerializer<T> extends AbstractListChildSerializer<T> {
         static final Class<boolean[]> TYPE = boolean[].class;
 
         @Override
-        protected boolean[] createNew(final int length, final Type elementType) {
+        protected boolean[] createNew(final int length, final AnnotatedType elementType) {
             return new boolean[length];
         }
 
         @Override
         protected void forEachElement(final boolean[] collection,
                 final CheckedConsumer<Object, SerializationException> action) throws SerializationException {
-            for (boolean b : collection) {
+            for (final boolean b : collection) {
                 action.accept(b);
             }
         }
@@ -107,14 +108,14 @@ abstract class ArraySerializer<T> extends AbstractListChildSerializer<T> {
         static final Class<byte[]> TYPE = byte[].class;
 
         @Override
-        protected byte[] createNew(final int length, final Type elementType) {
+        protected byte[] createNew(final int length, final AnnotatedType elementType) {
             return new byte[length];
         }
 
         @Override
         protected void forEachElement(final byte[] collection,
                 final CheckedConsumer<Object, SerializationException> action) throws SerializationException {
-            for (byte b : collection) {
+            for (final byte b : collection) {
                 action.accept(b);
             }
         }
@@ -132,14 +133,14 @@ abstract class ArraySerializer<T> extends AbstractListChildSerializer<T> {
         static final Class<char[]> TYPE = char[].class;
 
         @Override
-        protected char[] createNew(final int length, final Type elementType) {
+        protected char[] createNew(final int length, final AnnotatedType elementType) {
             return new char[length];
         }
 
         @Override
         protected void forEachElement(final char[] collection,
                 final CheckedConsumer<Object, SerializationException> action) throws SerializationException {
-            for (char b : collection) {
+            for (final char b : collection) {
                 action.accept(b);
             }
         }
@@ -157,14 +158,14 @@ abstract class ArraySerializer<T> extends AbstractListChildSerializer<T> {
         static final Class<short[]> TYPE = short[].class;
 
         @Override
-        protected short[] createNew(final int length, final Type elementType) {
+        protected short[] createNew(final int length, final AnnotatedType elementType) {
             return new short[length];
         }
 
         @Override
         protected void forEachElement(final short[] collection,
                 final CheckedConsumer<Object, SerializationException> action) throws SerializationException {
-            for (short b : collection) {
+            for (final short b : collection) {
                 action.accept(b);
             }
         }
@@ -182,14 +183,14 @@ abstract class ArraySerializer<T> extends AbstractListChildSerializer<T> {
         static final Class<int[]> TYPE = int[].class;
 
         @Override
-        protected int[] createNew(final int length, final Type elementType) {
+        protected int[] createNew(final int length, final AnnotatedType elementType) {
             return new int[length];
         }
 
         @Override
         protected void forEachElement(final int[] collection,
                 final CheckedConsumer<Object, SerializationException> action) throws SerializationException {
-            for (int b : collection) {
+            for (final int b : collection) {
                 action.accept(b);
             }
         }
@@ -207,14 +208,14 @@ abstract class ArraySerializer<T> extends AbstractListChildSerializer<T> {
         static final Class<long[]> TYPE = long[].class;
 
         @Override
-        protected long[] createNew(final int length, final Type elementType) {
+        protected long[] createNew(final int length, final AnnotatedType elementType) {
             return new long[length];
         }
 
         @Override
         protected void forEachElement(final long[] collection,
                 final CheckedConsumer<Object, SerializationException> action) throws SerializationException {
-            for (long b : collection) {
+            for (final long b : collection) {
                 action.accept(b);
             }
         }
@@ -232,14 +233,14 @@ abstract class ArraySerializer<T> extends AbstractListChildSerializer<T> {
         static final Class<float[]> TYPE = float[].class;
 
         @Override
-        protected float[] createNew(final int length, final Type elementType) {
+        protected float[] createNew(final int length, final AnnotatedType elementType) {
             return new float[length];
         }
 
         @Override
         protected void forEachElement(final float[] collection,
                 final CheckedConsumer<Object, SerializationException> action) throws SerializationException {
-            for (float b : collection) {
+            for (final float b : collection) {
                 action.accept(b);
             }
         }
@@ -257,14 +258,14 @@ abstract class ArraySerializer<T> extends AbstractListChildSerializer<T> {
         static final Class<double[]> TYPE = double[].class;
 
         @Override
-        protected double[] createNew(final int length, final Type elementType) {
+        protected double[] createNew(final int length, final AnnotatedType elementType) {
             return new double[length];
         }
 
         @Override
         protected void forEachElement(final double[] collection,
                 final CheckedConsumer<Object, SerializationException> action) throws SerializationException {
-            for (double b : collection) {
+            for (final double b : collection) {
                 action.accept(b);
             }
         }

--- a/core/src/main/java/org/spongepowered/configurate/serialize/ListSerializer.java
+++ b/core/src/main/java/org/spongepowered/configurate/serialize/ListSerializer.java
@@ -20,8 +20,8 @@ import io.leangen.geantyref.TypeToken;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.configurate.util.CheckedConsumer;
 
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
+import java.lang.reflect.AnnotatedParameterizedType;
+import java.lang.reflect.AnnotatedType;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,22 +33,22 @@ final class ListSerializer extends AbstractListChildSerializer<List<?>> {
     }
 
     @Override
-    protected Type elementType(final Type containerType) throws SerializationException {
-        if (!(containerType instanceof ParameterizedType)) {
+    protected AnnotatedType elementType(final AnnotatedType containerType) throws SerializationException {
+        if (!(containerType instanceof AnnotatedParameterizedType)) {
             throw new SerializationException(containerType, "Raw types are not supported for collections");
         }
-        return ((ParameterizedType) containerType).getActualTypeArguments()[0];
+        return ((AnnotatedParameterizedType) containerType).getAnnotatedActualTypeArguments()[0];
     }
 
     @Override
-    protected List<?> createNew(final int length, final Type elementType) {
+    protected List<?> createNew(final int length, final AnnotatedType elementType) {
         return new ArrayList<>(length);
     }
 
     @Override
     protected void forEachElement(final List<?> collection,
             final CheckedConsumer<Object, SerializationException> action) throws SerializationException {
-        for (Object el: collection) {
+        for (final Object el: collection) {
             action.accept(el);
         }
     }

--- a/core/src/main/java/org/spongepowered/configurate/serialize/SerializationException.java
+++ b/core/src/main/java/org/spongepowered/configurate/serialize/SerializationException.java
@@ -21,6 +21,7 @@ import org.spongepowered.configurate.ConfigurateException;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.NodePath;
 
+import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Type;
 
 /**
@@ -74,6 +75,18 @@ public class SerializationException extends ConfigurateException {
     }
 
     /**
+     * Create an exception without a cause.
+     *
+     * @param expectedType declared type being processed
+     * @param message message with information about the exception
+     * @since 4.2.0
+     */
+    public SerializationException(final AnnotatedType expectedType, final String message) {
+        super(message);
+        this.expectedType = expectedType.getType();
+    }
+
+    /**
      * Create an exception with a cause and no additional information.
      *
      * @param expectedType declared type being processed
@@ -83,6 +96,18 @@ public class SerializationException extends ConfigurateException {
     public SerializationException(final Type expectedType, final Throwable cause) {
         super(cause);
         this.expectedType = expectedType;
+    }
+
+    /**
+     * Create an exception with a cause and no additional information.
+     *
+     * @param expectedType declared type being processed
+     * @param cause wrapped causing throwable
+     * @since 4.2.0
+     */
+    public SerializationException(final AnnotatedType expectedType, final Throwable cause) {
+        super(cause);
+        this.expectedType = expectedType.getType();
     }
 
     /**
@@ -99,6 +124,19 @@ public class SerializationException extends ConfigurateException {
     }
 
     /**
+     * Create an exception with message and wrapped cause.
+     *
+     * @param expectedType declared type being processed
+     * @param message informational message
+     * @param cause cause to be wrapped
+     * @since 4.2.0
+     */
+    public SerializationException(final AnnotatedType expectedType, final String message, final Throwable cause) {
+        super(message, cause);
+        this.expectedType = expectedType.getType();
+    }
+
+    /**
      * Create an exception with a message and unknown cause.
      *
      * @param node node being processed
@@ -111,6 +149,18 @@ public class SerializationException extends ConfigurateException {
     }
 
     /**
+     * Create an exception with a message and unknown cause.
+     *
+     * @param node node being processed
+     * @param message informational message
+     * @param expectedType declared type being processed
+     * @since 4.2.0
+     */
+    public SerializationException(final ConfigurationNode node, final AnnotatedType expectedType, final String message) {
+        this(node, expectedType, message, null);
+    }
+
+    /**
      * Create an exception with wrapped cause.
      *
      * @param node node being processed
@@ -119,6 +169,18 @@ public class SerializationException extends ConfigurateException {
      * @since 4.0.0
      */
     public SerializationException(final ConfigurationNode node, final Type expectedType, final Throwable cause) {
+        this(node, expectedType, null, cause);
+    }
+
+    /**
+     * Create an exception with wrapped cause.
+     *
+     * @param node node being processed
+     * @param expectedType declared type being processed
+     * @param cause cause to be wrapped
+     * @since 4.2.0
+     */
+    public SerializationException(final ConfigurationNode node, final AnnotatedType expectedType, final Throwable cause) {
         this(node, expectedType, null, cause);
     }
 
@@ -140,6 +202,21 @@ public class SerializationException extends ConfigurateException {
     /**
      * Create an exception with message and wrapped cause.
      *
+     * @param node node being processed
+     * @param expectedType declared type being processed
+     * @param message informational message
+     * @param cause cause to be wrapped
+     * @since 4.2.0
+     */
+    public SerializationException(final ConfigurationNode node, final AnnotatedType expectedType,
+            final @Nullable String message, final @Nullable Throwable cause) {
+        super(node, message, cause);
+        this.expectedType = expectedType.getType();
+    }
+
+    /**
+     * Create an exception with message and wrapped cause.
+     *
      * @param path path to node being processed
      * @param expectedType declared type being processed
      * @param message informational message
@@ -149,6 +226,19 @@ public class SerializationException extends ConfigurateException {
         super(path, message, null);
 
         this.expectedType = expectedType;
+    }
+
+    /**
+     * Create an exception with message and wrapped cause.
+     *
+     * @param path path to node being processed
+     * @param expectedType declared type being processed
+     * @param message informational message
+     * @since 4.2.0
+     */
+    public SerializationException(final NodePath path, final AnnotatedType expectedType, final String message) {
+        super(path, message, null);
+        this.expectedType = expectedType.getType();
     }
 
     /**
@@ -166,7 +256,7 @@ public class SerializationException extends ConfigurateException {
         if (this.expectedType == null) {
             return super.getMessage();
         } else {
-            return path() + " of type " + this.expectedType.getTypeName() + ": " + rawMessage();
+            return this.path() + " of type " + this.expectedType.getTypeName() + ": " + this.rawMessage();
         }
     }
 
@@ -181,6 +271,20 @@ public class SerializationException extends ConfigurateException {
     public void initType(final Type type) {
         if (this.expectedType == null) {
             this.expectedType = type;
+        }
+    }
+
+    /**
+     * Initialize the expected type.
+     *
+     * <p>If a type has already been set, it will not be overridden.</p>
+     *
+     * @param type expected type
+     * @since 4.2.0
+     */
+    public final void initType(final AnnotatedType type) {
+        if (this.expectedType == null) {
+            this.expectedType = type.getType();
         }
     }
 

--- a/core/src/main/java/org/spongepowered/configurate/serialize/SetSerializer.java
+++ b/core/src/main/java/org/spongepowered/configurate/serialize/SetSerializer.java
@@ -20,7 +20,8 @@ import io.leangen.geantyref.GenericTypeReflector;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.configurate.util.CheckedConsumer;
 
-import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.AnnotatedParameterizedType;
+import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Type;
 import java.util.EnumSet;
 import java.util.LinkedHashSet;
@@ -38,17 +39,17 @@ final class SetSerializer extends AbstractListChildSerializer<Set<?>> {
     }
 
     @Override
-    protected Type elementType(final Type containerType) throws SerializationException {
-        if (!(containerType instanceof ParameterizedType)) {
+    protected AnnotatedType elementType(final AnnotatedType containerType) throws SerializationException {
+        if (!(containerType instanceof AnnotatedParameterizedType)) {
             throw new SerializationException("Raw types are not supported for collections");
         }
-        return ((ParameterizedType) containerType).getActualTypeArguments()[0];
+        return ((AnnotatedParameterizedType) containerType).getAnnotatedActualTypeArguments()[0];
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    protected Set<?> createNew(final int length, final Type elementType) {
-        final Class<?> erased = GenericTypeReflector.erase(elementType);
+    protected Set<?> createNew(final int length, final AnnotatedType elementType) {
+        final Class<?> erased = GenericTypeReflector.erase(elementType.getType());
         if (erased.isEnum()) {
             return EnumSet.noneOf(erased.asSubclass(Enum.class));
         }
@@ -58,7 +59,7 @@ final class SetSerializer extends AbstractListChildSerializer<Set<?>> {
     @Override
     protected void forEachElement(final Set<?> collection,
             final CheckedConsumer<Object, SerializationException> action) throws SerializationException {
-        for (Object el: collection) {
+        for (final Object el: collection) {
             action.accept(el);
         }
     }

--- a/core/src/main/java/org/spongepowered/configurate/serialize/TypeSerializerCollection.java
+++ b/core/src/main/java/org/spongepowered/configurate/serialize/TypeSerializerCollection.java
@@ -108,7 +108,7 @@ public final class TypeSerializerCollection {
     @SuppressWarnings("unchecked")
     public <T> @Nullable TypeSerializer<T> get(final TypeToken<T> token) {
         requireNonNull(token, "type");
-        return (TypeSerializer<T>) get0(token.getAnnotatedType());
+        return (TypeSerializer<T>) this.get0(token.getAnnotatedType());
     }
 
     /**
@@ -131,7 +131,7 @@ public final class TypeSerializerCollection {
         requireNonNull(token, "type");
         requireCompleteParameters(token);
 
-        return (TypeSerializer<T>) get((Type) token);
+        return (TypeSerializer<T>) this.get((Type) token);
     }
 
     /**
@@ -146,7 +146,7 @@ public final class TypeSerializerCollection {
      * @since 4.0.0
      */
     public @Nullable TypeSerializer<?> get(final Type type) {
-        return get0(GenericTypeReflector.box(type));
+        return this.get0(GenericTypeReflector.box(type));
     }
 
     /**
@@ -299,7 +299,7 @@ public final class TypeSerializerCollection {
          * @since 4.0.0
          */
         public <T> Builder register(final TypeToken<T> type, final TypeSerializer<? super T> serializer) {
-            return register0(type.getType(), serializer);
+            return this.register0(type.getType(), serializer);
         }
 
         /**
@@ -315,7 +315,7 @@ public final class TypeSerializerCollection {
          * @since 4.0.0
          */
         public <T> Builder register(final Class<T> type, final TypeSerializer<? super T> serializer) {
-            return register0(type, serializer);
+            return this.register0(type, serializer);
         }
 
         /**
@@ -347,7 +347,7 @@ public final class TypeSerializerCollection {
          */
         public <T> Builder register(final ScalarSerializer<T> serializer) {
             requireNonNull(serializer, "serializer");
-            return register(serializer.type(), serializer);
+            return this.register(serializer.type(), serializer);
         }
 
         /**
@@ -358,9 +358,10 @@ public final class TypeSerializerCollection {
          * @param serializer the serializer to serialize matching types with
          * @param <T> the type parameter
          * @return this builder
+         * @see TypeSerializer.Annotated
          * @since 4.2.0
          */
-        public <T> Builder registerAnnotated(final Predicate<AnnotatedType> test, final TypeSerializer.Annotated<? super T> serializer) {
+        public <T> Builder registerAnnotated(final Predicate<AnnotatedType> test, final TypeSerializer<? super T> serializer) {
             requireNonNull(test, "test");
             requireNonNull(serializer, "serializer");
             this.serializers.add(new AnnotatedTypeRegistration(test, serializer));
@@ -402,7 +403,7 @@ public final class TypeSerializerCollection {
          * @since 4.0.0
          */
         public <T> Builder registerExact(final TypeToken<T> type, final TypeSerializer<? super T> serializer) {
-            return registerExact0(type.getType(), serializer);
+            return this.registerExact0(type.getType(), serializer);
         }
 
         /**
@@ -419,7 +420,7 @@ public final class TypeSerializerCollection {
          * @since 4.0.0
          */
         public <T> Builder registerExact(final Class<T> type, final TypeSerializer<? super T> serializer) {
-            return registerExact0(type, serializer);
+            return this.registerExact0(type, serializer);
         }
 
         /**
@@ -436,7 +437,7 @@ public final class TypeSerializerCollection {
          */
         public <T> Builder registerExact(final ScalarSerializer<T> serializer) {
             requireNonNull(serializer, "serializer");
-            return registerExact(serializer.type(), serializer);
+            return this.registerExact(serializer.type(), serializer);
         }
 
         private Builder registerExact0(final Type type, final TypeSerializer<?> serializer) {
@@ -471,7 +472,7 @@ public final class TypeSerializerCollection {
          * @since 4.0.0
          */
         public Builder registerAnnotatedObjects(final ObjectMapper.Factory factory) {
-            return register(Builder::isAnnotatedTarget, factory.asTypeSerializer());
+            return this.register(Builder::isAnnotatedTarget, factory.asTypeSerializer());
         }
 
         /**

--- a/core/src/test/java/org/spongepowered/configurate/objectmapping/ObjectMapperTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/objectmapping/ObjectMapperTest.java
@@ -33,6 +33,9 @@ import org.spongepowered.configurate.ConfigurationOptions;
 import org.spongepowered.configurate.objectmapping.meta.Comment;
 import org.spongepowered.configurate.objectmapping.meta.Setting;
 import org.spongepowered.configurate.serialize.SerializationException;
+import org.spongepowered.configurate.serialize.UpperCase;
+import org.spongepowered.configurate.serialize.UppercaseStringTypeSerializer;
+import org.spongepowered.configurate.util.UnmodifiableCollections;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -397,6 +400,31 @@ class ObjectMapperTest {
             this.two = two;
         }
 
+    }
+
+    @ConfigSerializable
+    static class TestAnnotatedTypes {
+        @UpperCase String one;
+        String two;
+    }
+
+    @Test
+    void testAnnotatedTypes() throws SerializationException {
+        final BasicConfigurationNode node = BasicConfigurationNode.root(
+            ConfigurationOptions.defaults()
+                .serializers(builder -> builder.registerAnnotated(UppercaseStringTypeSerializer::applicable, UppercaseStringTypeSerializer.INSTANCE))
+                .nativeTypes(UnmodifiableCollections.toSet(String.class))
+        );
+
+        node.act(n -> {
+            n.node("one").set("hello");
+            n.node("two").set("world");
+        });
+
+        final TestAnnotatedTypes instance = node.require(TestAnnotatedTypes.class);
+
+        assertEquals("HELLO", instance.one);
+        assertEquals("world", instance.two);
     }
 
 }

--- a/core/src/test/java/org/spongepowered/configurate/serialize/TypeSerializersTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/serialize/TypeSerializersTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.leangen.geantyref.TypeToken;
@@ -619,6 +620,49 @@ class TypeSerializersTest {
         final ConfigurationNode contents = BasicConfigurationNode.root().set("hello");
 
         assertEquals("HELLO", serializer.deserialize(type.getAnnotatedType(), contents));
+    }
+
+    @Test
+    void testAnnotatedSerializersInMap() throws SerializationException {
+        final TypeSerializerCollection collection = TypeSerializerCollection.defaults().childBuilder()
+            .registerAnnotated(UppercaseStringTypeSerializer::applicable, UppercaseStringTypeSerializer.INSTANCE)
+            .build();
+        final TypeToken<Map<String, @UpperCase String>> type = new TypeToken<Map<String, @UpperCase String>>() {};
+        final TypeSerializer<Map<String, @UpperCase String>> serializer = collection.get(type);
+        assertNotNull(serializer);
+
+        final ConfigurationNode contents = BasicConfigurationNode.root(
+            ConfigurationOptions.defaults().serializers(collection),
+            n -> {
+                n.node("hello").set("world");
+                n.node("one").set("two");
+            }
+        );
+
+        final Map<String, String> value = serializer.deserialize(type.getAnnotatedType(), contents);
+        assertEquals("WORLD", value.get("hello"));
+        assertEquals("TWO", value.get("one"));
+    }
+
+    @Test
+    void testAnnotatedSerializersInList() throws SerializationException {
+        final TypeSerializerCollection collection = TypeSerializerCollection.defaults().childBuilder()
+            .registerAnnotated(UppercaseStringTypeSerializer::applicable, UppercaseStringTypeSerializer.INSTANCE)
+            .build();
+        final TypeToken<List<@UpperCase String>> type = new TypeToken<List<@UpperCase String>>() {};
+        final TypeSerializer<List<@UpperCase String>> serializer = collection.get(type);
+        assertNotNull(serializer);
+
+        final ConfigurationNode contents = BasicConfigurationNode.root(
+            ConfigurationOptions.defaults().serializers(collection),
+            n -> {
+                n.appendListNode().set("one");
+                n.appendListNode().set("two");
+            }
+        );
+
+        final List<String> value = serializer.deserialize(type.getAnnotatedType(), contents);
+        assertEquals(ImmutableList.of("ONE", "TWO"), value);
     }
 
 }

--- a/core/src/test/java/org/spongepowered/configurate/serialize/TypeSerializersTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/serialize/TypeSerializersTest.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -603,6 +604,21 @@ class TypeSerializersTest {
 
         // Then with specifically an enum set
         assertNotNull(TypeSerializerCollection.defaults().get(new TypeToken<EnumSet<TestEnum>>() {}));
+    }
+
+    @Test
+    void testAnnotatedSerializers() throws SerializationException {
+        final TypeSerializerCollection collection = TypeSerializerCollection.defaults().childBuilder()
+            .registerAnnotated(UppercaseStringTypeSerializer::applicable, UppercaseStringTypeSerializer.INSTANCE)
+            .build();
+        final TypeToken<@UpperCase String> type = new TypeToken<@UpperCase String>() {};
+        final TypeSerializer<@UpperCase String> serializer = collection.get(type);
+        assertNotNull(serializer);
+        assertInstanceOf(TypeSerializer.Annotated.class, serializer);
+
+        final ConfigurationNode contents = BasicConfigurationNode.root().set("hello");
+
+        assertEquals("HELLO", ((TypeSerializer.Annotated<?>) serializer).deserialize(type.getAnnotatedType(), contents));
     }
 
 }

--- a/core/src/test/java/org/spongepowered/configurate/serialize/TypeSerializersTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/serialize/TypeSerializersTest.java
@@ -614,11 +614,11 @@ class TypeSerializersTest {
         final TypeToken<@UpperCase String> type = new TypeToken<@UpperCase String>() {};
         final TypeSerializer<@UpperCase String> serializer = collection.get(type);
         assertNotNull(serializer);
-        assertInstanceOf(TypeSerializer.Annotated.class, serializer);
+        assertInstanceOf(UppercaseStringTypeSerializer.class, serializer);
 
         final ConfigurationNode contents = BasicConfigurationNode.root().set("hello");
 
-        assertEquals("HELLO", ((TypeSerializer.Annotated<?>) serializer).deserialize(type.getAnnotatedType(), contents));
+        assertEquals("HELLO", serializer.deserialize(type.getAnnotatedType(), contents));
     }
 
 }

--- a/core/src/test/java/org/spongepowered/configurate/serialize/UpperCase.java
+++ b/core/src/test/java/org/spongepowered/configurate/serialize/UpperCase.java
@@ -1,0 +1,28 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spongepowered.configurate.serialize;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE_USE)
+public @interface UpperCase {
+
+}

--- a/core/src/test/java/org/spongepowered/configurate/serialize/UppercaseStringTypeSerializer.java
+++ b/core/src/test/java/org/spongepowered/configurate/serialize/UppercaseStringTypeSerializer.java
@@ -20,9 +20,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 
 import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.Type;
 import java.util.Locale;
 
-public final class UppercaseStringTypeSerializer implements TypeSerializer.Annotated<@UpperCase String> {
+public final class UppercaseStringTypeSerializer implements TypeSerializer<@UpperCase String> {
 
     public static final UppercaseStringTypeSerializer INSTANCE = new UppercaseStringTypeSerializer();
 
@@ -34,14 +35,14 @@ public final class UppercaseStringTypeSerializer implements TypeSerializer.Annot
     }
 
     @Override
-    public @UpperCase String deserialize(final AnnotatedType type, final ConfigurationNode node) throws SerializationException {
+    public @UpperCase String deserialize(final Type type, final ConfigurationNode node) throws SerializationException {
         final String string = node.getString();
         return string.toUpperCase(Locale.ROOT);
     }
 
     @Override
     public void serialize(
-        final AnnotatedType type,
+        final Type type,
         final @Nullable @UpperCase String obj,
         final ConfigurationNode node
     ) throws SerializationException {

--- a/core/src/test/java/org/spongepowered/configurate/serialize/UppercaseStringTypeSerializer.java
+++ b/core/src/test/java/org/spongepowered/configurate/serialize/UppercaseStringTypeSerializer.java
@@ -1,0 +1,56 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spongepowered.configurate.serialize;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.configurate.ConfigurationNode;
+
+import java.lang.reflect.AnnotatedType;
+import java.util.Locale;
+
+public final class UppercaseStringTypeSerializer implements TypeSerializer.Annotated<@UpperCase String> {
+
+    public static final UppercaseStringTypeSerializer INSTANCE = new UppercaseStringTypeSerializer();
+
+    public static boolean applicable(final AnnotatedType type) {
+        return type.isAnnotationPresent(UpperCase.class) && String.class.equals(type.getType());
+    }
+
+    private UppercaseStringTypeSerializer() {
+    }
+
+    @Override
+    public @UpperCase String deserialize(final AnnotatedType type, final ConfigurationNode node) throws SerializationException {
+        final String string = node.getString();
+        return string.toUpperCase(Locale.ROOT);
+    }
+
+    @Override
+    public void serialize(
+        final AnnotatedType type,
+        final @Nullable @UpperCase String obj,
+        final ConfigurationNode node
+    ) throws SerializationException {
+        if (obj == null) {
+            node.set(null);
+            return;
+        }
+
+        node.set(obj.toUpperCase(Locale.ROOT));
+    }
+
+}


### PR DESCRIPTION
Fixes #286

Do we like having TypeSerializer.Annotated as a separate subtype? or do we want to have both methods in TypeSerializer for simplicity

the casts are kinda messy, is it worth it?

~~Should we attempt to merge field annotations into the type-use annotations?~~ (no, too much work, inconsistent with constructor-based field discoverers)

Handling in map/list-based serializers