### PR TITLE
core: Add default behaviour for mapped objects where property names differ from field names

### DIFF
--- a/core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectMapperFactoryImpl.java
+++ b/core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectMapperFactoryImpl.java
@@ -332,6 +332,7 @@ final class ObjectMapperFactoryImpl implements ObjectMapper.Factory, TypeSeriali
                 .addNodeResolver(NodeResolver.nodeKey())
                 .addNodeResolver(NodeResolver.keyFromSetting())
                 .addNodeResolver(NodeResolver.nodeFromParent())
+                .addNodeResolver(NodeResolver.propertyKey())
                 // Constraints and processors //
                 .addProcessor(Comment.class, Processor.comments())
                 .addConstraint(Matches.class, String.class, Constraint.pattern())

--- a/core/src/main/java/org/spongepowered/configurate/objectmapping/meta/NodeResolver.java
+++ b/core/src/main/java/org/spongepowered/configurate/objectmapping/meta/NodeResolver.java
@@ -151,4 +151,20 @@ public interface NodeResolver {
         };
     }
 
+    /**
+     * A resolver for the {@link org.spongepowered.configurate.objectmapping.meta.PropertyKey} annotation.
+     *
+     * @return resolver using specified key
+     * @since 4.2.0
+     */
+    static NodeResolver.Factory propertyKey() {
+        return (name, element) -> {
+            final @Nullable PropertyKey propertyKey = element.getAnnotation(PropertyKey.class);
+            if (propertyKey != null) {
+                return containerNode -> containerNode.node(propertyKey.value());
+            }
+            return null;
+        };
+    }
+
 }

--- a/core/src/main/java/org/spongepowered/configurate/objectmapping/meta/PropertyKey.java
+++ b/core/src/main/java/org/spongepowered/configurate/objectmapping/meta/PropertyKey.java
@@ -1,0 +1,42 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spongepowered.configurate.objectmapping.meta;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a field that uses a key that differs from its name.
+ *
+ * @since 4.2.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+@Documented
+public @interface PropertyKey {
+    /**
+     * The key to use to find this fields value.
+     *
+     * @return the key
+     * @since 4.2.0
+     */
+    String value();
+
+}


### PR DESCRIPTION
## Basic usage:
```java
@ConfigSerializable
static class Example {

    @PropertyKey("realKey")
    private String field = "defaultValue";

}
```
will serialize to/from a node `"realKey" = "defaultValue"` rather than `"field" = "defaultValue"`

More usage examples can be found in `org.spongepowered.configurate.objectmapping.NodeResolverTest`

## Notes / Open Questions:
* I added `@since 4.2.0` to the javadoc of my additions - is this the correct version?
* You might want to mention this addition in the wiki [here](https://github.com/SpongePowered/Configurate/wiki/Object-Mapper#naming-scheme) (or wherever else you think is best) - should I / can I do that?