### PR TITLE
Added support for YAML comments

### DIFF
--- a/format/yaml/src/main/java/org/spongepowered/configurate/yaml/YamlConfigurationLoader.java
+++ b/format/yaml/src/main/java/org/spongepowered/configurate/yaml/YamlConfigurationLoader.java
@@ -29,7 +29,6 @@ import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
-import org.yaml.snakeyaml.representer.Representer;
 
 import java.io.BufferedReader;
 import java.io.Writer;
@@ -175,7 +174,8 @@ public final class YamlConfigurationLoader extends AbstractConfigurationLoader<C
 
         final DumperOptions opts = builder.options;
         opts.setDefaultFlowStyle(NodeStyle.asSnakeYaml(builder.style));
-        this.yaml = ThreadLocal.withInitial(() -> new Yaml(new Constructor(loaderOpts), new Representer(opts), opts, loaderOpts));
+        opts.setProcessComments(true);
+        this.yaml = ThreadLocal.withInitial(() -> new Yaml(new Constructor(loaderOpts), new YamlRepresenter(opts), opts, loaderOpts));
     }
 
     @Override
@@ -185,7 +185,7 @@ public final class YamlConfigurationLoader extends AbstractConfigurationLoader<C
 
     @Override
     protected void saveInternal(final ConfigurationNode node, final Writer writer) {
-        this.yaml.get().dump(node.raw(), writer);
+        this.yaml.get().dump(node, writer);
     }
 
     @Override

--- a/format/yaml/src/main/java/org/spongepowered/configurate/yaml/YamlRepresenter.java
+++ b/format/yaml/src/main/java/org/spongepowered/configurate/yaml/YamlRepresenter.java
@@ -1,0 +1,100 @@
+/*
+ * Configurate
+ * Copyright (C) zml and Configurate contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spongepowered.configurate.yaml;
+
+import static org.spongepowered.configurate.loader.AbstractConfigurationLoader.CONFIGURATE_LINE_PATTERN;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.configurate.CommentedConfigurationNodeIntermediary;
+import org.spongepowered.configurate.ConfigurationNode;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.DumperOptions.FlowStyle;
+import org.yaml.snakeyaml.comments.CommentLine;
+import org.yaml.snakeyaml.comments.CommentType;
+import org.yaml.snakeyaml.nodes.MappingNode;
+import org.yaml.snakeyaml.nodes.Node;
+import org.yaml.snakeyaml.nodes.NodeTuple;
+import org.yaml.snakeyaml.nodes.SequenceNode;
+import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.representer.Represent;
+import org.yaml.snakeyaml.representer.Representer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+final class YamlRepresenter extends Representer {
+
+    YamlRepresenter(final DumperOptions options) {
+        super(options);
+        multiRepresenters.put(ConfigurationNode.class, new ConfigurationNodeRepresent());
+    }
+
+    private final class ConfigurationNodeRepresent implements Represent {
+        @Override
+        public Node representData(final Object nodeObject) {
+            final ConfigurationNode node = (ConfigurationNode) nodeObject;
+
+            final Node yamlNode;
+            if (node.isMap()) {
+                final List<NodeTuple> children = new ArrayList<>();
+                for (Map.Entry<Object, ? extends ConfigurationNode> ent : node.childrenMap().entrySet()) {
+                    // SnakeYAML supports both key as value comments. Add the comments on the key
+                    final Node value = represent(ent.getValue());
+                    final Node key = represent(String.valueOf(ent.getKey()));
+                    key.setBlockComments(value.getBlockComments());
+                    value.setBlockComments(Collections.emptyList());
+
+                    children.add(new NodeTuple(key, value));
+                }
+                yamlNode = new MappingNode(Tag.MAP, children, FlowStyle.AUTO);
+            } else if (node.isList()) {
+                final List<Node> children = new ArrayList<>();
+                for (ConfigurationNode ent : node.childrenList()) {
+                    children.add(represent(ent));
+                }
+                yamlNode = new SequenceNode(Tag.SET, children, FlowStyle.AUTO);
+            } else {
+                yamlNode = represent(node.rawScalar());
+            }
+
+            if (node instanceof CommentedConfigurationNodeIntermediary<?>) {
+                final @Nullable String nodeComment = ((CommentedConfigurationNodeIntermediary<?>) node).comment();
+                if (nodeComment != null) {
+                    yamlNode.setBlockComments(
+                        Arrays.stream(CONFIGURATE_LINE_PATTERN.split(nodeComment))
+                            .map(this::commentLineFor)
+                            .collect(Collectors.toList())
+                    );
+                }
+            }
+
+            return yamlNode;
+        }
+
+        private CommentLine commentLineFor(final String comment) {
+            // prepend a space before the comment:
+            // before: #hello
+            // after:  # hello
+            return new CommentLine(null, null, " " + comment, CommentType.BLOCK);
+        }
+    }
+
+}

--- a/format/yaml/src/test/java/org/spongepowered/configurate/yaml/YamlConfigurationLoaderTest.java
+++ b/format/yaml/src/test/java/org/spongepowered/configurate/yaml/YamlConfigurationLoaderTest.java
@@ -105,6 +105,30 @@ class YamlConfigurationLoaderTest {
         assertEquals(readLines(this.getClass().getResource("write-expected.yml")), Files.readAllLines(target, StandardCharsets.UTF_8));
     }
 
+    @Test
+    void testWriteComments(final @TempDir Path tempDir) throws IOException {
+        final Path target = tempDir.resolve("comments-actual.yml");
+        final ConfigurationNode node = CommentedConfigurationNode.root(n ->
+            n.node("pizza")
+                .comment("john's")
+                .act(p ->
+                    p.node("pineapple")
+                        .set(true)
+                        .comment("who doesn't love a good pineapple\non a pizza??")));
+
+        final YamlConfigurationLoader loader = YamlConfigurationLoader.builder()
+            .path(target)
+            .nodeStyle(NodeStyle.BLOCK)
+            .build();
+
+        loader.save(node);
+
+        assertEquals(
+            readLines(this.getClass().getResource("comments-expected.yml")),
+            Files.readAllLines(target, StandardCharsets.UTF_8)
+        );
+    }
+
     private static List<String> readLines(final URL source) throws IOException {
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(source.openStream(), StandardCharsets.UTF_8))) {
             return reader.lines().collect(Collectors.toList());

--- a/format/yaml/src/test/resources/org/spongepowered/configurate/yaml/comments-expected.yml
+++ b/format/yaml/src/test/resources/org/spongepowered/configurate/yaml/comments-expected.yml
@@ -1,0 +1,5 @@
+# john's
+pizza:
+    # who doesn't love pineapple
+    # on a pizza??
+    pineapple: true


### PR DESCRIPTION
Let me know if you want to see changes.
This should add support for comments on the keys for maps, and on the value for everything else.
```yml
# key comment
hello:
    world: true # value comment
```