### PR TITLE
chore(build): Run using a JDK 17 toolchain in CI

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -29,7 +29,7 @@ jobs:
         id: setup
         uses: SpongePowered/.github/.github/actions/setup-java-env@master
         with:
-          runtime_version: 11
+          runtime_version: 17
           publishing_branch_regex: "master|3\\.x|(?:release/[\\d.x]+)"
       # Actually build
       - name: Run Gradle Build

--- a/build-logic/src/main/groovy/org.spongepowered.configurate.build.component.gradle
+++ b/build-logic/src/main/groovy/org.spongepowered.configurate.build.component.gradle
@@ -167,7 +167,10 @@ tasks.jar {
 
 // Configure target versions
 indra {
-    javaVersions().testWith(8, 11, 17)
+    javaVersions() {
+        testWith(8, 11, 17)
+        minimumToolchain(17)
+    }
 }
 
 // Don't compile AP-generated sources from within IDE


### PR DESCRIPTION
This does not change the minimum supported runtime environment for Configurate itself.