### PR TITLE
Fix list value cannot be de-serialized

### DIFF
--- a/core/src/main/java/org/spongepowered/configurate/AbstractConfigurationNode.java
+++ b/core/src/main/java/org/spongepowered/configurate/AbstractConfigurationNode.java
@@ -671,7 +671,7 @@ abstract class AbstractConfigurationNode<N extends ScopedConfigurationNode<N>, A
                 }
             } else {
                 // if the existing value isn't a map, we need to update it's type
-                if (ListConfigValue.likelyListKey(child.key)) {
+                if (ListConfigValue.likelyNewListKey(child.key) || ListConfigValue.likelyListKey(oldValue, child.key)) {
                     // if child.key is an integer, we can infer that the type of this node should be a list
                     if (oldValue instanceof NullConfigValue) {
                         // if the oldValue was null, we can just replace it with an empty list

--- a/core/src/main/java/org/spongepowered/configurate/ListConfigValue.java
+++ b/core/src/main/java/org/spongepowered/configurate/ListConfigValue.java
@@ -50,13 +50,32 @@ final class ListConfigValue<N extends ScopedConfigurationNode<N>, A extends Abst
     };
 
     /**
-     * Return whether a key is likely to be an index into a list.
+     * Return whether a key is likely to create a new list.
      *
      * @param key key to check
-     * @return if the key is likely to be a list index
+     * @return if the key is likely to create a new list.
      */
-    static boolean likelyListKey(final @Nullable Object key) {
+    static boolean likelyNewListKey(final @Nullable Object key) {
         return (key instanceof Integer && ((Integer) key).intValue() == 0) || key == UNALLOCATED_IDX;
+    }
+
+    /**
+     * Return whether a key is likely to be an index into a list.
+     *
+     * @param configValue the list to check
+     * @param key         key to check
+     * @return if the key is likely to be  an index into a list.
+     */
+    static boolean likelyListKey(final @Nullable ConfigValue<?, ?> configValue, final @Nullable Object key) {
+        if (!(configValue instanceof ListConfigValue<?, ?>)) {
+            return false;
+        }
+        if (!(key instanceof Integer)) {
+            return false;
+        }
+        final ListConfigValue<?, ?> listConfigValue = (ListConfigValue<?, ?>) configValue;
+        final int keyAsInt = (Integer) key;
+        return keyAsInt >= 0 && keyAsInt <= listConfigValue.values.size();
     }
 
     private final A holder;

--- a/core/src/test/java/org/spongepowered/configurate/AbstractConfigurationNodeTest.java
+++ b/core/src/test/java/org/spongepowered/configurate/AbstractConfigurationNodeTest.java
@@ -151,6 +151,15 @@ class AbstractConfigurationNodeTest {
     }
 
     @Test
+    void testLisUnpacking2() {
+        final ConfigurationNode root = BasicConfigurationNode.root();
+        final ConfigurationNode subnode = root.node("subnode");
+        subnode.node(0).raw("test1");
+        subnode.node(1).raw("test2");
+        assertEquals(TEST_LIST, subnode.raw());
+    }
+
+    @Test
     void testListPacking() {
         final ConfigurationNode root = BasicConfigurationNode.root();
         root.appendListNode().raw("test1");


### PR DESCRIPTION
After 621e7915d314c356b213c08e9dde07e1cbe8c121, deserialize hocon config list value will got wrong thing.

As example, deserializing following config

```conf
subnode = [
  114, 514
]
```

will got wrong response:

```
var node = HoconConfiguationLoader.builder().file(....).load();
var subnode = node.node("subnode");

System.out.println(subnode.isMap()); // true
System.out.println(subnode.raw()); // {1=514}
```