### PR TITLE
Switch to `kotlin.reflect.typeOf` for `configurate-extra-kotlin`

### DIFF
--- a/core/src/main/java/org/spongepowered/configurate/ConfigurationNode.java
+++ b/core/src/main/java/org/spongepowered/configurate/ConfigurationNode.java
@@ -30,10 +30,7 @@ import org.spongepowered.configurate.serialize.TypeSerializer;
 
 import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Type;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
+import java.util.*;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 
@@ -735,6 +732,69 @@ public interface ConfigurationNode {
         final TypeToken<List<V>> type = makeListType(elementType);
         final List<V> ret = this.get(type, defSupplier);
         return ret.isEmpty() ? storeDefault(this, type.getType(), defSupplier.get()) : ret;
+    }
+
+    /**
+     * If this node has list values, this function unwraps them and converts
+     * them to an appropriate type based on the provided function.
+     *
+     * <p>If this node has a scalar value, this function treats it as a list
+     * with one value.</p>
+     *
+     * @param elementType the expected type
+     * @return an immutable copy of the values contained
+     * @throws SerializationException if any value fails to be converted to the
+     *                                requested type
+     * @since TODO: version
+     */
+    default @Nullable List<?> getList(Type elementType) throws SerializationException {
+        return (List<?>) this.get(TypeFactory.parameterizedClass(List.class, elementType));
+    }
+
+    /**
+     * If this node has list values, this function unwraps them and converts
+     * them to an appropriate type based on the provided function.
+     *
+     * <p>If this node has a scalar value, this function treats it as a list
+     * with one value.</p>
+     *
+     * @param elementType expected type
+     * @param def default value if no appropriate value is set
+     * @return an immutable copy of the values contained that could be
+     *         successfully converted, or {@code def} if no values could be
+     *         converted.
+     * @throws SerializationException if any value fails to be converted to the
+     *                                requested type
+     * @since TODO: version
+     */
+    default List<?> getList(Type elementType, List<?> def) throws SerializationException {
+        final Type type = TypeFactory.parameterizedClass(List.class, elementType);
+        final List<?> ret = (List<?>) this.get(type, def);
+        return ret.isEmpty() ? storeDefault(this, type, def) : ret;
+    }
+
+    /**
+     * If this node has list values, this function unwraps them and converts
+     * them to an appropriate type based on the provided function.
+     *
+     * <p>If this node has a scalar value, this function treats it as a list
+     * with one value.</p>
+     *
+     * @param elementType expected type
+     * @param defSupplier function that will be called to calculate a default
+     *                    value only if there is no existing value of the
+     *                    correct type
+     * @return an immutable copy of the values contained that could be
+     *         successfully converted, or {@code def} if no values could be
+     *         converted.
+     * @throws SerializationException if any value fails to be converted to the
+     *                                requested type
+     * @since TODO: version
+     */
+    default List<?> getList(Type elementType, Supplier<List<?>> defSupplier) throws SerializationException {
+        final Type type = TypeFactory.parameterizedClass(List.class, elementType);
+        final List<?> ret = (List<?>) this.get(type, defSupplier);
+        return ret.isEmpty() ? storeDefault(this, type, defSupplier.get()) : ret;
     }
 
     /**

--- a/core/src/main/java/org/spongepowered/configurate/reference/ConfigurationReference.java
+++ b/core/src/main/java/org/spongepowered/configurate/reference/ConfigurationReference.java
@@ -27,6 +27,7 @@ import org.spongepowered.configurate.reactive.Publisher;
 import org.spongepowered.configurate.reactive.TransactionalSubscriber;
 import org.spongepowered.configurate.serialize.SerializationException;
 
+import java.lang.reflect.Type;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.ForkJoinPool;
@@ -271,6 +272,10 @@ public interface ConfigurationReference<N extends ConfigurationNode> extends Aut
         this.node().node(path).set(type, value);
     }
 
+    default ValueReference<?, N> referenceTo(final Type type, final Object... path) throws SerializationException {
+        return this.referenceTo(type, NodePath.of(path));
+    }
+    
     /**
      * Create a reference to the node at the provided path. The value will be
      * deserialized according to the provided TypeToken.
@@ -309,6 +314,25 @@ public interface ConfigurationReference<N extends ConfigurationNode> extends Aut
      */
     default <T> ValueReference<T, N> referenceTo(final Class<T> type, final Object... path) throws SerializationException {
         return this.referenceTo(type, NodePath.of(path));
+    }
+    
+    /**
+     * Create a reference to the node at the provided path. The value will be
+     * deserialized according to the provided {@link Type}.
+     *
+     * <p>The returned reference will update with reloads of and changes to the
+     * value of the provided configuration. Any serialization errors encountered
+     * will be submitted to the {@link #errors()} stream.
+     *
+     * @param type the value's type
+     * @param path the path from the root node to the node containing the value
+     * @return a deserializing reference to the node at the given path
+     * @throws SerializationException if a type serializer could not be found
+     *         for the provided type
+     * @since TODO: version
+     */
+    default ValueReference<?, N> referenceTo(final Type type, final NodePath path) throws SerializationException {
+        return this.referenceTo(type, path, null);
     }
 
     /**
@@ -350,6 +374,23 @@ public interface ConfigurationReference<N extends ConfigurationNode> extends Aut
     default <T> ValueReference<T, N> referenceTo(final Class<T> type, final NodePath path) throws SerializationException {
         return this.referenceTo(type, path, null);
     }
+
+    /**
+     * Create a reference to the node at the provided path. The value will be
+     * deserialized according to the provided {@link Type}.
+     *
+     * <p>The returned reference will update with reloads of and changes to the
+     * value of the provided configuration. Any serialization errors encountered
+     * will be submitted to the {@link #errors()} stream.
+     *
+     * @param type the value's type
+     * @param path the path from the root node to the node containing the value
+     * @return a deserializing reference to the node at the given path
+     * @throws SerializationException if a type serializer could not be found
+     *          for the provided type
+     * @since TODO: version
+     */
+    ValueReference<?, N> referenceTo(Type type, NodePath path, @Nullable Object defaultValue) throws SerializationException;
 
     /**
      * Create a reference to the node at the provided path. The value will be

--- a/core/src/main/java/org/spongepowered/configurate/reference/ConfigurationReference.java
+++ b/core/src/main/java/org/spongepowered/configurate/reference/ConfigurationReference.java
@@ -272,6 +272,21 @@ public interface ConfigurationReference<N extends ConfigurationNode> extends Aut
         this.node().node(path).set(type, value);
     }
 
+    /**
+     * Create a reference to the node at the provided path. The value will be
+     * deserialized according to the provided {@link Type}.
+     *
+     * <p>The returned reference will update with reloads of and changes to the
+     * value of the provided configuration. Any serialization errors encountered
+     * will be submitted to the {@link #errors()} stream.
+     *
+     * @param type the value's type
+     * @param path the path from the root node to the node containing the value
+     * @return a deserializing reference to the node at the given path
+     * @throws SerializationException if a type serializer could not be found
+     *         for the provided type
+     * @since TODO: version
+     */
     default ValueReference<?, N> referenceTo(final Type type, final Object... path) throws SerializationException {
         return this.referenceTo(type, NodePath.of(path));
     }

--- a/core/src/main/java/org/spongepowered/configurate/reference/ManualConfigurationReference.java
+++ b/core/src/main/java/org/spongepowered/configurate/reference/ManualConfigurationReference.java
@@ -30,6 +30,7 @@ import org.spongepowered.configurate.reactive.Processor;
 import org.spongepowered.configurate.reactive.Publisher;
 import org.spongepowered.configurate.serialize.SerializationException;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
@@ -125,8 +126,13 @@ class ManualConfigurationReference<N extends ScopedConfigurationNode<N>> impleme
     }
 
     @Override
-    public final <T> ValueReference<T, N> referenceTo(final TypeToken<T> type,
-            final NodePath path, final @Nullable T def) throws SerializationException {
+    public final ValueReference<?, N> referenceTo(final Type type,
+            final NodePath path, final @Nullable Object def) throws SerializationException {
+        return new ValueReferenceImpl<>(this, path, type, def);
+    }
+
+    @Override
+    public final <T> ValueReference<T, N> referenceTo(final TypeToken<T> type, final NodePath path, final @Nullable T def) throws SerializationException {
         return new ValueReferenceImpl<>(this, path, type, def);
     }
 

--- a/extra/kotlin/build.gradle
+++ b/extra/kotlin/build.gradle
@@ -23,12 +23,12 @@ dependencies {
 }
 
 kotlin {
-    coreLibrariesVersion = "1.4.20"
+    coreLibrariesVersion = "1.8.20"
     target {
         compilations.configureEach {
             kotlinOptions {
                 jvmTarget = "1.8"
-                languageVersion = "1.4"
+                languageVersion = "1.8"
                 freeCompilerArgs += ["-opt-in=kotlin.RequiresOptIn", "-Xemit-jvm-type-annotations"]
             }
         }

--- a/extra/kotlin/src/main/kotlin/org/spongepowered/configurate/kotlin/ObjectMapping.kt
+++ b/extra/kotlin/src/main/kotlin/org/spongepowered/configurate/kotlin/ObjectMapping.kt
@@ -38,6 +38,8 @@ import org.spongepowered.configurate.objectmapping.FieldDiscoverer
 import org.spongepowered.configurate.objectmapping.ObjectMapper
 import org.spongepowered.configurate.objectmapping.ObjectMapper.Factory
 import org.spongepowered.configurate.util.Types.combinedAnnotations
+import kotlin.reflect.jvm.javaType
+import kotlin.reflect.typeOf
 
 private val dataClassMapperFactory =
     ObjectMapper.factoryBuilder().addDiscoverer(DataClassFieldDiscoverer).build()
@@ -60,16 +62,15 @@ fun dataClassFieldDiscoverer(): FieldDiscoverer<*> {
 }
 
 /** Get an object mapper for the type [T] using the default object mapper factory */
+@Suppress("UNCHECKED_CAST")
 inline fun <reified T> objectMapper(): ObjectMapper<T> {
-    return objectMapperFactory()[typeTokenOf()]
+    return objectMapperFactory()[typeOf<T>().javaType] as ObjectMapper<T>
 }
 
 /** Get an object mapper bound to the instance of [T], resolving type parameters */
 inline fun <reified T> T.toNode(target: ConfigurationNode) {
     return objectMapperFactory().get<T>().save(this, target)
 }
-
-@PublishedApi internal inline fun <reified T> typeTokenOf() = object : TypeToken<T>() {}
 
 /**
  * A field discoverer that gathers definitions from kotlin `data` classes.

--- a/extra/kotlin/src/main/kotlin/org/spongepowered/configurate/kotlin/extensions/ConfigurationNodeExtensions.kt
+++ b/extra/kotlin/src/main/kotlin/org/spongepowered/configurate/kotlin/extensions/ConfigurationNodeExtensions.kt
@@ -16,12 +16,14 @@
  */
 package org.spongepowered.configurate.kotlin.extensions
 
-import kotlin.reflect.KClass
 import org.spongepowered.configurate.ConfigurationNode
 import org.spongepowered.configurate.NodePath
 import org.spongepowered.configurate.ScopedConfigurationNode
-import org.spongepowered.configurate.kotlin.typeTokenOf
 import org.spongepowered.configurate.serialize.SerializationException
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.jvm.javaType
+import kotlin.reflect.typeOf
 
 /**
  * An implementation of `contains` that can traverse multiple levels in [path].
@@ -58,7 +60,7 @@ operator fun ConfigurationNode.contains(path: Any): Boolean {
  */
 @Throws(SerializationException::class)
 inline fun <reified V> ConfigurationNode.get(): V? {
-    return get(typeTokenOf<V>())
+    return get(typeOf<V>().javaType) as V?
 }
 
 /**
@@ -68,7 +70,7 @@ inline fun <reified V> ConfigurationNode.get(): V? {
  */
 @Throws(SerializationException::class)
 inline fun <reified V> ConfigurationNode.get(default: V): V {
-    return get(typeTokenOf(), default)
+    return get(typeOf<V>().javaType, default) as V
 }
 
 /**
@@ -103,9 +105,36 @@ fun <T : Any> ConfigurationNode.get(type: KClass<T>, default: () -> T): T {
  *
  * @see ConfigurationNode.get
  */
+fun ConfigurationNode.get(type: KType): Any? {
+    return get(type.javaType)
+}
+
+/**
+ * Get a value from the receiver using the type parameter.
+ *
+ * @see ConfigurationNode.get
+ */
+fun ConfigurationNode.get(type: KType, default: Any): Any {
+    return get(type.javaType, default)
+}
+
+/**
+ * Get a value from the receiver using the type parameter.
+ *
+ * @see ConfigurationNode.get
+ */
+fun ConfigurationNode.get(type: KType, default: () -> Any): Any {
+    return get(type.javaType, default)
+}
+
+/**
+ * Get a value from the receiver using the type parameter.
+ *
+ * @see ConfigurationNode.get
+ */
 @Throws(SerializationException::class)
 inline fun <reified V> ConfigurationNode.get(noinline default: () -> V): V {
-    return get(typeTokenOf<V>(), default)
+    return get(typeOf<V>().javaType, default) as V
 }
 
 /**
@@ -115,7 +144,7 @@ inline fun <reified V> ConfigurationNode.get(noinline default: () -> V): V {
  */
 @Throws(SerializationException::class)
 inline fun <reified V> ConfigurationNode.typedSet(value: V?) {
-    set(typeTokenOf(), value)
+    set(typeOf<V>().javaType, value)
 }
 
 /**
@@ -137,6 +166,34 @@ fun <T : Any> ConfigurationNode.getList(type: KClass<T>, default: List<T>): List
 }
 
 /**
+ * Get a list value from the receiver using a Kotlin type.
+ *
+ * @see ConfigurationNode.getList
+ */
+fun ConfigurationNode.getList(type: KType): List<*>? {
+    return getList(type.javaType)
+}
+
+/**
+ * Get a list value from the receiver using a Kotlin type.
+ *
+ * @see ConfigurationNode.getList
+ */
+fun ConfigurationNode.getList(type: KType, default: List<*>): List<*> {
+    return getList(type.javaType, default)
+}
+
+/**
+ * Get a list value with element type [T] from the receiver.
+ *
+ * @see ConfigurationNode.getList
+ */
+@Suppress("UNCHECKED_CAST")
+inline fun <reified T> ConfigurationNode.getList(default: List<T>): List<T> {
+    return getList(typeOf<T>().javaType, default) as List<T>
+}
+
+/**
  * Set a value on the receiver described by a kotlin class.
  *
  * @see ConfigurationNode.set
@@ -150,6 +207,24 @@ fun <T : Any> ConfigurationNode.set(type: KClass<T>, value: T?): ConfigurationNo
  *
  * @see ConfigurationNode.set
  */
+fun ConfigurationNode.set(type: KType, value: Any?): ConfigurationNode {
+    return set(type.javaType, value)
+}
+
+/**
+ * Set a value on the receiver described by a kotlin class.
+ *
+ * @see ConfigurationNode.set
+ */
 fun <T : Any, N : ScopedConfigurationNode<N>> N.set(type: KClass<T>, value: T?): N {
     return set(type.java, value)
+}
+
+/**
+ * Set a value on the receiver described by a kotlin class.
+ *
+ * @see ConfigurationNode.set
+ */
+fun <T : Any, N : ScopedConfigurationNode<N>> N.set(type: KType, value: T?): N {
+    return set(type.javaType, value)
 }

--- a/extra/kotlin/src/main/kotlin/org/spongepowered/configurate/kotlin/extensions/ConfigurationReferenceExtensions.kt
+++ b/extra/kotlin/src/main/kotlin/org/spongepowered/configurate/kotlin/extensions/ConfigurationReferenceExtensions.kt
@@ -18,20 +18,23 @@ package org.spongepowered.configurate.kotlin.extensions
 
 import kotlinx.coroutines.flow.Flow
 import org.spongepowered.configurate.ScopedConfigurationNode
-import org.spongepowered.configurate.kotlin.typeTokenOf
 import org.spongepowered.configurate.reference.ConfigurationReference
 import org.spongepowered.configurate.reference.ValueReference
+import kotlin.reflect.jvm.javaType
+import kotlin.reflect.typeOf
 
 /** Create a flow with events for every refresh of a value backing this reference */
+@Suppress("UNCHECKED_CAST")
 inline fun <reified T : Any, N : ScopedConfigurationNode<N>> ConfigurationReference<N>.flowOf(
     vararg path: Any
 ): Flow<T> {
-    return this.referenceTo<T>(typeTokenOf(), *path).asFlow()
+    return (this.referenceTo(typeOf<T>().javaType, *path) as ValueReference<T, N>).asFlow()
 }
 
 /** Get a reference to the value of type [T] at [path]. */
+@Suppress("UNCHECKED_CAST")
 inline fun <reified T : Any, N : ScopedConfigurationNode<N>> ConfigurationReference<N>.referenceTo(
     vararg path: Any
 ): ValueReference<T, N> {
-    return this.referenceTo(typeTokenOf(), *path)
+    return this.referenceTo(typeOf<T>().javaType, *path) as ValueReference<T, N>
 }

--- a/extra/kotlin/src/main/kotlin/org/spongepowered/configurate/kotlin/extensions/ObjectMapperExtensions.kt
+++ b/extra/kotlin/src/main/kotlin/org/spongepowered/configurate/kotlin/extensions/ObjectMapperExtensions.kt
@@ -17,7 +17,6 @@
 package org.spongepowered.configurate.kotlin.extensions
 
 import kotlin.reflect.KClass
-import org.spongepowered.configurate.kotlin.typeTokenOf
 import org.spongepowered.configurate.objectmapping.ObjectMapper
 import org.spongepowered.configurate.objectmapping.ObjectMapper.Factory
 import org.spongepowered.configurate.objectmapping.ObjectMapper.Factory.Builder
@@ -25,13 +24,25 @@ import org.spongepowered.configurate.objectmapping.meta.Constraint
 import org.spongepowered.configurate.objectmapping.meta.Processor
 import org.spongepowered.configurate.serialize.TypeSerializer
 import org.spongepowered.configurate.serialize.TypeSerializerCollection
+import kotlin.reflect.KType
+import kotlin.reflect.jvm.javaType
+import kotlin.reflect.typeOf
 
 /**
  * Create an object mapper with the given [Factory] for objects of type [T], accepting parameterized
  * types.
  */
+@Suppress("UNCHECKED_CAST")
 inline fun <reified T> Factory.get(): ObjectMapper<T> {
-    return get(typeTokenOf())
+    return get(typeOf<T>().javaType) as ObjectMapper<T>
+}
+
+/**
+ * Create an object mapper with the given [Factory] for objects of type [type], accepting parameterized
+ * types.
+ */
+fun Factory.get(type: KType): ObjectMapper<*> {
+    return get(type.javaType)
 }
 
 /**
@@ -46,8 +57,16 @@ fun <T : Any> Factory.get(type: KClass<T>): ObjectMapper<T> {
 /**
  * Get the appropriate [TypeSerializer] for the provided type [T], or null if none is applicable.
  */
+@Suppress("UNCHECKED_CAST")
 inline fun <reified T> TypeSerializerCollection.get(): TypeSerializer<T>? {
-    return get(typeTokenOf())
+    return get(typeOf<T>().javaType) as TypeSerializer<T>?
+}
+
+/**
+ * Get the appropriate [TypeSerializer] for the provided type [type], or null if none is applicable.
+ */
+fun TypeSerializerCollection.get(type: KType): TypeSerializer<*>? {
+    return get(type.javaType)
 }
 
 /**

--- a/extra/kotlin/src/main/kotlin/org/spongepowered/configurate/kotlin/extensions/PublisherExtensions.kt
+++ b/extra/kotlin/src/main/kotlin/org/spongepowered/configurate/kotlin/extensions/PublisherExtensions.kt
@@ -16,21 +16,19 @@
  */
 package org.spongepowered.configurate.kotlin.extensions
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.channels.sendBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.runBlocking
 import org.spongepowered.configurate.reactive.Publisher
 import org.spongepowered.configurate.reactive.Subscriber
 
 /** Given an [Publisher] instance, return a new [Flow] emitting values from the Flow */
-@OptIn(ExperimentalCoroutinesApi::class)
 fun <V : Any> Publisher<V>.asFlow(): Flow<V> = callbackFlow {
     val observer =
         object : Subscriber<V> {
             override fun submit(item: V) {
-                sendBlocking(item)
+                runBlocking { send(item) }
             }
 
             override fun onError(thrown: Throwable) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ junit-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref 
 stylecheck = "ca.stellardrift:stylecheck:0.2.1"
 
 # Kotlin
-kotlin-coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2"
+kotlin-coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.2"
 kotlin-reflect = {module = "org.jetbrains.kotlin:kotlin-reflect"} # version from Kotlin BOM
 
 # Core


### PR DESCRIPTION
This pull requests fixes #420 by replacing all `typeTokenOf<T>()` calls in the `configurate-extra-kotlin` module with `typeOf<T>().javaType` and also adds extension functions for `KType`.

I've also had to update Kotlin to `1.8.20` because `typeOf()` was experimental on the previous Kotlin version and added/changed some methods in the core module to also accept `java.lang.reflect.Type` instead of just `TypeToken` and `Class`.

I'm aware that this PR currently fails detekt tests, as `ConfigurationNodeExtensions.kt` now has 22/20 methods, but I don't see how (and why) one would split that file.