### PR TITLE
fix: include field annotations in AnnotatedType

### DIFF
--- a/core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectFieldDiscoverer.java
+++ b/core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectFieldDiscoverer.java
@@ -19,6 +19,7 @@ package org.spongepowered.configurate.objectmapping;
 import static io.leangen.geantyref.GenericTypeReflector.erase;
 import static io.leangen.geantyref.GenericTypeReflector.getExactSuperType;
 import static io.leangen.geantyref.GenericTypeReflector.getFieldType;
+import static io.leangen.geantyref.GenericTypeReflector.updateAnnotations;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.configurate.serialize.SerializationException;
@@ -149,7 +150,7 @@ class ObjectFieldDiscoverer implements FieldDiscoverer<Map<Field, Object>> {
 
             field.setAccessible(true);
             final AnnotatedType fieldType = getFieldType(field, clazz);
-            fieldMaker.accept(field.getName(), fieldType, Types.combinedAnnotations(fieldType, field),
+            fieldMaker.accept(field.getName(), updateAnnotations(fieldType, field.getAnnotations()), Types.combinedAnnotations(fieldType, field),
                               (intermediate, val, implicitProvider) -> {
                     if (val != null) {
                         intermediate.put(field, val);

--- a/core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectFieldDiscoverer.java
+++ b/core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectFieldDiscoverer.java
@@ -150,7 +150,7 @@ class ObjectFieldDiscoverer implements FieldDiscoverer<Map<Field, Object>> {
 
             field.setAccessible(true);
             final AnnotatedType fieldType = getFieldType(field, clazz);
-            fieldMaker.accept(field.getName(), updateAnnotations(fieldType, field.getAnnotations()), Types.combinedAnnotations(fieldType, field),
+            fieldMaker.accept(field.getName(), fieldType, Types.combinedAnnotations(fieldType, field),
                               (intermediate, val, implicitProvider) -> {
                     if (val != null) {
                         intermediate.put(field, val);

--- a/core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectFieldDiscoverer.java
+++ b/core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectFieldDiscoverer.java
@@ -19,7 +19,6 @@ package org.spongepowered.configurate.objectmapping;
 import static io.leangen.geantyref.GenericTypeReflector.erase;
 import static io.leangen.geantyref.GenericTypeReflector.getExactSuperType;
 import static io.leangen.geantyref.GenericTypeReflector.getFieldType;
-import static io.leangen.geantyref.GenericTypeReflector.updateAnnotations;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.configurate.serialize.SerializationException;

--- a/core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectMapperFactoryImpl.java
+++ b/core/src/main/java/org/spongepowered/configurate/objectmapping/ObjectMapperFactoryImpl.java
@@ -21,6 +21,7 @@ import static io.leangen.geantyref.GenericTypeReflector.box;
 import static io.leangen.geantyref.GenericTypeReflector.erase;
 import static io.leangen.geantyref.GenericTypeReflector.isMissingTypeParameters;
 import static io.leangen.geantyref.GenericTypeReflector.isSuperType;
+import static io.leangen.geantyref.GenericTypeReflector.updateAnnotations;
 import static java.util.Objects.requireNonNull;
 
 import io.leangen.geantyref.GenericTypeReflector;
@@ -215,7 +216,8 @@ final class ObjectMapperFactoryImpl implements ObjectMapper.Factory, TypeSeriali
             }
         }
 
-        fields.add(FieldData.of(name, type, constraints, processors, deserializer, serializer, resolver));
+        final AnnotatedType combinedType = updateAnnotations(type, container.getAnnotations());
+        fields.add(FieldData.of(name, combinedType, constraints, processors, deserializer, serializer, resolver));
     }
 
     // TypeSerializer //

--- a/core/src/test/java/org/spongepowered/configurate/objectmapping/ObjectMapperTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/objectmapping/ObjectMapperTest.java
@@ -406,6 +406,8 @@ class ObjectMapperTest {
     static class TestAnnotatedTypes {
         @UpperCase String one;
         String two;
+        @UpperCase.Field
+        String three;
     }
 
     @Test
@@ -419,12 +421,14 @@ class ObjectMapperTest {
         node.act(n -> {
             n.node("one").set("hello");
             n.node("two").set("world");
+            n.node("three").set("three");
         });
 
         final TestAnnotatedTypes instance = node.require(TestAnnotatedTypes.class);
 
         assertEquals("HELLO", instance.one);
         assertEquals("world", instance.two);
+        assertEquals("THREE", instance.three);
     }
 
 }

--- a/core/src/test/java/org/spongepowered/configurate/serialize/UpperCase.java
+++ b/core/src/test/java/org/spongepowered/configurate/serialize/UpperCase.java
@@ -25,4 +25,9 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE_USE)
 public @interface UpperCase {
 
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface Field {
+    }
+
 }

--- a/core/src/test/java/org/spongepowered/configurate/serialize/UppercaseStringTypeSerializer.java
+++ b/core/src/test/java/org/spongepowered/configurate/serialize/UppercaseStringTypeSerializer.java
@@ -28,7 +28,7 @@ public final class UppercaseStringTypeSerializer implements TypeSerializer<@Uppe
     public static final UppercaseStringTypeSerializer INSTANCE = new UppercaseStringTypeSerializer();
 
     public static boolean applicable(final AnnotatedType type) {
-        return type.isAnnotationPresent(UpperCase.class) && String.class.equals(type.getType());
+        return (type.isAnnotationPresent(UpperCase.class) || type.isAnnotationPresent(UpperCase.Field.class)) && String.class.equals(type.getType());
     }
 
     private UppercaseStringTypeSerializer() {


### PR DESCRIPTION
Previously, only TYPE_USE annotations were included in the AnnotatedType from fields in an ObjectMapper. This updates the AnnotatedType to include the field annotations. Added a test to ensure this behavior.

Fixes #350 