### PR TITLE
chore(ci): Bump to latest ubuntu image

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-latest]
+        os: [ubuntu-24.04, windows-latest]
     steps:
       # Setup
       - name: setup


### PR DESCRIPTION
`ubuntu-20.04` is now deprecated